### PR TITLE
Added support for minus (and plus) sign before variable (#21)

### DIFF
--- a/Debug/src/ti/subdir.mk
+++ b/Debug/src/ti/subdir.mk
@@ -46,6 +46,7 @@ C_SRCS += \
 ../src/ti/opr.c \
 ../src/ti/pipe.c \
 ../src/ti/pkg.c \
+../src/ti/preopr.c \
 ../src/ti/procedure.c \
 ../src/ti/procedures.c \
 ../src/ti/prop.c \
@@ -136,6 +137,7 @@ OBJS += \
 ./src/ti/opr.o \
 ./src/ti/pipe.o \
 ./src/ti/pkg.o \
+./src/ti/preopr.o \
 ./src/ti/procedure.o \
 ./src/ti/procedures.o \
 ./src/ti/prop.o \
@@ -226,6 +228,7 @@ C_DEPS += \
 ./src/ti/opr.d \
 ./src/ti/pipe.d \
 ./src/ti/pkg.d \
+./src/ti/preopr.d \
 ./src/ti/procedure.d \
 ./src/ti/procedures.d \
 ./src/ti/prop.d \

--- a/Release/src/ti/subdir.mk
+++ b/Release/src/ti/subdir.mk
@@ -46,6 +46,7 @@ C_SRCS += \
 ../src/ti/opr.c \
 ../src/ti/pipe.c \
 ../src/ti/pkg.c \
+../src/ti/preopr.c \
 ../src/ti/procedure.c \
 ../src/ti/procedures.c \
 ../src/ti/prop.c \
@@ -136,6 +137,7 @@ OBJS += \
 ./src/ti/opr.o \
 ./src/ti/pipe.o \
 ./src/ti/pkg.o \
+./src/ti/preopr.o \
 ./src/ti/procedure.o \
 ./src/ti/procedures.o \
 ./src/ti/prop.o \
@@ -226,6 +228,7 @@ C_DEPS += \
 ./src/ti/opr.d \
 ./src/ti/pipe.d \
 ./src/ti/pkg.d \
+./src/ti/preopr.d \
 ./src/ti/procedure.d \
 ./src/ti/procedures.d \
 ./src/ti/prop.d \

--- a/grammar/grammar.py
+++ b/grammar/grammar.py
@@ -18,6 +18,15 @@ from pyleri import (
     THIS,
 )
 
+
+# r = re.compile(r'(\s*!|\s*[\-+](?=[^0-9]))*')
+# m = r.match('+! ! -123;')
+# if m:
+#     print(m.groups())
+# print(m)
+# exit(0)
+
+
 # names have a max length of 255 characters
 RE_NAME = r'^[A-Za-z_][0-9A-Za-z_]{0,254}'
 
@@ -46,8 +55,8 @@ class LangDef(Grammar):
     x_closure = Token('|')
     x_function = Token('(')
     x_index = Token('[')
-    x_not = Token('!')
     x_parenthesis = Token('(')
+    x_preopr = Regex(r'(\s*!|\s*[\-+](?=[^0-9]))*')
     x_ternary = Token('?')
     x_thing = Token('{')
 
@@ -75,7 +84,6 @@ class LangDef(Grammar):
     t_string = Choice(r_single_quote, r_double_quote)
     t_true = Keyword('true')
 
-    o_not = Repeat(x_not)
     comments = Repeat(Choice(
         Regex(r'(?s)//.*?(\r?\n|$)'),  # Single line comment
         Regex(r'(?s)/\*.*?\*/'),  # Block comment
@@ -149,7 +157,7 @@ class LangDef(Grammar):
     parenthesis = Sequence(x_parenthesis, THIS, ')')
 
     expression = Sequence(
-        o_not,
+        x_preopr,
         Choice(
             chain,
             thing_by_id,
@@ -192,7 +200,7 @@ if __name__ == '__main__':
     # res = langdef.parse(r'''|x|...)''')
     # print(res.is_valid)
 
-    # res = langdef.parse(r'''x = Enum{||'X};''')
+    # res = langdef.parse(r'''a = 5;''')
     # print(res.is_valid)
 
     # exit(0)

--- a/inc/langdef/langdef.h
+++ b/inc/langdef/langdef.h
@@ -5,7 +5,7 @@
  * should be used with the libcleri module.
  *
  * Source class: LangDef
- * Created at: 2020-05-14 20:49:24
+ * Created at: 2020-05-28 16:53:55
  */
 #ifndef CLERI_EXPORT_LANGDEF_H_
 #define CLERI_EXPORT_LANGDEF_H_
@@ -38,7 +38,6 @@ enum cleri_grammar_ids {
     CLERI_GID_OPR6_CMP_AND,
     CLERI_GID_OPR7_CMP_OR,
     CLERI_GID_OPR8_TERNARY,
-    CLERI_GID_O_NOT,
     CLERI_GID_PARENTHESIS,
     CLERI_GID_R_DOUBLE_QUOTE,
     CLERI_GID_R_SINGLE_QUOTE,
@@ -66,8 +65,8 @@ enum cleri_grammar_ids {
     CLERI_GID_X_CLOSURE,
     CLERI_GID_X_FUNCTION,
     CLERI_GID_X_INDEX,
-    CLERI_GID_X_NOT,
     CLERI_GID_X_PARENTHESIS,
+    CLERI_GID_X_PREOPR,
     CLERI_GID_X_TERNARY,
     CLERI_GID_X_THING,
     CLERI_END // can be used to get the enum length

--- a/inc/ti/counters.h
+++ b/inc/ti/counters.h
@@ -21,7 +21,7 @@ ti_val_t * ti_counters_as_mpval(void);
 
 struct ti_counters_s
 {
-    uint64_t started_at;     /* time when counters were reset */
+    uint64_t started_at;            /* time when counters were reset */
     uint64_t queries_success;       /* node queries where this node acted as
                                        the master node and the query was
                                        successful finished

--- a/inc/ti/preopr.h
+++ b/inc/ti/preopr.h
@@ -1,0 +1,14 @@
+/*
+ * ti/preopr.h
+ */
+#ifndef TI_PREOPR_H_
+#define TI_PREOPR_H_
+
+#include <ex.h>
+#include <ti/val.h>
+
+int ti_preopr_bind(const char * s, size_t n);
+int ti_preopr_calc(int preopr, ti_val_t ** val, ex_t * e);
+
+
+#endif  /* TI_PREOPR_H_ */

--- a/inc/ti/version.h
+++ b/inc/ti/version.h
@@ -23,7 +23,7 @@
  *  "-alpha-1"
  *  ""
  */
-#define TI_VERSION_PRE_RELEASE "-alpha-5"
+#define TI_VERSION_PRE_RELEASE "-alpha-6"
 
 #define TI_MAINTAINER \
     "Jeroen van der Heijden <jeroen@transceptor.technology>"

--- a/inc/util/buf.h
+++ b/inc/util/buf.h
@@ -11,6 +11,7 @@ typedef struct buf_s buf_t;
 
 void buf_init(buf_t * buf);
 int buf_append(buf_t * buf, const char * s, size_t n);
+int buf_write(buf_t * buf, const char c);
 
 #define buf_append_str(buf__, s__) \
         buf_append(buf__, s__, strlen(s__))

--- a/itest/test_operators.py
+++ b/itest/test_operators.py
@@ -231,6 +231,38 @@ class TestOperators(TestBase):
         ''')
         self.assertEqual(set(res), {10, 20, 30, 41, 42, 50})
 
+    async def test_preopr(self, client):
+        self.assertIs(await client.query(r'''
+            !true;
+        '''), False)
+        self.assertIs(await client.query(r'''
+            !!true;
+        '''), True)
+        self.assertIs(await client.query(r'''
+            !! 42;
+        '''), True)
+        self.assertEqual(await client.query(r'''
+            -!! 42;
+        '''), -1)
+        self.assertEqual(await client.query(r'''
+            -!!-! 42;
+        '''), 0)
+        self.assertEqual(await client.query(r'''
+            --3.14;
+        '''), 3.14)
+        self.assertEqual(await client.query(r'''
+            -true;
+        '''), -1)
+        self.assertEqual(await client.query(r'''
+            ++true;
+        '''), 1)
+        self.assertEqual(await client.query(r'''
+            +false;
+        '''), 0)
+        self.assertEqual(await client.query(r'''
+            (|x| - ! x).def();
+        '''), "|x| -!x")
+
 
 if __name__ == '__main__':
     run_test(TestOperators())

--- a/src/langdef/langdef.c
+++ b/src/langdef/langdef.c
@@ -5,7 +5,7 @@
  * should be used with the libcleri module.
  *
  * Source class: LangDef
- * Created at: 2020-05-14 20:49:24
+ * Created at: 2020-05-28 16:53:55
  */
 
 #include <langdef/langdef.h>
@@ -26,8 +26,8 @@ cleri_grammar_t * compile_langdef(void)
     cleri_t * x_closure = cleri_token(CLERI_GID_X_CLOSURE, "|");
     cleri_t * x_function = cleri_token(CLERI_GID_X_FUNCTION, "(");
     cleri_t * x_index = cleri_token(CLERI_GID_X_INDEX, "[");
-    cleri_t * x_not = cleri_token(CLERI_GID_X_NOT, "!");
     cleri_t * x_parenthesis = cleri_token(CLERI_GID_X_PARENTHESIS, "(");
+    cleri_t * x_preopr = cleri_regex(CLERI_GID_X_PREOPR, "^(\\s*!|\\s*[\\-+](?=[^0-9]))*");
     cleri_t * x_ternary = cleri_token(CLERI_GID_X_TERNARY, "?");
     cleri_t * x_thing = cleri_token(CLERI_GID_X_THING, "{");
     cleri_t * r_single_quote = cleri_regex(CLERI_GID_R_SINGLE_QUOTE, "^(?:\'(?:[^\']*)\')+");
@@ -65,7 +65,6 @@ cleri_grammar_t * compile_langdef(void)
         r_double_quote
     );
     cleri_t * t_true = cleri_keyword(CLERI_GID_T_TRUE, "true", CLERI_CASE_SENSITIVE);
-    cleri_t * o_not = cleri_repeat(CLERI_GID_O_NOT, x_not, 0, 0);
     cleri_t * comments = cleri_repeat(CLERI_GID_COMMENTS, cleri_choice(
         CLERI_NONE,
         CLERI_FIRST_MATCH,
@@ -229,7 +228,7 @@ cleri_grammar_t * compile_langdef(void)
     cleri_t * expression = cleri_sequence(
         CLERI_GID_EXPRESSION,
         4,
-        o_not,
+        x_preopr,
         cleri_choice(
             CLERI_NONE,
             CLERI_FIRST_MATCH,

--- a/src/langdef/translate.c
+++ b/src/langdef/translate.c
@@ -29,7 +29,7 @@ const char * langdef_translate(cleri_t * elem)
     case CLERI_GID_X_CLOSURE:
     case CLERI_GID_X_FUNCTION:
     case CLERI_GID_X_INDEX:
-    case CLERI_GID_X_NOT:
+    case CLERI_GID_X_PREOPR:
     case CLERI_GID_X_PARENTHESIS:
     case CLERI_GID_X_TERNARY:
     case CLERI_GID_X_THING:

--- a/src/ti/do.c
+++ b/src/ti/do.c
@@ -20,6 +20,7 @@
 #include <ti/thing.inline.h>
 #include <ti/member.inline.h>
 #include <ti/vint.h>
+#include <ti/preopr.h>
 #include <util/strx.h>
 
 
@@ -1113,7 +1114,7 @@ static inline int do__template(ti_query_t * query, cleri_node_t * nd, ex_t * e)
 
 int ti_do_expression(ti_query_t * query, cleri_node_t * nd, ex_t * e)
 {
-    int nots = (int) ((intptr_t) nd->children->node->data);
+    int preopr = (int) ((intptr_t) nd->children->node->data);
     cleri_children_t * child = nd               /* sequence */
             ->children                          /* first child, not */
             ->next;
@@ -1141,7 +1142,7 @@ int ti_do_expression(ti_query_t * query, cleri_node_t * nd, ex_t * e)
             return e->nr;
 
         /* nothing is possible after a chain */
-        goto nots;
+        goto preopr;
     case CLERI_GID_THING_BY_ID:
         if (do__thing_by_id(query, nd, e))
             return e->nr;
@@ -1245,7 +1246,7 @@ int ti_do_expression(ti_query_t * query, cleri_node_t * nd, ex_t * e)
                 return e->nr;
 
             /* nothing is possible after assign since it ends with a scope */
-            goto nots;
+            goto preopr;
         case CLERI_GID_INSTANCE:
             if (do__instance(query, nd, e))
                 return e->nr;
@@ -1291,13 +1292,6 @@ int ti_do_expression(ti_query_t * query, cleri_node_t * nd, ex_t * e)
     if (child->next && do__chain(query, child->next->node, e))
         return e->nr;
 
-nots:
-    if (nots)
-    {
-        _Bool b = ti_val_as_bool(query->rval);
-        ti_val_drop(query->rval);
-        query->rval = (ti_val_t *) ti_vbool_get((nots & 1) ^ b);
-    }
-
-    return e->nr;
+preopr:
+    return preopr ? ti_preopr_calc(preopr, &query->rval, e) : e->nr;
 }

--- a/src/ti/fmt.c
+++ b/src/ti/fmt.c
@@ -2,6 +2,7 @@
  * ti/fmt.c
  */
 #include <assert.h>
+#include <ctype.h>
 #include <ti/fmt.h>
 #include <langdef/langdef.h>
 #include <util/logger.h>
@@ -395,14 +396,22 @@ static int fmt__expr_choice(ti_fmt_t * fmt, cleri_node_t * nd)
     return -1;
 }
 
+static int fmt__preopr(ti_fmt_t * fmt, cleri_node_t * nd)
+{
+    size_t n = nd->len;
+    const char * s = nd->str;
+    for(; n; --n, ++s)
+        if (!isspace(*s) && buf_write(&fmt->buf, *s))
+            return -1;
+    return 0;
+}
+
 static int fmt__expression(ti_fmt_t * fmt, cleri_node_t * nd)
 {
-    cleri_children_t * child;
     assert (nd->cl_obj->gid == CLERI_GID_EXPRESSION);
 
-    for (child = nd->children->node->children; child; child = child->next)
-        if (buf_append_str(&fmt->buf, "!"))
-            return -1;
+    if (fmt__preopr(fmt, nd->children->node))
+        return -1;
 
     if (fmt__expr_choice(fmt, nd->children->next->node))
         return -1;

--- a/src/ti/preopr.c
+++ b/src/ti/preopr.c
@@ -1,0 +1,139 @@
+/*
+ * ti/preopr.c
+ */
+#include <assert.h>
+#include <ti/preopr.h>
+#include <ti/vint.h>
+#include <ti/vfloat.h>
+#include <ti/vbool.h>
+#include <util/logger.h>
+
+enum
+{
+    PO__FALSE,
+    PO__BOOL,
+    PO__NEGATIVE,
+    PO__AS_NUM,
+    PO__CHK_NUM,
+};
+
+enum
+{
+    PO__FLAG_FALSE    =1<<PO__FALSE,
+    PO__FLAG_BOOL     =1<<PO__BOOL,
+    PO__FLAG_NEGATIVE =1<<PO__NEGATIVE,
+    PO__FLAG_AS_NUM   =1<<PO__AS_NUM,
+    PO__FLAG_CHK_NUM  =1<<PO__CHK_NUM,
+};
+
+int ti_preopr_bind(const char * s, size_t n)
+{
+    register int preopr = 0;
+    register int negative = 0;
+    register int nots = 0;
+
+    if (!n)
+        return preopr;
+
+    switch(*s)
+    {
+    case '-':
+        ++negative;
+        /* fall through */
+    case '+':
+        preopr |= 1 << PO__AS_NUM;
+        break;
+    case '!':
+        ++nots;
+    }
+
+    while (--n)
+    {
+        switch(*(++s))
+        {
+        case '-':
+            negative += !nots;
+            break;
+        case '!':
+            ++nots;
+        }
+    }
+    preopr |= (
+        ((nots & 1) << PO__FALSE) |
+        ((!!nots) << PO__BOOL) |
+        ((negative & 1) << PO__NEGATIVE) |
+        ((*s != '!') << PO__CHK_NUM)
+    );
+
+    return preopr;
+}
+
+int ti_preopr_calc(int preopr, ti_val_t ** val, ex_t * e)
+{
+    ti_val_t * v = *val;
+
+    if ((preopr & PO__FLAG_CHK_NUM) &&
+        v->tp != TI_VAL_INT &&
+        v->tp != TI_VAL_FLOAT &&
+        v->tp != TI_VAL_BOOL)
+    {
+        ex_set(e, EX_TYPE_ERROR,
+                "`-/+` not supported by type `%s`",
+                ti_val_str(v));
+        return e->nr;
+    }
+
+    if (preopr & PO__FLAG_BOOL)
+    {
+        _Bool b = (preopr & PO__FLAG_FALSE) ^ ti_val_as_bool(v);
+
+        ti_val_drop(v);
+
+        *val = preopr & PO__FLAG_AS_NUM
+            ? (ti_val_t *) ti_vint_create(preopr & PO__FLAG_NEGATIVE ? -b : b)
+            : (ti_val_t *) ti_vbool_get(b);
+
+        return 0;
+    }
+
+    assert (preopr & PO__FLAG_AS_NUM);
+
+    switch(v->tp)
+    {
+    case TI_VAL_INT:
+        if (preopr & PO__FLAG_NEGATIVE)
+        {
+            int64_t i = VINT(v);
+            if (i == LLONG_MIN)
+            {
+                ex_set(e, EX_OVERFLOW, "integer overflow");
+                return e->nr;
+            }
+            ti_val_drop(v);
+            *val = (ti_val_t *) ti_vint_create(-i);
+            if (!*val)
+                ex_set_mem(e);
+        }
+        break;
+    case TI_VAL_FLOAT:
+        if (preopr & PO__FLAG_NEGATIVE)
+        {
+            double nd = -VFLOAT(v);
+            ti_val_drop(v);
+            *val = (ti_val_t *) ti_vfloat_create(nd);
+            if (!*val)
+                ex_set_mem(e);
+        }
+        break;
+    case TI_VAL_BOOL:
+    {
+        _Bool b = VBOOL(v);
+
+        ti_val_drop(v);
+        *val = (ti_val_t *) ti_vint_create(preopr & PO__FLAG_NEGATIVE ? -b : b);
+        break;
+    }
+    }
+
+    return e->nr;
+}

--- a/src/ti/qbind.c
+++ b/src/ti/qbind.c
@@ -152,6 +152,7 @@
 #include <ti/fn/fnwrap.h>
 #include <ti/fn/fnwse.h>
 #include <ti/qbind.h>
+#include <ti/preopr.h>
 
 #define qbind__set_collection_event(__f) \
     (__f) |= (((__f) & TI_QBIND_FLAG_COLLECTION) && 1) << TI_QBIND_BIT_EVENT
@@ -844,16 +845,16 @@ static void qbind__expr_choice(ti_qbind_t * qbind, cleri_node_t * nd)
 
 static inline void qbind__expression(ti_qbind_t * qbind, cleri_node_t * nd)
 {
-    cleri_children_t * child;
-    intptr_t nots = 0;
+    cleri_node_t * node;
+    intptr_t preopr;
+
     assert (nd->cl_obj->gid == CLERI_GID_EXPRESSION);
 
     nd->data = ti_do_expression;
 
-    for (child = nd->children->node->children; child; child = child->next)
-        ++nots;
-
-    nd->children->node->data = (void *) nots;
+    node = nd->children->node;
+    preopr = (intptr_t) ti_preopr_bind(node->str, node->len);
+    node->data = (void *) preopr;
 
     qbind__expr_choice(qbind, nd->children->next->node);
 

--- a/src/util/buf.c
+++ b/src/util/buf.c
@@ -40,6 +40,25 @@ int buf_append(buf_t * buf, const char * s, size_t n)
     return 0;
 }
 
+int buf_write(buf_t * buf, const char c)
+{
+    if (buf->len == buf->cap)
+    {
+        char * tmp;
+        size_t nsize = buf->cap ? buf->cap << 1 : 8192;
+
+        tmp = realloc(buf->data, nsize);
+        if (!tmp)
+            return -1;
+
+        buf->data = tmp;
+        buf->cap = nsize;
+    }
+
+    buf->data[buf->len++] = c;
+    return 0;
+}
+
 int buf_append_fmt(buf_t * buf, const char * fmt, ...)
 {
     int rc;


### PR DESCRIPTION
* Added support for minus (and plus) sign before variable (#21)

The overall syntax relating to *plus* (`+`), *minus* (`-`) and *not* (`!`) signs is improved.

ThingsDB will still cache values like `-3.123`, `+42` etc, and uses some optimizations to handle other examples like `-x`, `--x`, `-+-7` etc. Even more combinations are possible, like `-![]` which result in `-1` since the empty list is `false`, *not* `false` is `true` and *minus* `true is `-1`. So `-` or `+` before a boolean will convert the boolean to an integer value `0` or `1` or `-1` if a minus sign is used.