### PR TITLE
Things as dictionary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.10.4
+
+* Added things as dictionary support, issue #146.
+
 # v0.10.3
 
 * Fixed Alpine Linux build, issue #152.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # v0.10.4
 
 * Added things as dictionary support, issue #146.
+* Allow zero arguments for `wse(..)` function, issue #148.
+* Deprecate injection of special variable, issue #151.
 
 # v0.10.3
 

--- a/Debug/src/ti/subdir.mk
+++ b/Debug/src/ti/subdir.mk
@@ -40,6 +40,7 @@ C_SRCS += \
 ../src/ti/fwd.c \
 ../src/ti/gc.c \
 ../src/ti/index.c \
+../src/ti/item.c \
 ../src/ti/job.c \
 ../src/ti/mapping.c \
 ../src/ti/member.c \
@@ -143,6 +144,7 @@ OBJS += \
 ./src/ti/fwd.o \
 ./src/ti/gc.o \
 ./src/ti/index.o \
+./src/ti/item.o \
 ./src/ti/job.o \
 ./src/ti/mapping.o \
 ./src/ti/member.o \
@@ -246,6 +248,7 @@ C_DEPS += \
 ./src/ti/fwd.d \
 ./src/ti/gc.d \
 ./src/ti/index.d \
+./src/ti/item.d \
 ./src/ti/job.d \
 ./src/ti/mapping.d \
 ./src/ti/member.d \

--- a/Release/src/ti/subdir.mk
+++ b/Release/src/ti/subdir.mk
@@ -40,6 +40,7 @@ C_SRCS += \
 ../src/ti/fwd.c \
 ../src/ti/gc.c \
 ../src/ti/index.c \
+../src/ti/item.c \
 ../src/ti/job.c \
 ../src/ti/mapping.c \
 ../src/ti/member.c \
@@ -143,6 +144,7 @@ OBJS += \
 ./src/ti/fwd.o \
 ./src/ti/gc.o \
 ./src/ti/index.o \
+./src/ti/item.o \
 ./src/ti/job.o \
 ./src/ti/mapping.o \
 ./src/ti/member.o \
@@ -246,6 +248,7 @@ C_DEPS += \
 ./src/ti/fwd.d \
 ./src/ti/gc.d \
 ./src/ti/index.d \
+./src/ti/item.d \
 ./src/ti/job.d \
 ./src/ti/mapping.d \
 ./src/ti/member.d \

--- a/inc/ti/closure.h
+++ b/inc/ti/closure.h
@@ -11,6 +11,7 @@
 #include <ti/closure.t.h>
 #include <ti/name.t.h>
 #include <ti/prop.t.h>
+#include <ti/item.t.h>
 #include <ti/qbind.t.h>
 #include <ti/query.t.h>
 #include <ti/val.t.h>
@@ -29,7 +30,7 @@ int ti_closure_inc(ti_closure_t * closure, ti_query_t * query, ex_t * e);
 void ti_closure_dec(ti_closure_t * closure, ti_query_t * query);
 int ti_closure_vars_nameval(
         ti_closure_t * closure,
-        ti_name_t * name,
+        ti_val_t * name,
         ti_val_t * val,
         ex_t * e);
 int ti_closure_vars_val_idx(ti_closure_t * closure, ti_val_t * v, int64_t i);
@@ -47,7 +48,23 @@ static inline int ti_closure_vars_prop(
         ti_prop_t * prop,
         ex_t * e)
 {
-    return ti_closure_vars_nameval(closure, prop->name, prop->val, e);
+    return ti_closure_vars_nameval(
+            closure,
+            (ti_val_t *) prop->name,
+            prop->val,
+            e);
+}
+
+static inline int ti_closure_vars_item(
+        ti_closure_t * closure,
+        ti_item_t * item,
+        ex_t * e)
+{
+    return ti_closure_vars_nameval(
+            closure,
+            (ti_val_t *) item->key,
+            item->val,
+            e);
 }
 
 static inline cleri_node_t * ti_closure_statement(ti_closure_t * closure)

--- a/inc/ti/closure.inline.h
+++ b/inc/ti/closure.inline.h
@@ -53,10 +53,10 @@ static inline int ti_closure_try_wse(
      * if we later decide to change the code.
      */
     if (    ((closure->flags & (
-                TI_VFLAG_CLOSURE_BTSCOPE|
-                TI_VFLAG_CLOSURE_BCSCOPE|
-                TI_VFLAG_CLOSURE_WSE
-            )) == TI_VFLAG_CLOSURE_WSE) &&
+                TI_CLOSURE_FLAG_BTSCOPE|
+                TI_CLOSURE_FLAG_BCSCOPE|
+                TI_CLOSURE_FLAG_WSE
+            )) == TI_CLOSURE_FLAG_WSE) &&
             (~query->flags & TI_QUERY_FLAG_WSE))
     {
         ex_set(e, EX_OPERATION,

--- a/inc/ti/closure.t.h
+++ b/inc/ti/closure.t.h
@@ -10,6 +10,26 @@
 
 typedef struct ti_closure_s ti_closure_t;
 
+enum
+{
+    TI_CLOSURE_FLAG_BTSCOPE =1<<0,      /* closure bound to query string
+                                            within the thingsdb scope;
+                                            when not stored, closures do not
+                                            own the closure string but refer
+                                            the full query string.*/
+    TI_CLOSURE_FLAG_BCSCOPE =1<<1,     /* closure bound to query string
+                                            within a collection scope;
+                                            when not stored, closures do not
+                                            own the closure string but refer
+                                            the full query string. */
+    TI_CLOSURE_FLAG_WSE     =1<<2,     /* stored closure with side effects;
+                                            when closure make changes they
+                                            require an event and thus must be
+                                            wrapped by wse() so we can know
+                                            an event is created.
+                                            (only stored closures) */
+};
+
 #include <cleri/cleri.h>
 #include <inttypes.h>
 #include <util/vec.h>

--- a/inc/ti/fn/fn.h
+++ b/inc/ti/fn/fn.h
@@ -18,10 +18,10 @@
 #include <ti/auth.h>
 #include <ti/closure.h>
 #include <ti/closure.inline.h>
+#include <ti/async.h>
 #include <ti/collections.h>
 #include <ti/datetime.h>
 #include <ti/do.h>
-#include <ti/async.h>
 #include <ti/enum.inline.h>
 #include <ti/enums.inline.h>
 #include <ti/export.h>
@@ -29,6 +29,7 @@
 #include <ti/future.h>
 #include <ti/future.inline.h>
 #include <ti/gc.h>
+#include <ti/item.t.h>
 #include <ti/member.h>
 #include <ti/member.inline.h>
 #include <ti/method.h>

--- a/inc/ti/fn/fn.h
+++ b/inc/ti/fn/fn.h
@@ -29,6 +29,7 @@
 #include <ti/future.h>
 #include <ti/future.inline.h>
 #include <ti/gc.h>
+#include <ti/item.h>
 #include <ti/item.t.h>
 #include <ti/member.h>
 #include <ti/member.inline.h>

--- a/inc/ti/fn/fn.h
+++ b/inc/ti/fn/fn.h
@@ -369,7 +369,7 @@ static int fn_call_o_try_n(
     if (!name_ || !(val = ti_thing_o_val_weak_get(thing, name_)))
     {
         ex_set(e, EX_LOOKUP_ERROR,
-                "thing "TI_THING_ID" has no property `%.*s`",
+                "thing "TI_THING_ID" has no property or method `%.*s`",
                 thing->id, n, name);
         return e->nr;
     }

--- a/inc/ti/fn/fn.h
+++ b/inc/ti/fn/fn.h
@@ -362,11 +362,10 @@ static int fn_call_o_try_n(
         cleri_node_t * nd,
         ex_t * e)
 {
-    ti_name_t * name_ = ti_names_weak_get_strn(name, n);
     ti_thing_t * thing = (ti_thing_t *) query->rval;
-    ti_val_t * val;
+    ti_val_t * val = ti_thing_val_by_strn(thing, name, n);
 
-    if (!name_ || !(val = ti_thing_o_val_weak_get(thing, name_)))
+    if (!val)
     {
         ex_set(e, EX_LOOKUP_ERROR,
                 "thing "TI_THING_ID" has no property or method `%.*s`",

--- a/inc/ti/fn/fnadd.h
+++ b/inc/ti/fn/fnadd.h
@@ -50,7 +50,7 @@ static int do__f_add(ti_query_t * query, cleri_node_t * nd, ex_t * e)
         ti_task_t * task = ti_task_get_task(query->ev, vset->parent);
         if (!task || ti_task_add_add(
                 task,
-                vset->name,
+                vset->key,
                 added))
             goto alloc_err;  /* we do not need to cleanup task, since the task
                                 is added to `query->ev->tasks` */

--- a/inc/ti/fn/fndel.h
+++ b/inc/ti/fn/fndel.h
@@ -6,7 +6,7 @@ static int do__f_del(ti_query_t * query, cleri_node_t * nd, ex_t * e)
     cleri_node_t * name_nd;
     ti_task_t * task;
     ti_thing_t * thing;
-    ti_prop_t * prop;
+    ti_item_t * item;
     ti_raw_t * rname;
 
     if (!ti_val_is_object(query->rval))
@@ -38,16 +38,15 @@ static int do__f_del(ti_query_t * query, cleri_node_t * nd, ex_t * e)
 
     rname = (ti_raw_t *) query->rval;
 
-    prop = ti_thing_o_del_e(thing, rname, e);
-    if (!prop)
+    item = ti_thing_o_del_e(thing, rname, e);
+    if (!item)
         goto fail0;  /* error is set, rname is still bound to query */
 
-    query->rval = prop->val;
+    query->rval = item->val;
     ti_incref(query->rval);
 
     ti_val_attach(query->rval, NULL, NULL);
-
-    ti_prop_destroy(prop);
+    ti_item_destroy(item);
 
     if (thing->id)
     {

--- a/inc/ti/fn/fneach.h
+++ b/inc/ti/fn/fneach.h
@@ -54,7 +54,7 @@ static int do__f_each(ti_query_t * query, cleri_node_t * nd, ex_t * e)
         ti_thing_t * thing = (ti_thing_t *) iterval;
         if (ti_thing_is_object(thing))
         {
-            for (vec_each(thing->items, ti_prop_t, p))
+            for (vec_each(thing->items.vec, ti_prop_t, p))
             {
                 if (ti_closure_vars_prop(closure, p, e) ||
                     ti_closure_do_statement(closure, query, e))

--- a/inc/ti/fn/fneach.h
+++ b/inc/ti/fn/fneach.h
@@ -64,7 +64,7 @@ static int do__f_each(ti_query_t * query, cleri_node_t * nd, ex_t * e)
         ti_thing_t * thing = (ti_thing_t *) iterval;
         if (ti_thing_is_object(thing))
         {
-            if (ti_thing_is_object_i(thing))
+            if (ti_thing_is_dict(thing))
             {
                 each__walk_t w = {
                         .e = e,

--- a/inc/ti/fn/fnextend.h
+++ b/inc/ti/fn/fnextend.h
@@ -57,7 +57,7 @@ static int do__f_extend(ti_query_t * query, cleri_node_t * nd, ex_t * e)
         ti_task_t * task = ti_task_get_task(query->ev, varr_dest->parent);
         if (!task || ti_task_add_splice(
                 task,
-                varr_dest->name,
+                varr_dest->key,
                 varr_dest,
                 current_n,
                 0,

--- a/inc/ti/fn/fnextract.h
+++ b/inc/ti/fn/fnextract.h
@@ -80,43 +80,43 @@ static int do__f_extract(ti_query_t * query, cleri_node_t * nd, ex_t * e)
     /* year */
     name = (ti_name_t *) ti_val_year_name();
     vint = ti_vint_create(tm.tm_year + 1900);
-    if (!vint || !ti_thing_o_prop_add(as_thing, name, (ti_val_t *) vint))
+    if (!vint || !ti_thing_p_prop_add(as_thing, name, (ti_val_t *) vint))
         goto mem_error;
 
     /* month */
     name = (ti_name_t *) ti_val_month_name();
     vint = ti_vint_create(tm.tm_mon + 1);
-    if (!vint || !ti_thing_o_prop_add(as_thing, name, (ti_val_t *) vint))
+    if (!vint || !ti_thing_p_prop_add(as_thing, name, (ti_val_t *) vint))
         goto mem_error;
 
     /* day */
     name = (ti_name_t *) ti_val_day_name();
     vint = ti_vint_create(tm.tm_mday);
-    if (!vint || !ti_thing_o_prop_add(as_thing, name, (ti_val_t *) vint))
+    if (!vint || !ti_thing_p_prop_add(as_thing, name, (ti_val_t *) vint))
         goto mem_error;
 
     /* hour */
     name = (ti_name_t *) ti_val_hour_name();
     vint = ti_vint_create(tm.tm_hour);
-    if (!vint || !ti_thing_o_prop_add(as_thing, name, (ti_val_t *) vint))
+    if (!vint || !ti_thing_p_prop_add(as_thing, name, (ti_val_t *) vint))
         goto mem_error;
 
     /* minute */
     name = (ti_name_t *) ti_val_minute_name();
     vint = ti_vint_create(tm.tm_min);
-    if (!vint || !ti_thing_o_prop_add(as_thing, name, (ti_val_t *) vint))
+    if (!vint || !ti_thing_p_prop_add(as_thing, name, (ti_val_t *) vint))
         goto mem_error;
 
     /* second */
     name = (ti_name_t *) ti_val_second_name();
     vint = ti_vint_create(tm.tm_sec);
-    if (!vint || !ti_thing_o_prop_add(as_thing, name, (ti_val_t *) vint))
+    if (!vint || !ti_thing_p_prop_add(as_thing, name, (ti_val_t *) vint))
         goto mem_error;
 
     /* gmt_offset */
     name = (ti_name_t *) ti_val_gmt_offset_name();
     vint = ti_vint_create(tm.tm_gmtoff);
-    if (!vint || !ti_thing_o_prop_add(as_thing, name, (ti_val_t *) vint))
+    if (!vint || !ti_thing_p_prop_add(as_thing, name, (ti_val_t *) vint))
         goto mem_error;
 
     ti_val_unsafe_drop(query->rval);

--- a/inc/ti/fn/fnfilter.h
+++ b/inc/ti/fn/fnfilter.h
@@ -63,7 +63,7 @@ static int do__f_filter(ti_query_t * query, cleri_node_t * nd, ex_t * e)
     {
         ti_thing_t * thing, * t = (ti_thing_t *) iterval;
 
-        thing = ti_thing_o_create(0, t->items->n, query->collection);
+        thing = ti_thing_o_create(0, ti_thing_n(t), query->collection);
         if (!thing)
             goto fail2;
 
@@ -71,7 +71,7 @@ static int do__f_filter(ti_query_t * query, cleri_node_t * nd, ex_t * e)
 
         if (ti_thing_is_object(t))
         {
-            for (vec_each(t->items, ti_prop_t, p))
+            for (vec_each(t->items.vec, ti_prop_t, p))
             {
                 if (ti_closure_vars_prop(closure, p, e) ||
                     ti_closure_do_statement(closure, query, e))
@@ -137,7 +137,7 @@ static int do__f_filter(ti_query_t * query, cleri_node_t * nd, ex_t * e)
                 VEC_push(varr->vec, v);
 
                 if (ti_val_is_thing(v))
-                    varr->flags |= TI_VFLAG_ARR_MHT;
+                    varr->flags |= TI_VARR_FLAG_MHT;
             }
 
             ti_val_unsafe_drop(query->rval);

--- a/inc/ti/fn/fnfilter.h
+++ b/inc/ti/fn/fnfilter.h
@@ -6,9 +6,9 @@ typedef struct
     ti_closure_t * closure;
     ti_query_t * query;
     ti_vset_t * vset;
-} filter__walk_t;
+} filter__walk_set_t;
 
-static int filter__walk_set(ti_thing_t * t, filter__walk_t * w)
+static int filter__walk_set(ti_thing_t * t, filter__walk_set_t * w)
 {
     if (ti_closure_vars_vset(w->closure, t) ||
         ti_closure_do_statement(w->closure, w->query, w->e))
@@ -19,6 +19,34 @@ static int filter__walk_set(ti_thing_t * t, filter__walk_t * w)
         if (ti_vset_add(w->vset, t))
             return -1;
         ti_incref(t);
+    }
+
+    ti_val_unsafe_drop(w->query->rval);
+    w->query->rval = NULL;
+    return 0;
+}
+
+typedef struct
+{
+    ex_t * e;
+    ti_closure_t * closure;
+    ti_query_t * query;
+    ti_thing_t * thing;
+} filter__walk_i_t;
+
+static int filter__walk_i(ti_item_t * item, filter__walk_i_t * w)
+{
+    if (ti_closure_vars_item(w->closure, item, w->e) ||
+        ti_closure_do_statement(w->closure, w->query, w->e))
+        return -1;
+
+    if (ti_val_as_bool(w->query->rval))
+    {
+        if (ti_val_make_variable(&item->val, w->e) ||
+            !ti_thing_i_item_add(w->thing, item->key, item->val))
+            return -1;
+        ti_incref(item->key);
+        ti_incref(item->val);
     }
 
     ti_val_unsafe_drop(w->query->rval);
@@ -63,6 +91,26 @@ static int do__f_filter(ti_query_t * query, cleri_node_t * nd, ex_t * e)
     {
         ti_thing_t * thing, * t = (ti_thing_t *) iterval;
 
+        if (ti_thing_is_object_i(t))
+        {
+            thing = ti_thing_i_create(0, query->collection);
+            if (!thing)
+                goto fail2;
+
+            retval = (ti_val_t *) thing;
+
+            filter__walk_i_t w = {
+                    .closure = closure,
+                    .e = e,
+                    .query = query,
+                    .thing = thing,
+            };
+
+            if (smap_values(t->items.smap, (smap_val_cb) filter__walk_i, &w))
+                goto fail2;
+            break;
+        }
+
         thing = ti_thing_o_create(0, ti_thing_n(t), query->collection);
         if (!thing)
             goto fail2;
@@ -80,7 +128,7 @@ static int do__f_filter(ti_query_t * query, cleri_node_t * nd, ex_t * e)
                 if (ti_val_as_bool(query->rval))
                 {
                     if (    ti_val_make_variable(&p->val, e) ||
-                            !ti_thing_o_prop_add(thing, p->name, p->val))
+                            !ti_thing_p_prop_add(thing, p->name, p->val))
                         goto fail2;
                     ti_incref(p->name);
                     ti_incref(p->val);
@@ -96,14 +144,14 @@ static int do__f_filter(ti_query_t * query, cleri_node_t * nd, ex_t * e)
             ti_val_t * val;
             for (thing_t_each(t, name, val))
             {
-                if (ti_closure_vars_nameval(closure, name, val, e) ||
+                if (ti_closure_vars_nameval(closure, (ti_val_t *) name, val, e) ||
                     ti_closure_do_statement(closure, query, e))
                     goto fail2;
 
                 if (ti_val_as_bool(query->rval))
                 {
                     if (    ti_val_make_variable(&val, e) ||
-                            !ti_thing_o_prop_add(thing, name, val))
+                            !ti_thing_p_prop_add(thing, name, val))
                         goto fail2;
                     ti_incref(name);
                     ti_incref(val);
@@ -149,7 +197,7 @@ static int do__f_filter(ti_query_t * query, cleri_node_t * nd, ex_t * e)
     }
     case TI_VAL_SET:
     {
-        filter__walk_t w = {
+        filter__walk_set_t w = {
                 .e = e,
                 .closure = closure,
                 .query = query,

--- a/inc/ti/fn/fnfilter.h
+++ b/inc/ti/fn/fnfilter.h
@@ -91,7 +91,7 @@ static int do__f_filter(ti_query_t * query, cleri_node_t * nd, ex_t * e)
     {
         ti_thing_t * thing, * t = (ti_thing_t *) iterval;
 
-        if (ti_thing_is_object_i(t))
+        if (ti_thing_is_dict(t))
         {
             thing = ti_thing_i_create(0, query->collection);
             if (!thing)

--- a/inc/ti/fn/fnfind.h
+++ b/inc/ti/fn/fnfind.h
@@ -95,7 +95,7 @@ static int do__f_find(ti_query_t * query, cleri_node_t * nd, ex_t * e)
     case TI_VAL_SET:
     {
         int rc;
-        filter__walk_t w = {
+        find__walk_t w = {
                 .e = e,
                 .closure = closure,
                 .query = query,

--- a/inc/ti/fn/fnfuture.h
+++ b/inc/ti/fn/fnfuture.h
@@ -22,8 +22,8 @@ static int do__f_future(ti_query_t * query, cleri_node_t * nd, ex_t * e)
         ti_thing_t * thing = (ti_thing_t *) query->rval;
         ti_name_t * module_name = (ti_name_t *) ti_val_borrow_module_name();
         ti_name_t * deep_name = (ti_name_t *) ti_val_borrow_deep_name();
-        ti_val_t * module_val = ti_thing_weak_val_by_name(thing, module_name);
-        ti_val_t * deep_val = ti_thing_weak_val_by_name(thing, deep_name);
+        ti_val_t * module_val = ti_thing_val_weak_by_name(thing, module_name);
+        ti_val_t * deep_val = ti_thing_val_weak_by_name(thing, deep_name);
 
         if (!module_val)
         {

--- a/inc/ti/fn/fnget.h
+++ b/inc/ti/fn/fnget.h
@@ -4,7 +4,7 @@ static int do__f_get(ti_query_t * query, cleri_node_t * nd, ex_t * e)
 {
     const int nargs = langdef_nd_n_function_params(nd);
     ti_thing_t * thing;
-    ti_wprop_t wprop;
+    ti_witem_t witem;
     _Bool found;
 
     if (!ti_val_is_thing(query->rval))
@@ -20,7 +20,7 @@ static int do__f_get(ti_query_t * query, cleri_node_t * nd, ex_t * e)
         fn_arg_str("get", DOC_THING_GET, 1, query->rval, e))
         goto done;
 
-    found = ti_thing_get_by_raw(&wprop, thing, (ti_raw_t *) query->rval);
+    found = ti_thing_get_by_raw(&witem, thing, (ti_raw_t *) query->rval);
 
     ti_val_unsafe_drop(query->rval);
 
@@ -37,7 +37,7 @@ static int do__f_get(ti_query_t * query, cleri_node_t * nd, ex_t * e)
         goto done;
     }
 
-    query->rval = *wprop.val;
+    query->rval = *witem.val;
     ti_incref(query->rval);
 
 done:

--- a/inc/ti/fn/fnhas.h
+++ b/inc/ti/fn/fnhas.h
@@ -28,7 +28,7 @@ fail1:
 static int do__f_has_thing(ti_query_t * query, cleri_node_t * nd, ex_t * e)
 {
     const int nargs = langdef_nd_n_function_params(nd);
-    ti_name_t * name;
+    _Bool has;
     ti_thing_t * thing;
 
     if (fn_nargs("has", DOC_THING_HAS, 1, nargs, e))
@@ -41,11 +41,10 @@ static int do__f_has_thing(ti_query_t * query, cleri_node_t * nd, ex_t * e)
         fn_arg_str("has", DOC_THING_HAS, 1, query->rval, e))
         goto fail1;
 
-    name = ti_names_weak_from_raw((ti_raw_t *) query->rval);
+    has = ti_thing_o_has_key(thing, (ti_raw_t *) query->rval);
 
     ti_val_unsafe_drop(query->rval);
-    query->rval = (ti_val_t *) ti_vbool_get(
-            name && ti_thing_val_weak_get(thing, name));
+    query->rval = (ti_val_t *) ti_vbool_get(has);
 
 fail1:
     ti_val_unsafe_drop((ti_val_t *) thing);

--- a/inc/ti/fn/fnkeys.h
+++ b/inc/ti/fn/fnkeys.h
@@ -1,5 +1,12 @@
 #include <ti/fn/fn.h>
 
+static int keys__walk(ti_item_t * item, vec_t * vec)
+{
+    VEC_push(vec, item->key);
+    ti_incref(item->key);
+    return 0;
+}
+
 static int do__f_keys(ti_query_t * query, cleri_node_t * nd, ex_t * e)
 {
     const int nargs = langdef_nd_n_function_params(nd);
@@ -13,7 +20,7 @@ static int do__f_keys(ti_query_t * query, cleri_node_t * nd, ex_t * e)
         return e->nr;
 
     thing = (ti_thing_t *) query->rval;
-    varr = ti_varr_create(thing->items->n);
+    varr = ti_varr_create(ti_thing_n(thing));
     if (!varr)
     {
         ex_set_mem(e);
@@ -22,10 +29,20 @@ static int do__f_keys(ti_query_t * query, cleri_node_t * nd, ex_t * e)
 
     if (ti_thing_is_object(thing))
     {
-        for (vec_each(thing->items, ti_prop_t, prop))
+        if (ti_thing_is_object_i(thing))
         {
-            VEC_push(varr->vec, prop->name);
-            ti_incref(prop->name);
+            (void) smap_values(
+                    thing->items.smap,
+                    (smap_val_cb) keys__walk,
+                    varr->vec);
+        }
+        else
+        {
+            for (vec_each(thing->items.vec, ti_prop_t, prop))
+            {
+                VEC_push(varr->vec, prop->name);
+                ti_incref(prop->name);
+            }
         }
     }
     else

--- a/inc/ti/fn/fnkeys.h
+++ b/inc/ti/fn/fnkeys.h
@@ -29,7 +29,7 @@ static int do__f_keys(ti_query_t * query, cleri_node_t * nd, ex_t * e)
 
     if (ti_thing_is_object(thing))
     {
-        if (ti_thing_is_object_i(thing))
+        if (ti_thing_is_dict(thing))
         {
             (void) smap_values(
                     thing->items.smap,

--- a/inc/ti/fn/fnmap.h
+++ b/inc/ti/fn/fnmap.h
@@ -64,7 +64,7 @@ static int do__f_map(ti_query_t * query, cleri_node_t * nd, ex_t * e)
 
         if (ti_thing_is_object(thing))
         {
-            for (vec_each(thing->items, ti_prop_t, p))
+            for (vec_each(thing->items.vec, ti_prop_t, p))
             {
                 if (ti_closure_vars_prop(closure, p, e) ||
                     ti_closure_do_statement(closure, query, e) ||

--- a/inc/ti/fn/fnmap.h
+++ b/inc/ti/fn/fnmap.h
@@ -79,7 +79,7 @@ static int do__f_map(ti_query_t * query, cleri_node_t * nd, ex_t * e)
             ti_val_t * val;
             for (thing_t_each(thing, name, val))
             {
-                if (ti_closure_vars_nameval(closure, name, val, e) ||
+                if (ti_closure_vars_nameval(closure, (ti_val_t *) name, val, e) ||
                     ti_closure_do_statement(closure, query, e) ||
                     ti_varr_append(retvarr, (void **) &query->rval, e))
                     goto fail2;

--- a/inc/ti/fn/fnmap.h
+++ b/inc/ti/fn/fnmap.h
@@ -18,6 +18,16 @@ static int map__walk_set(ti_thing_t * t, map__walk_t * w)
     return 0;
 }
 
+static int map__walk_i(ti_item_t * item, map__walk_t * w)
+{
+    if (ti_closure_vars_item(w->closure, item, w->e) ||
+        ti_closure_do_statement(w->closure, w->query, w->e) ||
+        ti_varr_append(w->varr, (void **) &w->query->rval, w->e))
+        return -1;
+    w->query->rval = NULL;
+    return 0;
+}
+
 static int do__f_map(ti_query_t * query, cleri_node_t * nd, ex_t * e)
 {
     const char * doc;
@@ -64,13 +74,31 @@ static int do__f_map(ti_query_t * query, cleri_node_t * nd, ex_t * e)
 
         if (ti_thing_is_object(thing))
         {
-            for (vec_each(thing->items.vec, ti_prop_t, p))
+            if (ti_thing_is_dict(thing))
             {
-                if (ti_closure_vars_prop(closure, p, e) ||
-                    ti_closure_do_statement(closure, query, e) ||
-                    ti_varr_append(retvarr, (void **) &query->rval, e))
+                map__walk_t w = {
+                        .e = e,
+                        .closure = closure,
+                        .query = query,
+                        .varr = retvarr,
+                };
+
+                if (smap_values(
+                        thing->items.smap,
+                        (smap_val_cb) map__walk_i,
+                        &w))
                     goto fail2;
-                query->rval = NULL;
+            }
+            else
+            {
+                for (vec_each(thing->items.vec, ti_prop_t, p))
+                {
+                    if (ti_closure_vars_prop(closure, p, e) ||
+                        ti_closure_do_statement(closure, query, e) ||
+                        ti_varr_append(retvarr, (void **) &query->rval, e))
+                        goto fail2;
+                    query->rval = NULL;
+                }
             }
         }
         else

--- a/inc/ti/fn/fnnewtoken.h
+++ b/inc/ti/fn/fnnewtoken.h
@@ -69,7 +69,7 @@ static int do__f_new_token(ti_query_t * query, cleri_node_t * nd, ex_t * e)
             double ts = VFLOAT(query->rval);
             if (ts < now)
                 goto errpast;
-            if (ts > TI_MAX_EXPIRATION_DOUDLE)
+            if (ts > TI_MAX_EXPIRATION_DOUBLE)
                 goto errfuture;
 
             exp_time = (uint64_t) ts;

--- a/inc/ti/fn/fnpop.h
+++ b/inc/ti/fn/fnpop.h
@@ -26,7 +26,7 @@ static int do__f_pop(ti_query_t * query, cleri_node_t * nd, ex_t * e)
         ti_task_t * task = ti_task_get_task(query->ev, varr->parent);
         if (!task || ti_task_add_splice(
                 task,
-                varr->name,
+                varr->key,
                 NULL,
                 varr->vec->n,
                 1,

--- a/inc/ti/fn/fnpush.h
+++ b/inc/ti/fn/fnpush.h
@@ -41,7 +41,7 @@ static int do__f_push(ti_query_t * query, cleri_node_t * nd, ex_t * e)
         ti_task_t * task = ti_task_get_task(query->ev, varr->parent);
         if (!task || ti_task_add_splice(
                 task,
-                varr->name,
+                varr->key,
                 varr,
                 current_n,
                 0,

--- a/inc/ti/fn/fnremove.h
+++ b/inc/ti/fn/fnremove.h
@@ -49,7 +49,7 @@ static int do__f_remove_list(ti_query_t * query, cleri_node_t * nd, ex_t * e)
                 task = ti_task_get_task(query->ev, varr->parent);
                 if (!task || ti_task_add_splice(
                         task,
-                        varr->name,
+                        varr->key,
                         NULL,
                         idx,
                         1,
@@ -243,7 +243,7 @@ static int do__f_remove_set(
         ti_task_t * task = ti_task_get_task(query->ev, vset->parent);
         if (!task || ti_task_add_remove(
                 task,
-                vset->name,
+                vset->key,
                 removed))
         {
             ex_set_mem(e);

--- a/inc/ti/fn/fnreplace.h
+++ b/inc/ti/fn/fnreplace.h
@@ -374,7 +374,7 @@ static int do__replace_datetime(ti_query_t * query, cleri_node_t * nd, ex_t * e)
 
     if (ti_thing_is_object(thing))
     {
-        for (vec_each(thing->items, ti_prop_t, p))
+        for (vec_each(thing->items.vec, ti_prop_t, p))
             if (do__replace_value(&tm, p->name, p->val, e))
                 return e->nr;
     }

--- a/inc/ti/fn/fnreverse.h
+++ b/inc/ti/fn/fnreverse.h
@@ -26,7 +26,7 @@ static int do__f_reverse(ti_query_t * query, cleri_node_t * nd, ex_t * e)
     }
 
     /* set the may-have-things flags if set on the source */
-    dst->flags = src->flags & TI_VFLAG_ARR_MHT;
+    dst->flags = src->flags & TI_VARR_FLAG_MHT;
 
     ti_val_unsafe_drop(query->rval);
     query->rval = (ti_val_t *) dst;

--- a/inc/ti/fn/fnset.h
+++ b/inc/ti/fn/fnset.h
@@ -52,7 +52,7 @@ static int do__f_set_new_type(ti_query_t * query, cleri_node_t * nd, ex_t * e)
 static int do__f_set_property(ti_query_t * query, cleri_node_t * nd, ex_t * e)
 {
     const int nargs = langdef_nd_n_function_params(nd);
-    ti_wprop_t wprop;
+    ti_witem_t witem;
     ti_thing_t * thing;
     ti_raw_t * rname;
 
@@ -77,7 +77,7 @@ static int do__f_set_property(ti_query_t * query, cleri_node_t * nd, ex_t * e)
         goto fail1;
 
     if (ti_thing_set_val_from_strn(
-            &wprop,
+            &witem,
             thing,
             (const char *) rname->data,
             rname->n,
@@ -87,7 +87,7 @@ static int do__f_set_property(ti_query_t * query, cleri_node_t * nd, ex_t * e)
     if (thing->id)
     {
         ti_task_t * task = ti_task_get_task(query->ev, thing);
-        if (!task || ti_task_add_set(task, wprop.name, *wprop.val))
+        if (!task || ti_task_add_set(task, witem.key, *witem.val))
         {
             ex_set_mem(e);
             goto fail1;

--- a/inc/ti/fn/fnshift.h
+++ b/inc/ti/fn/fnshift.h
@@ -27,7 +27,7 @@ static int do__f_shift(ti_query_t * query, cleri_node_t * nd, ex_t * e)
         ti_task_t * task = ti_task_get_task(query->ev, varr->parent);
         if (!task || ti_task_add_splice(
                 task,
-                varr->name,
+                varr->key,
                 NULL,
                 0,
                 1,

--- a/inc/ti/fn/fnsplice.h
+++ b/inc/ti/fn/fnsplice.h
@@ -86,7 +86,7 @@ static int do__f_splice(ti_query_t * query, cleri_node_t * nd, ex_t * e)
         ti_task_t * task = ti_task_get_task(query->ev, varr->parent);
         if (!task || ti_task_add_splice(
                 task,
-                varr->name,
+                varr->key,
                 varr,
                 (uint32_t) i,
                 (uint32_t) c,

--- a/inc/ti/fn/fnunshift.h
+++ b/inc/ti/fn/fnunshift.h
@@ -47,7 +47,7 @@ static int do__f_unshift(ti_query_t * query, cleri_node_t * nd, ex_t * e)
         ti_task_t * task = ti_task_get_task(query->ev, varr->parent);
         if (!task || ti_task_add_splice(
                 task,
-                varr->name,
+                varr->key,
                 varr,
                 0,
                 0,

--- a/inc/ti/fn/fnvalues.h
+++ b/inc/ti/fn/fnvalues.h
@@ -13,7 +13,7 @@ static int do__f_values(ti_query_t * query, cleri_node_t * nd, ex_t * e)
         return e->nr;
 
     thing = (ti_thing_t *) query->rval;
-    varr = ti_varr_create(thing->items->n);
+    varr = ti_varr_create(ti_thing_n(thing));
     if (!varr)
     {
         ex_set_mem(e);
@@ -22,7 +22,7 @@ static int do__f_values(ti_query_t * query, cleri_node_t * nd, ex_t * e)
 
     if (ti_thing_is_object(thing))
     {
-        for (vec_each(thing->items, ti_prop_t, prop))
+        for (vec_each(thing->items.vec, ti_prop_t, prop))
         {
             VEC_push(varr->vec, prop->val);
             ti_incref(prop->val);
@@ -30,7 +30,7 @@ static int do__f_values(ti_query_t * query, cleri_node_t * nd, ex_t * e)
     }
     else
     {
-        for (vec_each(thing->items, ti_val_t, val))
+        for (vec_each(thing->items.vec, ti_val_t, val))
         {
             VEC_push(varr->vec, val);
             ti_incref(val);

--- a/inc/ti/fn/fnvalues.h
+++ b/inc/ti/fn/fnvalues.h
@@ -1,5 +1,12 @@
 #include <ti/fn/fn.h>
 
+static int values__walk_i(ti_item_t * item, vec_t * vec)
+{
+    VEC_push(vec, item->val);
+    ti_incref(item->val);
+    return 0;
+}
+
 static int do__f_values(ti_query_t * query, cleri_node_t * nd, ex_t * e)
 {
     const int nargs = langdef_nd_n_function_params(nd);
@@ -22,10 +29,20 @@ static int do__f_values(ti_query_t * query, cleri_node_t * nd, ex_t * e)
 
     if (ti_thing_is_object(thing))
     {
-        for (vec_each(thing->items.vec, ti_prop_t, prop))
+        if (ti_thing_is_dict(thing))
         {
-            VEC_push(varr->vec, prop->val);
-            ti_incref(prop->val);
+            (void) smap_values(
+                    thing->items.smap,
+                    (smap_val_cb) values__walk_i,
+                    varr->vec);
+        }
+        else
+        {
+            for (vec_each(thing->items.vec, ti_prop_t, prop))
+            {
+                VEC_push(varr->vec, prop->val);
+                ti_incref(prop->val);
+            }
         }
     }
     else

--- a/inc/ti/fn/fnwse.h
+++ b/inc/ti/fn/fnwse.h
@@ -5,8 +5,14 @@ static int do__f_wse(ti_query_t * query, cleri_node_t * nd, ex_t * e)
     const int nargs = langdef_nd_n_function_params(nd);
     uint8_t wse_flag_state;
 
-    if (fn_nargs("wse", DOC_WSE, 1, nargs, e))
+    if (fn_nargs_max("wse", DOC_WSE, 1, nargs, e))
         return e->nr;
+
+    if (!nargs)
+    {
+        query->rval = (ti_val_t *) ti_nil_get();
+        return e->nr;
+    }
 
     wse_flag_state = ~query->flags & TI_QUERY_FLAG_WSE;
     query->flags |= TI_QUERY_FLAG_WSE;

--- a/inc/ti/item.h
+++ b/inc/ti/item.h
@@ -1,0 +1,15 @@
+/*
+ * ti/item.h
+ */
+#ifndef TI_ITEM_H_
+#define TI_ITEM_H_
+
+#include <ti/item.t.h>
+#include <ti/raw.t.h>
+#include <ti/val.t.h>
+
+ti_item_t * ti_item_create(ti_raw_t * raw, ti_val_t * val);
+ti_item_t * ti_item_dup(ti_item_t * item);
+void ti_item_destroy(ti_item_t * item);
+
+#endif /* TI_ITEM_H_ */

--- a/inc/ti/item.t.h
+++ b/inc/ti/item.t.h
@@ -1,0 +1,18 @@
+/*
+ * ti/item.t.h
+ */
+#ifndef TI_ITEM_T_H_
+#define TI_ITEM_T_H_
+
+typedef struct ti_item_s  ti_item_t;
+
+#include <ti/raw.t.h>
+#include <ti/val.t.h>
+
+struct ti_item_s
+{
+    ti_raw_t * key;     /* with reference */
+    ti_val_t * val;     /* with reference */
+};
+
+#endif /* TI_ITEM_T_H_ */

--- a/inc/ti/raw.h
+++ b/inc/ti/raw.h
@@ -43,6 +43,7 @@ ti_raw_t * ti_raw_cat_strn_strn(
 _Bool ti_raw_contains(ti_raw_t * a, ti_raw_t * b);
 int ti_raw_check_valid_name(ti_raw_t * raw, const char * s, ex_t * e);
 int ti_raw_err_not_found(ti_raw_t * raw, const char * s, ex_t * e);
+const char * ti_raw_as_printable_str(ti_raw_t * raw);
 static inline _Bool ti_raw_startswith(ti_raw_t * a, ti_raw_t * b);
 static inline _Bool ti_raw_endswith(ti_raw_t * a, ti_raw_t * b);
 static inline _Bool ti_raw_eq(const ti_raw_t * a, const ti_raw_t * b);

--- a/inc/ti/raw.inline.h
+++ b/inc/ti/raw.inline.h
@@ -25,4 +25,9 @@ static inline ti_raw_t * ti_mp_create(const unsigned char * bin, size_t n)
     return ti_raw_create(TI_VAL_MP, bin, n);
 }
 
+static inline _Bool ti_raw_is_name(ti_raw_t * raw)
+{
+    return raw->tp == TI_VAL_NAME;
+}
+
 #endif  /* TI_RAW_INLINE_H_ */

--- a/inc/ti/raw.inline.h
+++ b/inc/ti/raw.inline.h
@@ -30,4 +30,9 @@ static inline _Bool ti_raw_is_name(ti_raw_t * raw)
     return raw->tp == TI_VAL_NAME;
 }
 
+static inline _Bool ti_raw_is_reserved_key(ti_raw_t * raw)
+{
+    return raw->n == 1 && ((*raw->data & 240) == 32);
+}
+
 #endif  /* TI_RAW_INLINE_H_ */

--- a/inc/ti/raw.inline.h
+++ b/inc/ti/raw.inline.h
@@ -32,7 +32,7 @@ static inline _Bool ti_raw_is_name(ti_raw_t * raw)
 
 static inline _Bool ti_raw_is_reserved_key(ti_raw_t * raw)
 {
-    return raw->n == 1 && ((*raw->data & 240) == 32);
+    return raw->n == 1 && (*raw->data >> 4 == 2);
 }
 
 #endif  /* TI_RAW_INLINE_H_ */

--- a/inc/ti/task.h
+++ b/inc/ti/task.h
@@ -26,8 +26,8 @@ ti_task_t * ti_task_create(uint64_t event_id, ti_thing_t * thing);
 ti_task_t * ti_task_get_task(ti_event_t * ev, ti_thing_t * thing);
 void ti_task_destroy(ti_task_t * task);
 ti_pkg_t * ti_task_pkg_watch(ti_task_t * task);
-int ti_task_add_add(ti_task_t * task, ti_name_t * name, vec_t * added);
-int ti_task_add_set(ti_task_t * task, ti_name_t * name, ti_val_t * val);
+int ti_task_add_add(ti_task_t * task, ti_raw_t * key, vec_t * added);
+int ti_task_add_set(ti_task_t * task, ti_raw_t * key, ti_val_t * val);
 int ti_task_add_new_type(ti_task_t * task, ti_type_t * type);
 int ti_task_add_set_type(ti_task_t * task, ti_type_t * type);
 int ti_task_add_del(ti_task_t * task, ti_raw_t * name);
@@ -80,7 +80,7 @@ int ti_task_add_mod_type_ren(
         ti_name_t * newname);
 int ti_task_add_mod_type_wpo(ti_task_t * task, ti_type_t * type);
 int ti_task_add_del_node(ti_task_t * task, uint32_t node_id);
-int ti_task_add_remove(ti_task_t * task, ti_name_t * name, vec_t * removed);
+int ti_task_add_remove(ti_task_t * task, ti_raw_t * key, vec_t * removed);
 int ti_task_add_rename_collection(
         ti_task_t * task,
         ti_collection_t * collection);
@@ -104,7 +104,7 @@ int ti_task_add_revoke(
 int ti_task_add_set_password(ti_task_t * task, ti_user_t * user);
 int ti_task_add_splice(
         ti_task_t * task,
-        ti_name_t * name,
+        ti_raw_t * key,
         ti_varr_t * varr,       /* array or array-of-things */
         uint32_t i,              /* start at index */
         uint32_t c,              /* number of items to remove */

--- a/inc/ti/thing.h
+++ b/inc/ti/thing.h
@@ -8,6 +8,7 @@
 #include <stdint.h>
 #include <ti/collection.t.h>
 #include <ti/field.t.h>
+#include <ti/item.t.h>
 #include <ti/name.t.h>
 #include <ti/prop.t.h>
 #include <ti/raw.t.h>
@@ -27,6 +28,7 @@ ti_thing_t * ti_thing_o_create(
         uint64_t id,
         size_t init_sz,
         ti_collection_t * collection);
+ti_thing_t * ti_thing_i_create(uint64_t id, ti_collection_t * collection);
 ti_thing_t * ti_thing_t_create(
         uint64_t id,
         ti_type_t * type,
@@ -40,9 +42,13 @@ int ti_thing_props_from_vup(
         size_t sz,
         ex_t * e);
 ti_thing_t * ti_thing_new_from_vup(ti_vup_t * vup, size_t sz, ex_t * e);
-ti_prop_t * ti_thing_o_prop_add(    /* only when property does not exists */
+ti_prop_t * ti_thing_p_prop_add(    /* only when property does not exists */
         ti_thing_t * thing,
         ti_name_t * name,
+        ti_val_t * val);
+ti_item_t * ti_thing_i_item_add(
+        ti_thing_t * thing,
+        ti_raw_t * key,
         ti_val_t * val);
 ti_prop_t * ti_thing_p_prop_set(
         ti_thing_t * thing,
@@ -54,7 +60,7 @@ void ti_thing_t_prop_set(
         ti_val_t * val);
 void ti_thing_t_to_object(ti_thing_t * thing);
 _Bool ti_thing_o_del(ti_thing_t * thing, ti_name_t * name);
-ti_prop_t * ti_thing_o_del_e(ti_thing_t * thing, ti_raw_t * rname, ex_t * e);
+ti_item_t * ti_thing_o_del_e(ti_thing_t * thing, ti_raw_t * rname, ex_t * e);
 _Bool ti_thing_get_by_raw(ti_witem_t * witem, ti_thing_t * thing, ti_raw_t * raw);
 ti_val_t * ti_thing_weak_val_by_name(ti_thing_t * thing, ti_name_t * name);
 int ti_thing_get_by_raw_e(

--- a/inc/ti/thing.h
+++ b/inc/ti/thing.h
@@ -64,7 +64,7 @@ void ti_thing_t_prop_set(
         ti_field_t * field,
         ti_val_t * val);
 void ti_thing_t_to_object(ti_thing_t * thing);
-_Bool ti_thing_o_del(ti_thing_t * thing, ti_name_t * name);
+void ti_thing_o_del(ti_thing_t * thing, const char * str, size_t n);
 ti_item_t * ti_thing_o_del_e(ti_thing_t * thing, ti_raw_t * rname, ex_t * e);
 _Bool ti_thing_get_by_raw(ti_witem_t * witem, ti_thing_t * thing, ti_raw_t * raw);
 ti_val_t * ti_thing_weak_val_by_name(ti_thing_t * thing, ti_name_t * name);

--- a/inc/ti/thing.h
+++ b/inc/ti/thing.h
@@ -19,6 +19,7 @@
 #include <ti/vup.t.h>
 #include <ti/watch.t.h>
 #include <ti/wprop.t.h>
+#include <ti/witem.t.h>
 #include <util/mpack.h>
 #include <util/vec.h>
 
@@ -32,6 +33,7 @@ ti_thing_t * ti_thing_t_create(
         ti_collection_t * collection);
 void ti_thing_destroy(ti_thing_t * thing);
 void ti_thing_clear(ti_thing_t * thing);
+int ti_thing_to_items(ti_thing_t * thing);
 int ti_thing_props_from_vup(
         ti_thing_t * thing,
         ti_vup_t * vup,
@@ -42,7 +44,7 @@ ti_prop_t * ti_thing_o_prop_add(    /* only when property does not exists */
         ti_thing_t * thing,
         ti_name_t * name,
         ti_val_t * val);
-ti_prop_t * ti_thing_o_prop_set(
+ti_prop_t * ti_thing_p_prop_set(
         ti_thing_t * thing,
         ti_name_t * name,
         ti_val_t * val);
@@ -53,10 +55,10 @@ void ti_thing_t_prop_set(
 void ti_thing_t_to_object(ti_thing_t * thing);
 _Bool ti_thing_o_del(ti_thing_t * thing, ti_name_t * name);
 ti_prop_t * ti_thing_o_del_e(ti_thing_t * thing, ti_raw_t * rname, ex_t * e);
-_Bool ti_thing_get_by_raw(ti_wprop_t * wprop, ti_thing_t * thing, ti_raw_t * raw);
+_Bool ti_thing_get_by_raw(ti_witem_t * witem, ti_thing_t * thing, ti_raw_t * raw);
 ti_val_t * ti_thing_weak_val_by_name(ti_thing_t * thing, ti_name_t * name);
 int ti_thing_get_by_raw_e(
-        ti_wprop_t * wprop,
+        ti_witem_t * witem,
         ti_thing_t * thing,
         ti_raw_t * r,
         ex_t * e);
@@ -76,6 +78,13 @@ int ti_thing__to_pk(ti_thing_t * thing, msgpack_packer * pk, int options);
 int ti_thing_t_to_pk(ti_thing_t * thing, msgpack_packer * pk, int options);
 _Bool ti__thing_has_watchers_(ti_thing_t * thing);
 _Bool ti_thing_equals(ti_thing_t * thing, ti_val_t * other, uint8_t deep);
+int ti_thing_i_set_val_from_strn(
+        ti_witem_t * witem,
+        ti_thing_t * thing,
+        const char * str,
+        size_t n,
+        ti_val_t ** val,
+        ex_t * e);
 int ti_thing_o_set_val_from_valid_strn(
         ti_wprop_t * wprop,
         ti_thing_t * thing,
@@ -100,6 +109,16 @@ static inline _Bool ti_thing_is_object(ti_thing_t * thing)
     return thing->type_id == TI_SPEC_OBJECT;
 }
 
+static inline _Bool ti_thing_is_object_i(ti_thing_t * thing)
+{
+    return thing->flags & TI_THING_FLAG_ITEMS;
+}
+
+static inline _Bool ti_thing_is_object_p(ti_thing_t * thing)
+{
+    return ti_thing_is_object(thing) && (~thing->flags & TI_THING_FLAG_ITEMS);
+}
+
 static inline _Bool ti_thing_is_instance(ti_thing_t * thing)
 {
     return thing->type_id != TI_SPEC_OBJECT;
@@ -122,19 +141,23 @@ static inline int ti_thing_id_to_pk(ti_thing_t * thing, msgpack_packer * pk)
 
 static inline _Bool ti_thing_is_new(ti_thing_t * thing)
 {
-    return thing->flags & TI_VFLAG_THING_NEW;
+    return thing->flags & TI_THING_FLAG_NEW;
 }
 static inline void ti_thing_mark_new(ti_thing_t * thing)
 {
-    thing->flags |= TI_VFLAG_THING_NEW;
+    thing->flags |= TI_THING_FLAG_NEW;
 }
 static inline void ti_thing_unmark_new(ti_thing_t * thing)
 {
-    thing->flags &= ~TI_VFLAG_THING_NEW;
+    thing->flags &= ~TI_THING_FLAG_NEW;
 }
 static inline uint64_t ti_thing_key(ti_thing_t * thing)
 {
     return (uintptr_t) thing;
+}
+static inline uint32_t ti_thing_n(ti_thing_t * thing)
+{
+    return thing->items.vec->n;
 }
 
 static inline ti_prop_t * ti_thing_o_prop_weak_get(
@@ -142,24 +165,24 @@ static inline ti_prop_t * ti_thing_o_prop_weak_get(
         ti_name_t * name)
 {
     assert (ti_thing_is_object(thing));
-    for (vec_each(thing->items, ti_prop_t, prop))
+    for (vec_each(thing->items.vec, ti_prop_t, prop))
         if (prop->name == name)
             return prop;
     return NULL;
 }
 
-#define thing_t_each(t__, name__, val__)                          \
-    void ** v__ = t__->items->data,                             \
-    ** e__ = v__ + t__->items->n,                               \
+#define thing_t_each(t__, name__, val__)                        \
+    void ** v__ = t__->items.vec->data,                         \
+    ** e__ = v__ + t__->items.vec->n,                           \
     ** n__ = ti_thing_type(t__)->fields->data;                  \
     v__ < e__ &&                                                \
     (name__ = ((ti_field_t *) *n__)->name) &&                   \
     (val__ = *v__);                                             \
     ++v__, ++n__
 
-#define thing_t_each_addr(t__, name__, val__)                     \
-    void ** v__ = t__->items->data,                             \
-    ** e__ = v__ + t__->items->n,                               \
+#define thing_t_each_addr(t__, name__, val__)                   \
+    void ** v__ = t__->items.vec->data,                         \
+    ** e__ = v__ + t__->items.vec->n,                           \
     ** n__ = ti_thing_type(t__)->fields->data;                  \
     v__ < e__ &&                                                \
     (name__ = ((ti_field_t *) *n__)->name) &&                   \

--- a/inc/ti/thing.h
+++ b/inc/ti/thing.h
@@ -35,7 +35,8 @@ ti_thing_t * ti_thing_t_create(
         ti_collection_t * collection);
 void ti_thing_destroy(ti_thing_t * thing);
 void ti_thing_clear(ti_thing_t * thing);
-int ti_thing_to_items(ti_thing_t * thing);
+int ti_thing_to_dict(ti_thing_t * thing);
+int ti_thing_to_strict(ti_thing_t * thing, ti_raw_t ** incompatible);
 int ti_thing_props_from_vup(
         ti_thing_t * thing,
         ti_vup_t * vup,
@@ -53,6 +54,10 @@ ti_item_t * ti_thing_i_item_add(
 ti_prop_t * ti_thing_p_prop_set(
         ti_thing_t * thing,
         ti_name_t * name,
+        ti_val_t * val);
+ti_item_t * ti_thing_i_item_set(
+        ti_thing_t * thing,
+        ti_raw_t * key,
         ti_val_t * val);
 void ti_thing_t_prop_set(
         ti_thing_t * thing,
@@ -158,6 +163,7 @@ static inline uint64_t ti_thing_key(ti_thing_t * thing)
 }
 static inline uint32_t ti_thing_n(ti_thing_t * thing)
 {
+    /* both smap_t and vec_t have the `n` counter on top */
     return thing->items.vec->n;
 }
 
@@ -165,7 +171,9 @@ static inline ti_prop_t * ti_thing_o_prop_weak_get(
         ti_thing_t * thing,
         ti_name_t * name)
 {
-    assert (ti_thing_is_object(thing));
+    if (ti_thing_is_dict(thing))
+        return smap_get(thing->items.smap, name->str);
+
     for (vec_each(thing->items.vec, ti_prop_t, prop))
         if (prop->name == name)
             return prop;

--- a/inc/ti/thing.h
+++ b/inc/ti/thing.h
@@ -115,14 +115,9 @@ static inline _Bool ti_thing_is_object(ti_thing_t * thing)
     return thing->type_id == TI_SPEC_OBJECT;
 }
 
-static inline _Bool ti_thing_is_object_i(ti_thing_t * thing)
+static inline _Bool ti_thing_is_dict(ti_thing_t * thing)
 {
-    return thing->flags & TI_THING_FLAG_ITEMS;
-}
-
-static inline _Bool ti_thing_is_object_p(ti_thing_t * thing)
-{
-    return ti_thing_is_object(thing) && (~thing->flags & TI_THING_FLAG_ITEMS);
+    return thing->flags & TI_THING_FLAG_DICT;
 }
 
 static inline _Bool ti_thing_is_instance(ti_thing_t * thing)

--- a/inc/ti/thing.h
+++ b/inc/ti/thing.h
@@ -67,7 +67,6 @@ void ti_thing_t_to_object(ti_thing_t * thing);
 void ti_thing_o_del(ti_thing_t * thing, const char * str, size_t n);
 ti_item_t * ti_thing_o_del_e(ti_thing_t * thing, ti_raw_t * rname, ex_t * e);
 _Bool ti_thing_get_by_raw(ti_witem_t * witem, ti_thing_t * thing, ti_raw_t * raw);
-ti_val_t * ti_thing_weak_val_by_name(ti_thing_t * thing, ti_name_t * name);
 int ti_thing_get_by_raw_e(
         ti_witem_t * witem,
         ti_thing_t * thing,
@@ -87,6 +86,7 @@ int ti_thing_watch_init(ti_thing_t * thing, ti_stream_t * stream);
 int ti_thing_unwatch(ti_thing_t * thing, ti_stream_t * stream);
 int ti_thing__to_pk(ti_thing_t * thing, msgpack_packer * pk, int options);
 int ti_thing_t_to_pk(ti_thing_t * thing, msgpack_packer * pk, int options);
+ti_val_t * ti_thing_val_by_strn(ti_thing_t * thing, const char * str, size_t n);
 _Bool ti__thing_has_watchers_(ti_thing_t * thing);
 _Bool ti_thing_equals(ti_thing_t * thing, ti_val_t * other, uint8_t deep);
 int ti_thing_i_set_val_from_strn(

--- a/inc/ti/thing.inline.h
+++ b/inc/ti/thing.inline.h
@@ -143,7 +143,7 @@ static inline void ti_thing_t_set_not_found(
     else
     {
         ex_set(e, EX_VALUE_ERROR,
-                "type properties name must follow the naming rules"DOC_NAMES);
+                "type keys must follow the naming rules"DOC_NAMES);
     }
 }
 

--- a/inc/ti/thing.inline.h
+++ b/inc/ti/thing.inline.h
@@ -65,7 +65,7 @@ static inline int ti_thing_o_set_val_from_strn(
         return e->nr;
     }
 
-    if (!ti_thing_is_object_i(thing) && ti_thing_to_items(thing))
+    if (!ti_thing_is_dict(thing) && ti_thing_to_items(thing))
     {
         ex_set_mem(e);
         return e->nr;

--- a/inc/ti/thing.inline.h
+++ b/inc/ti/thing.inline.h
@@ -46,13 +46,17 @@ static inline int ti_thing_o_set_val_from_strn(
         ex_t * e)
 {
     if (ti_name_is_valid_strn(str, n))
+        /* Create a name when the key is a valid name, this is required since
+         * some logic, for example in `do.c` checks if a name exists, and from
+         * that result might decide a property exists or not.
+         */
         return ti_thing_o_set_val_from_valid_strn(
                 (ti_wprop_t *) witem,
                 thing, str, n, val, e);
 
     /*
-     *  TODO: UTF-8 encoding depends on correct msgpack data, should we add an
-     *  extra check?
+     *  TODO: UTF-8 encoding depends on correct msgpack data, decide if we
+     *  want to keep this check, or rely on correct usage of msgpack.
      */
 
     if (!strx_is_utf8n(str, n))

--- a/inc/ti/thing.t.h
+++ b/inc/ti/thing.t.h
@@ -24,7 +24,8 @@ enum
                                            a full `dump` in a task while
                                            existing things only can contain
                                            the `id`.*/
-    TI_THING_FLAG_ITEMS     =1<<2,
+    TI_THING_FLAG_DICT      =1<<2,      /* thing is an object and items are
+                                           stored in the smap_t. */
 };
 
 union ti_thing_via

--- a/inc/ti/thing.t.h
+++ b/inc/ti/thing.t.h
@@ -30,12 +30,21 @@ enum
 union ti_thing_via
 {
     vec_t * vec;                /* contains:
-                                 *  - ti_prop_t : when thing is an object with
-                                 *                only valid name properties.
-                                 *  - ti_val_t : when thing is an instance of
+                                 *  - ti_prop_t :
+                                 *          When thing is an object with
+                                 *          only valid name properties.
+                                 *  - ti_val_t :
+                                 *          When thing is an instance of
                                  *               a type.
                                  */
-    smap_t * smap;              /* contains ti_item_t */
+    smap_t * smap;              /* contains ti_item_t :
+                                 *          In an item the `key` value is of
+                                 *          type ti_raw_t, but valid names are
+                                 *          must still be of type ti_name_t
+                                 *          because logic might decide a
+                                 *          key does not exist in case there is
+                                 *          no name available.
+                                 */
 };
 
 struct ti_thing_s

--- a/inc/ti/thing.t.h
+++ b/inc/ti/thing.t.h
@@ -5,12 +5,38 @@
 #define TI_THING_T_H_
 
 typedef struct ti_thing_s  ti_thing_t;
+typedef union ti_thing_via ti_thing_via_t;
 
 #include <stdint.h>
 #include <ti/collection.t.h>
 #include <util/vec.h>
 
 extern vec_t * ti_thing_gc_vec;
+
+enum
+{
+    TI_THING_FLAG_SWEEP     =1<<0,      /* marked for sweep; each thing is
+                                           initially marked and while running
+                                           garbage collection this mark is
+                                           removed as long as the `thing` is
+                                           attached to the collection. */
+    TI_THING_FLAG_NEW       =1<<1,      /* thing is new; new things require
+                                           a full `dump` in a task while
+                                           existing things only can contain
+                                           the `id`.*/
+    TI_THING_FLAG_ITEMS     =1<<2,
+};
+
+union ti_thing_via
+{
+    vec_t * vec;                /* contains:
+                                 *  - ti_prop_t : when thing is an object with
+                                 *                only valid name properties.
+                                 *  - ti_val_t : when thing is an instance of
+                                 *               a type.
+                                 */
+    smap_t * smap;              /* contains ti_item_t */
+};
 
 struct ti_thing_s
 {
@@ -24,9 +50,10 @@ struct ti_thing_s
                                      * only `null` when in thingsdb or node
                                      * scope, but never in a collection scope
                                      */
-    vec_t * items;                  /* vec contains ti_prop_t or ti_val_t,
-                                     * depending if a thing is an object or
-                                     * instance */
+    ti_thing_via_t items;           /* contains ti_prop_t, ti_item_t or
+                                     * ti_val_t, depending if a thing is an
+                                     * object strict,  with free keys, or
+                                     * instance of a type */
     vec_t * watchers;               /* vec contains ti_watch_t,
                                        NULL if no watchers,  */
 };

--- a/inc/ti/val.inline.h
+++ b/inc/ti/val.inline.h
@@ -238,7 +238,7 @@ static inline _Bool ti_val_is_instance(ti_val_t * val)
 static inline void ti_val_attach(
         ti_val_t * val,
         ti_thing_t * parent,
-        ti_name_t * name)
+        void * key)  /* ti_raw_t or ti_name_t */
 {
     switch ((ti_val_enum) val->tp)
     {
@@ -261,11 +261,11 @@ static inline void ti_val_attach(
         return;
     case TI_VAL_ARR:
         ((ti_varr_t *) val)->parent = parent;
-        ((ti_varr_t *) val)->name = name;
+        ((ti_varr_t *) val)->key = key;
         return;
     case TI_VAL_SET:
         ((ti_vset_t *) val)->parent = parent;
-        ((ti_vset_t *) val)->name = name;
+        ((ti_vset_t *) val)->key = key;
         return;
     case TI_VAL_TEMPLATE:
         break;
@@ -286,7 +286,7 @@ static inline void ti_val_attach(
 static inline int ti_val_make_assignable(
         ti_val_t ** val,
         ti_thing_t * parent,
-        ti_name_t * name,
+        void * key,
         ex_t * e)
 {
     switch ((ti_val_enum) (*val)->tp)
@@ -313,7 +313,7 @@ static inline int ti_val_make_assignable(
             return e->nr;
         }
         ((ti_varr_t *) *val)->parent = parent;
-        ((ti_varr_t *) *val)->name = name;
+        ((ti_varr_t *) *val)->key = key;
         return 0;
     case TI_VAL_SET:
         if (ti_vset_assign((ti_vset_t **) val))
@@ -322,7 +322,7 @@ static inline int ti_val_make_assignable(
             return e->nr;
         }
         ((ti_vset_t *) *val)->parent = parent;
-        ((ti_vset_t *) *val)->name = name;
+        ((ti_vset_t *) *val)->key = key;
         return 0;
     case TI_VAL_CLOSURE:
         return ti_closure_unbound((ti_closure_t * ) *val, e);

--- a/inc/ti/val.t.h
+++ b/inc/ti/val.t.h
@@ -75,41 +75,8 @@ typedef enum
 
 enum
 {
-    TI_VFLAG_THING_SWEEP     =1<<0,      /* marked for sweep; each thing is
-                                            initially marked and while running
-                                            garbage collection this mark is
-                                            removed as long as the `thing` is
-                                            attached to the collection. */
-    TI_VFLAG_THING_NEW       =1<<1,      /* thing is new; new things require
-                                            a full `dump` in a task while
-                                            existing things only can contain
-                                            the `id`.*/
-    TI_VFLAG_CLOSURE_BTSCOPE =1<<2,      /* closure bound to query string
-                                            within the thingsdb scope;
-                                            when not stored, closures do not
-                                            own the closure string but refer
-                                            the full query string.*/
-    TI_VFLAG_CLOSURE_BCSCOPE =1<<3,      /* closure bound to query string
-                                            within a collection scope;
-                                            when not stored, closures do not
-                                            own the closure string but refer
-                                            the full query string. */
-    TI_VFLAG_CLOSURE_WSE     =1<<4,      /* stored closure with side effects;
-                                            when closure make changes they
-                                            require an event and thus must be
-                                            wrapped by wse() so we can know
-                                            an event is created.
-                                            (only stored closures) */
-    TI_VFLAG_LOCK            =1<<5,      /* thing or value in use;
+    TI_VFLAG_LOCK            =1<<7,      /* thing or value in use;
                                             used to prevent illegal changes */
-    TI_VFLAG_ARR_TUPLE       =1<<6,      /* array is immutable; nested, and
-                                            only nested array's are tuples;
-                                            once a tuple is direct assigned to
-                                            a thing, it converts back to a
-                                            mutable list. */
-    TI_VFLAG_ARR_MHT         =1<<7,      /* array may-have-things; some code
-                                            might skip arrays without this flag
-                                            while searching for things; */
 };
 
 typedef enum

--- a/inc/ti/varr.h
+++ b/inc/ti/varr.h
@@ -24,17 +24,17 @@ _Bool ti__varr_eq(ti_varr_t * varra, ti_varr_t * varrb);
 
 static inline _Bool ti_varr_may_have_things(ti_varr_t * varr)
 {
-    return varr->flags & TI_VFLAG_ARR_MHT;
+    return varr->flags & TI_VARR_FLAG_MHT;
 }
 
 static inline _Bool ti_varr_is_list(ti_varr_t * varr)
 {
-    return ~varr->flags & TI_VFLAG_ARR_TUPLE;
+    return ~varr->flags & TI_VARR_FLAG_TUPLE;
 }
 
 static inline _Bool ti_varr_is_tuple(ti_varr_t * varr)
 {
-    return varr->flags & TI_VFLAG_ARR_TUPLE;
+    return varr->flags & TI_VARR_FLAG_TUPLE;
 }
 
 static inline _Bool ti_varr_eq(ti_varr_t * va, ti_varr_t * vb)

--- a/inc/ti/varr.t.h
+++ b/inc/ti/varr.t.h
@@ -9,6 +9,18 @@
 typedef struct ti_varr_s ti_varr_t;
 typedef struct ti_tuple_s ti_tuple_t;
 
+enum
+{
+    TI_VARR_FLAG_TUPLE      =1<<0,      /* array is immutable; nested, and
+                                            only nested array's are tuples;
+                                            once a tuple is direct assigned to
+                                            a thing, it converts back to a
+                                            mutable list. */
+    TI_VARR_FLAG_MHT        =1<<1,      /* array may-have-things; some code
+                                            might skip arrays without this flag
+                                            while searching for things; */
+};
+
 #include <ex.h>
 #include <inttypes.h>
 #include <ti/name.t.h>
@@ -33,7 +45,7 @@ struct ti_varr_s
     vec_t * vec;
     ti_thing_t * parent;    /* without reference,
                                NULL when this is a variable or tuple */
-    ti_name_t * name;       /* without reference */
+    ti_raw_t * key;         /* without reference */
 };
 
 #endif  /* TI_VARR_T_H_ */

--- a/inc/ti/version.h
+++ b/inc/ti/version.h
@@ -6,7 +6,7 @@
 
 #define TI_VERSION_MAJOR 0
 #define TI_VERSION_MINOR 10
-#define TI_VERSION_PATCH 2
+#define TI_VERSION_PATCH 3
 
 /* The syntax version is used to test compatibility with functions
  * using the `ti_nodes_check_syntax()` function */
@@ -23,7 +23,7 @@
  *  "-alpha-1"
  *  ""
  */
-#define TI_VERSION_PRE_RELEASE "-alpha-7"
+#define TI_VERSION_PRE_RELEASE "-alpha-0"
 
 #define TI_MAINTAINER \
     "Jeroen van der Heijden <jeroen@transceptor.technology>"

--- a/inc/ti/vset.h
+++ b/inc/ti/vset.h
@@ -38,7 +38,7 @@ struct ti_vset_s
     imap_t * imap;          /* key: thing_key() / value: *ti_things_t */
     ti_thing_t * parent;    /* without reference,
                                NULL when this is a variable */
-    ti_name_t * name;       /* without reference */
+    ti_raw_t * key;         /* without reference */
 };
 
 /*

--- a/inc/ti/witem.t.h
+++ b/inc/ti/witem.t.h
@@ -1,0 +1,18 @@
+/*
+ * ti/witem.t.h
+ */
+#ifndef TI_WITEM_T_H_
+#define TI_WITEM_T_H_
+
+typedef struct ti_witem_s  ti_witem_t;
+
+#include <ti/raw.t.h>
+#include <ti/val.t.h>
+
+struct ti_witem_s
+{
+    ti_raw_t * key;     /* without reference */
+    ti_val_t ** val;    /* without reference */
+};
+
+#endif /* TI_WITEM_T_H_ */

--- a/inc/tiinc.h
+++ b/inc/tiinc.h
@@ -134,4 +134,9 @@ typedef enum
     TI_STR_INFO
 } ti_ext_tp;
 
+static inline _Bool ti_is_reserved_key_strn(const char * str, size_t n)
+{
+    return n == 1 && ((*str & 240) == 32);
+}
+
 #endif  /* TIINC_H_ */

--- a/inc/tiinc.h
+++ b/inc/tiinc.h
@@ -4,8 +4,6 @@
 #ifndef TIINC_H_
 #define TIINC_H_
 
-#define TI_URL "https://thingsdb.github.io"
-
 #define TI_DEFAULT_CLIENT_PORT 9200
 #define TI_DEFAULT_NODE_PORT 9220
 
@@ -33,17 +31,15 @@
 #define TI_THING_ID "`#%"PRIu64"`"
 #define TI_USER_ID "`user:%"PRIu64"`"
 #define TI_QBIND "syntax v%u"
-#define TI_SAVE_PK_SZ (60 + ti_.nodes->imap->n * 140)
 
 /* Max token expiration time */
-#define TI_MAX_EXPIRATION_DOUDLE 4294967295.0
+#define TI_MAX_EXPIRATION_DOUBLE 4294967295.0
 #define TI_MAX_EXPIRATION_LONG 4294967295L
 
 /*
  * File name schema to check version info on created files.
  */
 #define TI_FN_SCHEMA 0
-
 
 /*
  * If a system has a WORDSIZE of 64 bits, we can take advantage of storing
@@ -93,41 +89,9 @@ static const int TI_CLERI_PARSE_FLAGS =
 enum
 {
     TI_FLAG_SIGNAL          =1<<0,
-    TI_FLAG_STOP            =1<<1,
-    TI_FLAG_INDEXING        =1<<2,
-    TI_FLAG_LOCKED          =1<<3,
-    TI_FLAG_NODES_CHANGED   =1<<4,
+    TI_FLAG_LOCKED          =1<<1,
+    TI_FLAG_NODES_CHANGED   =1<<2,
 };
-
-typedef enum
-{
-    TI_a = 'a',
-    TI_b,
-    TI_c,
-    TI_d,
-    TI_e,
-    TI_f,
-    TI_g,
-    TI_h,
-    TI_i,
-    TI_j,
-    TI_k,
-    TI_l,
-    TI_m,
-    TI_n,
-    TI_o,
-    TI_p,
-    TI_q,
-    TI_r,
-    TI_s,
-    TI_t,
-    TI_u,
-    TI_v,
-    TI_w,
-    TI_x,
-    TI_y,
-    TI_z,
-} ti_alpha_lower_t;
 
 typedef enum
 {
@@ -136,7 +100,7 @@ typedef enum
 
 static inline _Bool ti_is_reserved_key_strn(const char * str, size_t n)
 {
-    return n == 1 && ((*str & 240) == 32);
+    return n == 1 && (*str >> 4 == 2);
 }
 
 #endif  /* TIINC_H_ */

--- a/inc/util/smap.h
+++ b/inc/util/smap.h
@@ -12,7 +12,6 @@ enum
     SMAP_SUCCESS        =0,
     SMAP_ERR_ALLOC      =-1,
     SMAP_ERR_EXIST      =-2,
-    SMAP_ERR_EMPTY_KEY  =-3,
 };
 
 typedef struct smap_s smap_t;
@@ -29,11 +28,14 @@ typedef void (*smap_destroy_cb)(void * data);
 
 smap_t * smap_create(void);
 void smap_destroy(smap_t * smap, smap_destroy_cb cb);
+void smap_clear(smap_t * smap, smap_destroy_cb cb);
 int smap_add(smap_t * smap, const char * key, void * data);
+int smap_addn(smap_t * smap, const char * key, size_t n, void * data);
 void * smap_get(smap_t * node, const char * key);
 void ** smap_getaddr(smap_t * smap, const char * key);
 void * smap_getn(smap_t * smap, const char * key, size_t n);
 void * smap_pop(smap_t * smap, const char * key);
+void * smap_popn(smap_t * smap, const char * key, size_t n);
 size_t smap_longest_key_size(smap_t * smap);
 int smap_items(smap_t * smap, char * buf, smap_item_cb cb, void * arg);
 int smap_values(smap_t * smap, smap_val_cb cb, void * arg);
@@ -45,6 +47,7 @@ struct smap_s
     uint8_t sz;             /* size of this node, starting at offset  */
     uint16_t pad0;
     smap_nodes_t * nodes;
+    void * data;            /* for empty "" key */
 };
 
 struct smap_node_s

--- a/itest/run_all_tests.py
+++ b/itest/run_all_tests.py
@@ -7,6 +7,7 @@ from test_arguments import TestArguments
 from test_backup import TestBackup
 from test_collection_functions import TestCollectionFunctions
 from test_datetime import TestDatetime
+from test_dict import TestDict
 from test_doc_url import TestDocUrl
 from test_enum import TestEnum
 from test_events import TestEvents
@@ -52,6 +53,7 @@ if __name__ == '__main__':
     run_test(TestBackup())
     run_test(TestCollectionFunctions())
     run_test(TestDatetime())
+    run_test(TestDict())
     if args.skip_doc_test is False:
         run_test(TestDocUrl())
     run_test(TestEnum())

--- a/itest/test_arguments.py
+++ b/itest/test_arguments.py
@@ -44,8 +44,8 @@ class TestArguments(TestBase):
 
         with self.assertRaisesRegex(
                 TypeError,
-                r'property names must be of type `str` and follow the '
-                r'naming rules'):
+                r'property names must be of type `str` '
+                r'\(in argument `blob`\)'):
             await client.query(r'blob;', blob={0: 1})
 
         with self.assertRaisesRegex(

--- a/itest/test_collection_functions.py
+++ b/itest/test_collection_functions.py
@@ -659,8 +659,8 @@ class TestCollectionFunctions(TestBase):
             await client.query('.del(nil);')
 
         with self.assertRaisesRegex(
-                ValueError,
-                r'property name must follow the naming rules'):
+                LookupError,
+                r'thing `#\d+` has no property ``'):
             await client.query('.del("");')
 
         with self.assertRaisesRegex(
@@ -3602,8 +3602,8 @@ class TestCollectionFunctions(TestBase):
 
         with self.assertRaisesRegex(
                 NumArgumentsError,
-                'function `wse` takes 1 argument but 0 were given'):
-            await client.query('wse();')
+                'function `wse` takes at most 1 argument but 2 were given'):
+            await client.query('wse({}, nil);')
 
         res = await client.query(r'''
             wse({

--- a/itest/test_dict.py
+++ b/itest/test_dict.py
@@ -203,8 +203,8 @@ class TestDict(TestBase):
 
         with self.assertRaisesRegex(
                 ValueError,
-                'property `#` is reserved'):
-            await client.query(r'', x={"#": 123})
+                'property `!` is reserved'):
+            await client.query(r'', x={"!": 123})
 
     async def test_assign_and_del(self, client0):
         if not self.with_node1():

--- a/itest/test_dict.py
+++ b/itest/test_dict.py
@@ -54,8 +54,13 @@ class TestDict(TestBase):
             "b": 2,
         })
         res = await client.query(r'''
-            d = thing(.dict);
+            a = {};
+            a[""] = 1;
+            a[""] += 1;
+            a[""] = a.get("") + 1;
+            a;
         ''')
+        self.assertEqual(res, {"": 3})
 
 
 if __name__ == '__main__':

--- a/itest/test_dict.py
+++ b/itest/test_dict.py
@@ -203,8 +203,8 @@ class TestDict(TestBase):
 
         with self.assertRaisesRegex(
                 ValueError,
-                'property `!` is reserved'):
-            await client.query(r'', x={"!": 123})
+                'property `.` is reserved'):
+            await client.query(r'', x={".": 123})
 
     async def test_assign_and_del(self, client0):
         if not self.with_node1():
@@ -357,7 +357,7 @@ class TestDict(TestBase):
 
             [x.equals(y), y.equals(x)];
         ''')
-        self.assertEquals(res, [True, True])
+        self.assertEqual(res, [True, True])
 
         res = await client.query(r'''
             x = {};
@@ -372,7 +372,7 @@ class TestDict(TestBase):
 
             [x.equals(y), y.equals(x)];
         ''')
-        self.assertEquals(res, [False, False])
+        self.assertEqual(res, [False, False])
 
         res = await client.query(r'''
             x = {};
@@ -391,7 +391,7 @@ class TestDict(TestBase):
 
             [x.equals(y), y.equals(x)];
         ''')
-        self.assertEquals(res, [True, True])
+        self.assertEqual(res, [True, True])
 
         res = await client.query(r'''
             x = {};
@@ -410,7 +410,7 @@ class TestDict(TestBase):
 
             [x.equals(z), z.equals(x)];
         ''')
-        self.assertEquals(res, [False, False])
+        self.assertEqual(res, [False, False])
 
     async def test_gen_ids(self, client):
         res = await client.query(r'''

--- a/itest/test_dict.py
+++ b/itest/test_dict.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+import asyncio
+import pickle
+import time
+from lib import run_test
+from lib import default_test_setup
+from lib.testbase import TestBase
+from lib.client import get_client
+from thingsdb.exceptions import AssertionError
+from thingsdb.exceptions import ValueError
+from thingsdb.exceptions import TypeError
+from thingsdb.exceptions import NumArgumentsError
+from thingsdb.exceptions import BadDataError
+from thingsdb.exceptions import LookupError
+from thingsdb.exceptions import OverflowError
+from thingsdb.exceptions import ZeroDivisionError
+from thingsdb.exceptions import OperationError
+from thingsdb.exceptions import ForbiddenError
+
+
+class TestDict(TestBase):
+
+    title = 'Test thing as dictionary '
+
+    @default_test_setup(num_nodes=2, seed=1, threshold_full_storage=10)
+    async def run(self):
+
+        await self.node0.init_and_run()
+
+        client = await get_client(self.node0)
+        client.set_default_scope('//stuff')
+
+        # add another node otherwise backups are not possible
+        # await self.node1.join_until_ready(client)
+
+        await self.run_tests(client)
+
+        client.close()
+        await client.wait_closed()
+
+    async def test_functions(self, client):
+        res = await client.query(r'''
+            .dict = {};
+            .dict["this is a key"] = 42;
+            .dict.set("", "empty key");
+            .dict.set("a", 1);
+            .dict.set("b", 2);
+            .dict.filter(||true);
+        ''')
+        self.assertEqual(res, {
+            "this is a key": 42,
+            "": "empty key",
+            "a": 1,
+            "b": 2,
+        })
+        res = await client.query(r'''
+            d = thing(.dict);
+        ''')
+
+
+if __name__ == '__main__':
+    run_test(TestDict())

--- a/itest/test_dict.py
+++ b/itest/test_dict.py
@@ -2,6 +2,7 @@
 import asyncio
 import pickle
 import time
+import random
 from lib import run_test
 from lib import default_test_setup
 from lib.testbase import TestBase
@@ -39,6 +40,12 @@ class TestDict(TestBase):
         await client.wait_closed()
 
     async def test_functions(self, client):
+        keys = [
+            "",
+            "a",
+            "b",
+            "this is a key",
+        ]
         res = await client.query(r'''
             .dict = {};
             .dict["this is a key"] = 42;
@@ -61,6 +68,194 @@ class TestDict(TestBase):
             a;
         ''')
         self.assertEqual(res, {"": 3})
+        res = await client.query(r'''
+            .dict.del("");
+        ''')
+        self.assertEqual(res, "empty key")
+        res = await client.query(r'''
+            x = {}; x[""] = "!empty";
+            .dict.assign(x);
+            nil;
+        ''')
+        self.assertEqual(res, None)
+        res = await client.query(r'''.dict.len();''')
+        self.assertEqual(res, 4)
+        res = await client.query(r'''.dict.keys()''')
+        self.assertEqual(res, keys)
+        res = await client.query(r'''
+            keys = [];
+            .dict.each(|k| keys.push(k));
+            keys;
+        ''')
+        self.assertEqual(res, keys)
+        res = await client.query(r'''.dict.map(|k| k);''')
+        self.assertEqual(res, keys)
+
+        res = await client.query(r'''.dict.values();''')
+        self.assertEqual(res, [
+            "!empty",
+            1,
+            2,
+            42
+        ])
+
+        # object <- dict
+        res = await client.query(r'''
+            x = {
+                other: 123,
+            };
+            x.assign(.dict);
+            x;
+        ''')
+        self.assertEqual(res, {
+            "this is a key": 42,
+            "": "!empty",
+            "a": 1,
+            "b": 2,
+            "other": 123
+        })
+        # dict <- dict
+        res = await client.query(r'''
+            x = {};
+            x["!x"] = 666;
+            x.assign(.dict);
+            x;
+        ''')
+        self.assertEqual(res, {
+            "this is a key": 42,
+            "": "!empty",
+            "a": 1,
+            "b": 2,
+            "!x": 666
+        })
+        # type <- dict
+        res = await client.query(r'''
+            set_type('A', {name: 'str'});
+            a = A{name: 'Iris'};
+            b = {name: 'Cato'};
+            b[""] = 123;
+            b.del("");
+            a.assign(b);
+            a;
+        ''')
+        self.assertEqual(res, {
+            "name": "Cato"
+        })
+        # dict <- type
+        res = await client.query(r'''
+            .dict.assign(A{});
+            .dict.filter(|_, v| is_str(v));
+        ''')
+        self.assertEqual(res, {
+            "": "!empty",
+            "name": ""
+        })
+        with self.assertRaisesRegex(
+                LookupError,
+                r'type `A` has no property '
+                r'`#this is a very simple test with a very long...`'):
+            await client.query(r'''
+                x = {};
+                x["#this is a very simple test with a very long key"] = 123;
+                A{}.assign(x);
+            ''')
+
+        res = await client.query(r'''
+            dt = datetime('2021-01-28');
+            x = {};
+            x[""] = nil;
+            x["day"] = 6;
+            x["month"] = 2;
+            dt.replace(x);
+        ''')
+        self.assertEqual(res, '2021-02-06T00:00:00Z')
+        res = await client.query(r'''
+            [
+                .dict.has(""),
+                .dict.has("a"),
+                .dict.has("this is a key"),
+                .dict.has("a b c"),
+                .dict.has("z"),
+                {}.has("a"),
+                {}.has("")
+            ];
+        ''')
+        self.assertEqual(res, [True, True, True, False, False, False, False])
+
+    async def test_errors(self, client):
+        with self.assertRaisesRegex(
+                ValueError,
+                'property `#` is reserved'):
+            await client.query(r'x = {}; x["#"] = 123;')
+
+        with self.assertRaisesRegex(
+                ValueError,
+                'property `#` is reserved'):
+            await client.query(r'x = {}; x.set("#", 123);')
+
+        with self.assertRaisesRegex(
+                ValueError,
+                'property `#` is reserved'):
+            await client.query(r'', x={"#": 123})
+
+    async def test_assign_and_del(self, client):
+        await client.query(r'''
+            .dict = {};
+        ''')
+        keys = []
+        for i in range(0, 2000, 50):
+            key = [chr(random.randint(ord('0'), ord('z'))) for x in range(i)]
+            keys.append(''.join(key))
+        for key in keys:
+            await client.query(r'''
+                .dict.set(key, nil);
+            ''', key=key)
+        self.assertEqual(await client.query('.dict.len();'), len(keys))
+        for key in keys:
+            await client.query(r'''
+                .dict.del(key);
+            ''', key=key)
+        self.assertEqual(await client.query('.dict.len();'), 0)
+
+    async def test_dict_enum(self, client):
+        with self.assertRaisesRegex(
+                ValueError,
+                'enum member must follow the naming rules;'):
+            res = await client.query(r'''
+                x = {}; x[""] = nil;
+                x["yes"] = 0;
+                x["no"] = 1;
+                set_enum('C', x);
+            ''')
+        res = await client.query(r'''
+            x = {}; x[""] = nil;
+            x["yes"] = 0;
+            x["no"] = 1;
+            x.del("");
+            set_enum('C', x);
+            [C{yes}, C{no}];
+        ''')
+        self.assertEqual(res, [0, 1])
+
+    async def test_dict_type(self, client):
+        with self.assertRaisesRegex(
+                ValueError,
+                'xxx'):
+            res = await client.query(r'''
+                x = {}; x[""] = nil;
+                x["name"] = 'str';
+                x["age"] = 'int';
+                set_type('T', x);
+            ''')
+        res = await client.query(r'''
+            x = {}; x[""] = nil;
+            x["name"] = 'str;
+            x["age"] = 'int';
+            x.del("");
+            set_type('T', x);
+            T{};
+        ''')
+        self.assertEqual(res, {name: '', age: 0})
 
 
 if __name__ == '__main__':

--- a/itest/test_modules.py
+++ b/itest/test_modules.py
@@ -662,7 +662,7 @@ class TestModules(TestBase):
                     host: 'localhost',
                     port: 9000
                 }]
-            }, nil);
+            });
         ''', scope='/t')
 
         await asyncio.sleep(3)

--- a/itest/test_pre_restore.py
+++ b/itest/test_pre_restore.py
@@ -34,12 +34,6 @@ class TestNodes(TestBase):
         client = await get_client(self.node0)
         await client.del_collection('stuff')
 
-        await client.query(r'''
-            new_procedure('test', |a, b| {
-                future(|a, b| a*b);
-            });
-        ''', scope='/t')
-
         if NUM_NODES > 1:
             await self.node1.join_until_ready(client)
 

--- a/itest/test_procedures.py
+++ b/itest/test_procedures.py
@@ -108,13 +108,6 @@ class TestProcedures(TestBase):
         )
 
         with self.assertRaisesRegex(
-                ValueError,
-                r'property name must follow the naming rules'
-                r'; see.*'
-                r'\(argument 0 for procedure `upd_list`\)'):
-            await client0.run('upd_list', {"0InvalidKey": 4})
-
-        with self.assertRaisesRegex(
                 LookupError,
                 r'thing `#42` not found; if you want to create a new thing '
                 r'then remove the id \(`#`\) and try again '

--- a/itest/test_syntax.py
+++ b/itest/test_syntax.py
@@ -53,16 +53,8 @@ class TestSyntax(TestBase):
             await client.query('.{} = 1'.format('a'*256))
 
         await client.query('thing(.id())[prop] = 1', prop='b'*255)
-        with self.assertRaisesRegex(
-                ValueError,
-                r'properties must follow the naming rules'):
-            await client.query('thing(.id())[prop] = 1', prop='b'*256)
 
         await client.query('thing(.id()).set(prop, 1)', prop='c'*255)
-        with self.assertRaisesRegex(
-                ValueError,
-                r'properties must follow the naming rules'):
-            await client.query('thing(.id())[prop] = 1', prop='c'*256)
 
     async def test_invalid_syntax(self, client):
         with self.assertRaisesRegex(

--- a/src/ti/closure.c
+++ b/src/ti/closure.c
@@ -404,7 +404,7 @@ void ti_closure_dec(ti_closure_t * closure, ti_query_t * query)
 
 int ti_closure_vars_nameval(
         ti_closure_t * closure,
-        ti_name_t * name,
+        ti_val_t * name,
         ti_val_t * val,
         ex_t * e)
 {
@@ -427,7 +427,7 @@ int ti_closure_vars_nameval(
         prop = VEC_get(closure->vars, 0);
         ti_incref(name);
         ti_val_unsafe_drop(prop->val);
-        prop->val = (ti_val_t *) name;
+        prop->val = name;
         /* fall through */
     case 0:
         break;

--- a/src/ti/closure.c
+++ b/src/ti/closure.c
@@ -20,7 +20,7 @@
 #include <util/strx.h>
 #include <cleri/node.inline.h>
 
-#define CLOSURE__QBOUND (TI_VFLAG_CLOSURE_BTSCOPE|TI_VFLAG_CLOSURE_BCSCOPE)
+#define CLOSURE__QBOUND (TI_CLOSURE_FLAG_BTSCOPE|TI_CLOSURE_FLAG_BCSCOPE)
 
 static inline _Bool closure__is_unbound(ti_closure_t * closure)
 {
@@ -225,7 +225,7 @@ ti_closure_t * ti_closure_from_strn(
     closure->future_depth = 0;
     closure->node = closure__node_from_strn(syntax, str, n, e);
     closure->flags = syntax->flags & TI_QBIND_FLAG_EVENT
-            ? TI_VFLAG_CLOSURE_WSE
+            ? TI_CLOSURE_FLAG_WSE
             : 0;
     closure->stacked = NULL;
     closure->vars = closure->node ? closure__create_vars(closure) : NULL;
@@ -264,7 +264,7 @@ int ti_closure_unbound(ti_closure_t * closure, ex_t * e)
 
     ti_qbind_t syntax = {
             .immutable_n = 0,
-            .flags = closure->flags & TI_VFLAG_CLOSURE_BTSCOPE
+            .flags = closure->flags & TI_CLOSURE_FLAG_BTSCOPE
                 ? TI_QBIND_FLAG_THINGSDB
                 : TI_QBIND_FLAG_COLLECTION,
     };
@@ -277,7 +277,7 @@ int ti_closure_unbound(ti_closure_t * closure, ex_t * e)
         return e->nr;
 
     closure->flags = syntax.flags & TI_QBIND_FLAG_EVENT
-            ? TI_VFLAG_CLOSURE_WSE
+            ? TI_CLOSURE_FLAG_WSE
             : 0;
     closure->node = node;
 

--- a/src/ti/collection.c
+++ b/src/ti/collection.c
@@ -310,7 +310,7 @@ static void collection__gc_mark_thing(ti_thing_t * thing)
     thing->flags &= ~TI_THING_FLAG_SWEEP;
 
     if (ti_thing_is_object(thing))
-        if (ti_thing_is_object_i(thing))
+        if (ti_thing_is_dict(thing))
             (void) smap_values(
                     thing->items.smap,
                     (smap_val_cb) collection__gc_i_cb,

--- a/src/ti/enum.c
+++ b/src/ti/enum.c
@@ -198,7 +198,7 @@ static int enum__init_cb(ti_item_t * item, enum__init_t * w)
 
 static int enum__init_thing_o(ti_enum_t * enum_, ti_thing_t * thing, ex_t * e)
 {
-    if (ti_thing_is_object_i(thing))
+    if (ti_thing_is_dict(thing))
     {
         enum__init_t w = {
                 .enum_ = enum_,

--- a/src/ti/enum.c
+++ b/src/ti/enum.c
@@ -204,15 +204,12 @@ static int enum__init_thing_o(ti_enum_t * enum_, ti_thing_t * thing, ex_t * e)
                 .enum_ = enum_,
                 .e = e,
         };
-        (void) smap_values(thing->items.smap, (smap_val_cb) enum__init_cb, &w);
+        return smap_values(thing->items.smap, (smap_val_cb) enum__init_cb, &w);
     }
-    else
-    {
-        for (vec_each(thing->items.vec, ti_prop_t, prop))
-            if (!ti_member_create(enum_, prop->name, prop->val, e))
-                return e->nr;
-    }
-    return e->nr;
+    for (vec_each(thing->items.vec, ti_prop_t, prop))
+        if (!ti_member_create(enum_, prop->name, prop->val, e))
+            return e->nr;
+    return 0;
 }
 
 static int enum__init_thing_t(ti_enum_t * enum_, ti_thing_t * thing, ex_t * e)

--- a/src/ti/enum.c
+++ b/src/ti/enum.c
@@ -178,7 +178,7 @@ void ti_enum_del_member(ti_enum_t * enum_, ti_member_t * member)
 
 static int enum__init_thing_o(ti_enum_t * enum_, ti_thing_t * thing, ex_t * e)
 {
-    for (vec_each(thing->items, ti_prop_t, prop))
+    for (vec_each(thing->items.vec, ti_prop_t, prop))
         if (!ti_member_create(enum_, prop->name, prop->val, e))
             return e->nr;
 
@@ -198,7 +198,7 @@ static int enum__init_thing_t(ti_enum_t * enum_, ti_thing_t * thing, ex_t * e)
 
 int ti_enum_init_from_thing(ti_enum_t * enum_, ti_thing_t * thing, ex_t * e)
 {
-    if (ti_enum_prealloc(enum_, thing->items->n, e))
+    if (ti_enum_prealloc(enum_, ti_thing_n(thing), e))
         return e->nr;
 
     return ti_thing_is_object(thing)

--- a/src/ti/field.c
+++ b/src/ti/field.c
@@ -706,7 +706,7 @@ static int field__mod_nested_cb(ti_thing_t * thing, ti_field_t * field)
 {
     if (thing->type_id == field->type->type_id)
     {
-        ti_val_t * val = VEC_get(thing->items, field->idx);
+        ti_val_t * val = VEC_get(thing->items.vec, field->idx);
 
         switch ((ti_val_enum) val->tp)
         {
@@ -950,14 +950,14 @@ static int field__ren_cb(ti_thing_t * thing, ti_field_t * field)
 {
     if (thing->type_id == field->type->type_id)
     {
-        ti_val_t * val = VEC_get(thing->items, field->idx);
+        ti_val_t * val = VEC_get(thing->items.vec, field->idx);
         switch((ti_val_enum) val->tp)
         {
         case TI_VAL_ARR:
-            ((ti_varr_t *) val)->name = field->name;
+            ((ti_varr_t *) val)->key = (ti_raw_t *) field->name;
             break;
         case TI_VAL_SET:
-            ((ti_vset_t *) val)->name = field->name;
+            ((ti_vset_t *) val)->key = (ti_raw_t *) field->name;
             break;
         default:
             break;
@@ -1081,7 +1081,7 @@ int ti_field_del(ti_field_t * field, uint64_t ev_id)
             if (ti_thing_has_watchers(thing))
                 field__del_watch(thing, data, ev_id);
 
-            ti_val_unsafe_drop(vec_swap_remove(thing->items, field->idx));
+            ti_val_unsafe_drop(vec_swap_remove(thing->items.vec, field->idx));
         }
         ti_val_unsafe_drop((ti_val_t *) thing);
     }
@@ -1097,7 +1097,9 @@ int ti_field_del(ti_field_t * field, uint64_t ev_id)
             if (ti_thing_has_watchers(gc->thing))
                 field__del_watch(gc->thing, data, ev_id);
 
-            ti_val_unsafe_drop(vec_swap_remove(gc->thing->items, field->idx));
+            ti_val_unsafe_drop(vec_swap_remove(
+                    gc->thing->items.vec,
+                    field->idx));
         }
     }
 
@@ -1926,7 +1928,7 @@ static int field__add(ti_thing_t * thing, field__add_t * w)
 
     /* closure is already unbound, so only a memory exception can occur */
     if (ti_val_make_assignable(w->vaddr, thing, w->name, &w->e) ||
-        vec_push(&thing->items, *w->vaddr))
+        vec_push(&thing->items.vec, *w->vaddr))
         return 1;
 
     ti_incref(*w->vaddr);

--- a/src/ti/item.c
+++ b/src/ti/item.c
@@ -1,0 +1,45 @@
+/*
+ * ti/item.c
+ */
+#include <stdlib.h>
+#include <ti.h>
+#include <ti/raw.h>
+#include <ti/item.h>
+#include <ti/val.inline.h>
+
+ti_item_t * ti_item_create(ti_raw_t * raw, ti_val_t * val)
+{
+    ti_item_t * item = malloc(sizeof(ti_item_t));
+    if (!item)
+        return NULL;
+
+    item->val = val;
+    item->key = raw;
+
+    return item;
+}
+
+/*
+ * Returns a duplicate of the item with a new reference for the raw and value.
+ */
+ti_item_t * ti_item_dup(ti_item_t * item)
+{
+    ti_item_t * dup = malloc(sizeof(ti_item_t));
+    if (!item)
+        return NULL;
+
+    memcpy(dup, item, sizeof(ti_item_t));
+    ti_incref(dup->key);
+    ti_incref(dup->val);
+
+    return dup;
+}
+
+void ti_item_destroy(ti_item_t * item)
+{
+    if (!item)
+        return;
+    ti_val_unsafe_drop((ti_val_t *) item->key);
+    ti_val_unsafe_gc_drop(item->val);
+    free(item);
+}

--- a/src/ti/job.c
+++ b/src/ti/job.c
@@ -1261,7 +1261,7 @@ static int job__mod_type_wpo(ti_thing_t * thing, mp_unp_t * up)
 static int job__del(ti_thing_t * thing, mp_unp_t * up)
 {
     assert (ti_thing_is_object(thing));
-    ti_name_t * name;
+
     mp_obj_t mp_prop;
 
     if (mp_next(up, &mp_prop) != MP_STR)
@@ -1273,29 +1273,8 @@ static int job__del(ti_thing_t * thing, mp_unp_t * up)
         return -1;
     }
 
-    /* the job is already validated so getting the name will most likely
-     * succeed */
-    name = ti_names_weak_get_strn(mp_prop.via.str.data, mp_prop.via.str.n);
-    if (!name || !ti_thing_o_del(thing, name))
-    {
-        if (ti_name_is_valid_strn(mp_prop.via.str.data, mp_prop.via.str.n))
-        {
-            log_critical(
-                    "job `del` property from "TI_THING_ID": "
-                    "thing has no property `%.*s`",
-                    thing->id,
-                    (int) mp_prop.via.str.n, mp_prop.via.str.data);
-        }
-        else
-        {
-            log_critical(
-                    "job `del` property from "TI_THING_ID": "
-                    "invalid name property",
-                    thing->id);
-        }
+    ti_thing_o_del(thing, mp_prop.via.str.data, mp_prop.via.str.n);
 
-        return -1;
-    }
     return 0;
 }
 

--- a/src/ti/job.c
+++ b/src/ti/job.c
@@ -159,7 +159,7 @@ static int job__set(ti_thing_t * thing, mp_unp_t * up)
 
     if (ti_thing_is_object(thing))
     {
-        if (!ti_thing_o_prop_set(thing, name, val))
+        if (!ti_thing_p_prop_set(thing, name, val))
         {
             log_critical(
                     "job `set` to "TI_THING_ID": "

--- a/src/ti/ncache.c
+++ b/src/ti/ncache.c
@@ -72,8 +72,8 @@ int ncache__gen_immutable(
         nd->data = ti_closure_from_node(
                 nd,
                 (syntax->flags & TI_QBIND_FLAG_THINGSDB)
-                            ? TI_VFLAG_CLOSURE_BTSCOPE
-                            : TI_VFLAG_CLOSURE_BCSCOPE);
+                            ? TI_CLOSURE_FLAG_BTSCOPE
+                            : TI_CLOSURE_FLAG_BCSCOPE);
         break;
     case CLERI_GID_T_FLOAT:
         nd->data = ti_vfloat_create(strx_to_double(nd->str, NULL));
@@ -212,8 +212,8 @@ static int ncache__enum(
         nd->data = ti_closure_from_node(
                 nd,
                 (syntax->flags & TI_QBIND_FLAG_THINGSDB)
-                            ? TI_VFLAG_CLOSURE_BTSCOPE
-                            : TI_VFLAG_CLOSURE_BCSCOPE);
+                            ? TI_CLOSURE_FLAG_BTSCOPE
+                            : TI_CLOSURE_FLAG_BCSCOPE);
         if (nd->data)
             VEC_push(vcache, nd->data);
         else
@@ -342,8 +342,8 @@ static int ncache__expr_choice(
         nd->data = ti_closure_from_node(
                 nd,
                 (syntax->flags & TI_QBIND_FLAG_THINGSDB)
-                            ? TI_VFLAG_CLOSURE_BTSCOPE
-                            : TI_VFLAG_CLOSURE_BCSCOPE);
+                            ? TI_CLOSURE_FLAG_BTSCOPE
+                            : TI_CLOSURE_FLAG_BCSCOPE);
         break;
     case CLERI_GID_T_FLOAT:
         nd->data = ti_vfloat_create(strx_to_double(nd->str, NULL));

--- a/src/ti/procedure.c
+++ b/src/ti/procedure.c
@@ -104,7 +104,7 @@ int ti_procedure_info_to_pk(
         )) ||
 
         mp_pack_str(pk, "with_side_effects") ||
-        mp_pack_bool(pk, procedure->closure->flags & TI_VFLAG_CLOSURE_WSE) ||
+        mp_pack_bool(pk, procedure->closure->flags & TI_CLOSURE_FLAG_WSE) ||
 
         mp_pack_str(pk, "arguments") ||
         msgpack_pack_array(pk, procedure->closure->vars->n))

--- a/src/ti/procedures.c
+++ b/src/ti/procedures.c
@@ -12,7 +12,6 @@ int ti_procedures_add(smap_t * procedures, ti_procedure_t * procedure)
 {
     switch(smap_add(procedures, procedure->name, procedure))
     {
-    case SMAP_ERR_EMPTY_KEY:
     case SMAP_ERR_ALLOC:
         return -1;
     case SMAP_ERR_EXIST:

--- a/src/ti/query.c
+++ b/src/ti/query.c
@@ -486,7 +486,7 @@ int ti_query_unp_run(
         return e->nr;
     }
 
-    if (procedure->closure->flags & TI_VFLAG_CLOSURE_WSE)
+    if (procedure->closure->flags & TI_CLOSURE_FLAG_WSE)
     {
         query->qbind.flags |= TI_QBIND_FLAG_EVENT;
         query->flags |= TI_QUERY_FLAG_WSE;
@@ -683,7 +683,7 @@ static void query__then(ti_query_t * query, ex_t * e)
 
     ++ti.futures_count;
 
-    if (future->then->flags & TI_VFLAG_CLOSURE_WSE)
+    if (future->then->flags & TI_CLOSURE_FLAG_WSE)
     {
         query->qbind.flags |= TI_QBIND_FLAG_EVENT;
         query->flags |= TI_QUERY_FLAG_WSE;
@@ -1188,13 +1188,13 @@ static int query__var_walk_thing(ti_thing_t * thing, imap_t * imap)
 
     if (ti_thing_is_object(thing))
     {
-        for (vec_each(thing->items, ti_prop_t, prop))
+        for (vec_each(thing->items.vec, ti_prop_t, prop))
             if (query__get_things(prop->val, imap))
                 return -1;
     }
     else
     {
-        for (vec_each(thing->items, ti_val_t, val))
+        for (vec_each(thing->items.vec, ti_val_t, val))
             if (query__get_things(val, imap))
                 return -1;
     }

--- a/src/ti/raw.c
+++ b/src/ti/raw.c
@@ -12,6 +12,7 @@
 #include <ti/raw.h>
 #include <ti/val.h>
 #include <util/logger.h>
+#include <util/strx.h>
 
 static const int base64__idx[256] = {
         0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0, 0,  0,  0,  0,  0,  0,
@@ -25,6 +26,9 @@ static const int base64__idx[256] = {
 
 static const unsigned char base64__table[65] =
     "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+#define RAW__AS_PRINTABLE_BUF_SZ 48
+static char raw__as_printable_buf[RAW__AS_PRINTABLE_BUF_SZ];
 
 ti_raw_t * ti_raw_create(uint8_t tp, const void * raw, size_t n)
 {
@@ -505,3 +509,25 @@ int ti_raw_err_not_found(ti_raw_t * raw, const char * s, ex_t * e)
     return e->nr;
 }
 
+const char * ti_raw_as_printable_str(ti_raw_t * raw)
+{
+    const size_t m = RAW__AS_PRINTABLE_BUF_SZ-4;
+    size_t n = raw->n <= m ? raw->n : m;
+    char * pt = raw__as_printable_buf;
+
+    if (!strx_is_printablen((const char *) raw->data, n))
+    {
+        strcpy(pt, "<non-printable sting>");
+        return pt;
+    }
+
+    memcpy(pt, raw->data, n);
+    if (raw->n > n)
+    {
+        strcpy(pt + n, "...");
+        return pt;
+    }
+
+    pt[n] = '\0';
+    return pt;
+}

--- a/src/ti/store/storegcollect.c
+++ b/src/ti/store/storegcollect.c
@@ -59,6 +59,17 @@ done:
     return 0;
 }
 
+static int store__walk_i(ti_item_t * item, msgpack_packer * pk)
+{
+    uintptr_t p = (uintptr_t) item->key;
+
+    return -((ti_raw_is_name(item->key)
+        ? msgpack_pack_uint64(pk, p)
+        : mp_pack_strn(pk, item->key->data, item->key->n)) ||
+        ti_val_to_pk(item->val, pk, TI_VAL_PACK_FILE));
+}
+
+
 static int store__walk_data(ti_thing_t * thing, msgpack_packer * pk)
 {
     if (msgpack_pack_uint64(pk, thing->id))
@@ -69,6 +80,13 @@ static int store__walk_data(ti_thing_t * thing, msgpack_packer * pk)
         if (msgpack_pack_map(pk, ti_thing_n(thing)))
             return -1;
 
+        if (ti_thing_is_dict(thing))
+            return smap_values(
+                    thing->items.smap,
+                    (smap_val_cb) store__walk_i,
+                    pk);
+
+
         for (vec_each(thing->items.vec, ti_prop_t, prop))
         {
             uintptr_t p = (uintptr_t) prop->name;
@@ -76,16 +94,16 @@ static int store__walk_data(ti_thing_t * thing, msgpack_packer * pk)
                 ti_val_to_pk(prop->val, pk, TI_VAL_PACK_FILE)
             ) return -1;
         }
+        return 0;
     }
-    else
-    {
-        if (msgpack_pack_array(pk, ti_thing_n(thing)))
+    /* type */
+    if (msgpack_pack_array(pk, ti_thing_n(thing)))
+        return -1;
+
+    for (vec_each(thing->items.vec, ti_val_t, val))
+        if (ti_val_to_pk(val, pk, TI_VAL_PACK_FILE))
             return -1;
 
-        for (vec_each(thing->items.vec, ti_val_t, val))
-            if (ti_val_to_pk(val, pk, TI_VAL_PACK_FILE))
-                return -1;
-    }
     return 0;
 }
 
@@ -202,10 +220,10 @@ int ti_store_gcollect_restore_data(
     ex_t e = {0};
     fx_mmap_t fmap;
     ti_thing_t * thing;
-    ti_name_t * name;
+    ti_raw_t * key;
     ti_type_t * type;
     ti_val_t * val;
-    mp_obj_t obj, mp_ver, mp_thing_id, mp_name_id;
+    mp_obj_t obj, mp_ver, mp_thing_id, mp_key;
     mp_unp_t up;
     size_t i, ii;
     ti_vup_t vup = {
@@ -259,25 +277,34 @@ int ti_store_gcollect_restore_data(
 
             for (ii = obj.via.sz; ii--;)
             {
-                if (mp_next(&up, &mp_name_id) != MP_U64)
+                if (mp_next(&up, &mp_key) <= MP_END)
                     goto fail1;
 
-                name = imap_get(names, mp_name_id.via.u64);
-                if (!name)
+                switch(mp_key.tp)
                 {
-                    log_critical(
-                            "cannot find name with id: %"PRIu64,
-                            mp_name_id.via.u64);
+                case MP_U64:
+                    key = imap_get(names, mp_key.via.u64);
+                    break;
+                case MP_STR:
+                    key = ti_str_create(mp_key.via.str.data, mp_key.via.str.n);
+                    break;
+                default:
+                    goto fail1;
+                }
+
+                if (!key)
+                {
+                    log_critical("failed to load (gc) key");
                     goto fail1;
                 }
 
                 val = ti_val_from_vup(&vup);
 
-                if (!val || ti_val_make_assignable(&val, thing, name, &e) ||
-                    !ti_thing_p_prop_add(thing, name, val))
+                if (!val || ti_val_make_assignable(&val, thing, key, &e) ||
+                    ti_thing_o_add(thing, key, val))
                     goto fail1;
 
-                ti_incref(name);
+                ti_incref(key);
             }
         }
         else

--- a/src/ti/store/storegcollect.c
+++ b/src/ti/store/storegcollect.c
@@ -66,10 +66,10 @@ static int store__walk_data(ti_thing_t * thing, msgpack_packer * pk)
 
     if (ti_thing_is_object(thing))
     {
-        if (msgpack_pack_map(pk, thing->items->n))
+        if (msgpack_pack_map(pk, ti_thing_n(thing)))
             return -1;
 
-        for (vec_each(thing->items, ti_prop_t, prop))
+        for (vec_each(thing->items.vec, ti_prop_t, prop))
         {
             uintptr_t p = (uintptr_t) prop->name;
             if (msgpack_pack_uint64(pk, p) ||
@@ -79,10 +79,10 @@ static int store__walk_data(ti_thing_t * thing, msgpack_packer * pk)
     }
     else
     {
-        if (msgpack_pack_array(pk, thing->items->n))
+        if (msgpack_pack_array(pk, ti_thing_n(thing)))
             return -1;
 
-        for (vec_each(thing->items, ti_val_t, val))
+        for (vec_each(thing->items.vec, ti_val_t, val))
             if (ti_val_to_pk(val, pk, TI_VAL_PACK_FILE))
                 return -1;
     }
@@ -298,7 +298,7 @@ int ti_store_gcollect_restore_data(
                 if (!val ||
                     ti_val_make_assignable(&val, thing, field->name, &e))
                     goto fail1;
-                VEC_push(thing->items, val);
+                VEC_push(thing->items.vec, val);
             }
         }
     }

--- a/src/ti/store/storegcollect.c
+++ b/src/ti/store/storegcollect.c
@@ -274,7 +274,7 @@ int ti_store_gcollect_restore_data(
                 val = ti_val_from_vup(&vup);
 
                 if (!val || ti_val_make_assignable(&val, thing, name, &e) ||
-                    !ti_thing_o_prop_add(thing, name, val))
+                    !ti_thing_p_prop_add(thing, name, val))
                     goto fail1;
 
                 ti_incref(name);

--- a/src/ti/store/storethings.c
+++ b/src/ti/store/storethings.c
@@ -246,7 +246,7 @@ int ti_store_things_restore_data(
                 val = ti_val_from_vup(&vup);
 
                 if (!val || ti_val_make_assignable(&val, thing, name, &e) ||
-                    !ti_thing_o_prop_add(thing, name, val))
+                    !ti_thing_p_prop_add(thing, name, val))
                     goto fail1;
 
                 ti_incref(name);

--- a/src/ti/store/storethings.c
+++ b/src/ti/store/storethings.c
@@ -253,27 +253,28 @@ int ti_store_things_restore_data(
                 {
                 case MP_U64:
                     key = imap_get(names, mp_key.via.u64);
+                    if (!key)
+                    {
+                        log_critical("failed to load key");
+                        goto fail1;
+                    }
+                    ti_incref(key);
                     break;
                 case MP_STR:
                     key = ti_str_create(mp_key.via.str.data, mp_key.via.str.n);
-                    break;
+                    if (key)
+                        break;
+                    /* fall through */
                 default:
                     goto fail1;
                 }
 
-                if (!key)
-                {
-                    log_critical("failed to load key");
-                    goto fail1;
-                }
 
                 val = ti_val_from_vup(&vup);
 
                 if (!val || ti_val_make_assignable(&val, thing, key, &e) ||
                     ti_thing_o_add(thing, key, val))
-                    goto fail1;
-
-                ti_incref(key);
+                    goto fail1;  /* may leak a few bytes for key */
             }
         }
         else

--- a/src/ti/store/storethings.c
+++ b/src/ti/store/storethings.c
@@ -63,10 +63,10 @@ static int store__walk_data(ti_thing_t * thing, msgpack_packer * pk)
 
     if (ti_thing_is_object(thing))
     {
-        if (msgpack_pack_map(pk, thing->items->n))
+        if (msgpack_pack_map(pk, ti_thing_n(thing)))
             return -1;
 
-        for (vec_each(thing->items, ti_prop_t, prop))
+        for (vec_each(thing->items.vec, ti_prop_t, prop))
         {
             uintptr_t p = (uintptr_t) prop->name;
             if (msgpack_pack_uint64(pk, p) ||
@@ -76,10 +76,10 @@ static int store__walk_data(ti_thing_t * thing, msgpack_packer * pk)
     }
     else
     {
-        if (msgpack_pack_array(pk, thing->items->n))
+        if (msgpack_pack_array(pk, ti_thing_n(thing)))
             return -1;
 
-        for (vec_each(thing->items, ti_val_t, val))
+        for (vec_each(thing->items.vec, ti_val_t, val))
             if (ti_val_to_pk(val, pk, TI_VAL_PACK_FILE))
                 return -1;
     }
@@ -270,7 +270,7 @@ int ti_store_things_restore_data(
                 if (!val ||
                     ti_val_make_assignable(&val, thing, field->name, &e))
                     goto fail1;
-                VEC_push(thing->items, val);
+                VEC_push(thing->items.vec, val);
             }
         }
     }

--- a/src/ti/store/storethings.c
+++ b/src/ti/store/storethings.c
@@ -56,6 +56,16 @@ done:
     return 0;
 }
 
+static int store__walk_i(ti_item_t * item, msgpack_packer * pk)
+{
+    uintptr_t p = (uintptr_t) item->key;
+
+    return -((ti_raw_is_name(item->key)
+        ? msgpack_pack_uint64(pk, p)
+        : mp_pack_strn(pk, item->key->data, item->key->n)) ||
+        ti_val_to_pk(item->val, pk, TI_VAL_PACK_FILE));
+}
+
 static int store__walk_data(ti_thing_t * thing, msgpack_packer * pk)
 {
     if (msgpack_pack_uint64(pk, thing->id))
@@ -66,6 +76,12 @@ static int store__walk_data(ti_thing_t * thing, msgpack_packer * pk)
         if (msgpack_pack_map(pk, ti_thing_n(thing)))
             return -1;
 
+        if (ti_thing_is_dict(thing))
+            return smap_values(
+                    thing->items.smap,
+                    (smap_val_cb) store__walk_i,
+                    pk);
+
         for (vec_each(thing->items.vec, ti_prop_t, prop))
         {
             uintptr_t p = (uintptr_t) prop->name;
@@ -73,16 +89,15 @@ static int store__walk_data(ti_thing_t * thing, msgpack_packer * pk)
                 ti_val_to_pk(prop->val, pk, TI_VAL_PACK_FILE)
             ) return -1;
         }
+        return 0;
     }
-    else
-    {
-        if (msgpack_pack_array(pk, ti_thing_n(thing)))
-            return -1;
+    /* type */
+    if (msgpack_pack_array(pk, ti_thing_n(thing)))
+        return -1;
 
-        for (vec_each(thing->items.vec, ti_val_t, val))
-            if (ti_val_to_pk(val, pk, TI_VAL_PACK_FILE))
-                return -1;
-    }
+    for (vec_each(thing->items.vec, ti_val_t, val))
+        if (ti_val_to_pk(val, pk, TI_VAL_PACK_FILE))
+            return -1;
     return 0;
 }
 
@@ -184,10 +199,10 @@ int ti_store_things_restore_data(
     ex_t e = {0};
     fx_mmap_t fmap;
     ti_thing_t * thing;
-    ti_name_t * name;
+    ti_raw_t * key;
     ti_type_t * type;
     ti_val_t * val;
-    mp_obj_t obj, mp_ver, mp_thing_id, mp_name_id;
+    mp_obj_t obj, mp_ver, mp_thing_id, mp_key;
     mp_unp_t up;
     size_t i, ii;
     ti_vup_t vup = {
@@ -231,25 +246,34 @@ int ti_store_things_restore_data(
 
             for (ii = obj.via.sz; ii--;)
             {
-                if (mp_next(&up, &mp_name_id) != MP_U64)
+                if (mp_next(&up, &mp_key) <= MP_END)
                     goto fail1;
 
-                name = imap_get(names, mp_name_id.via.u64);
-                if (!name)
+                switch(mp_key.tp)
                 {
-                    log_critical(
-                            "cannot find name with id: %"PRIu64,
-                            mp_name_id.via.u64);
+                case MP_U64:
+                    key = imap_get(names, mp_key.via.u64);
+                    break;
+                case MP_STR:
+                    key = ti_str_create(mp_key.via.str.data, mp_key.via.str.n);
+                    break;
+                default:
+                    goto fail1;
+                }
+
+                if (!key)
+                {
+                    log_critical("failed to load key");
                     goto fail1;
                 }
 
                 val = ti_val_from_vup(&vup);
 
-                if (!val || ti_val_make_assignable(&val, thing, name, &e) ||
-                    !ti_thing_p_prop_add(thing, name, val))
+                if (!val || ti_val_make_assignable(&val, thing, key, &e) ||
+                    ti_thing_o_add(thing, key, val))
                     goto fail1;
 
-                ti_incref(name);
+                ti_incref(key);
             }
         }
         else

--- a/src/ti/task.c
+++ b/src/ti/task.c
@@ -103,10 +103,10 @@ ti_pkg_t * ti_task_pkg_watch(ti_task_t * task)
     return pkg;
 }
 
-int ti_task_add_add(ti_task_t * task, ti_name_t * name, vec_t * added)
+int ti_task_add_add(ti_task_t * task, ti_raw_t * key, vec_t * added)
 {
     assert (added->n);
-    assert (name);
+    assert (key);
     ti_data_t * data;
     msgpack_packer pk;
     msgpack_sbuffer buffer;
@@ -119,7 +119,7 @@ int ti_task_add_add(ti_task_t * task, ti_name_t * name, vec_t * added)
         msgpack_pack_map(&pk, 1)
     ) goto fail_pack;
 
-    if (mp_pack_strn(&pk, name->str, name->n) ||
+    if (mp_pack_strn(&pk, key->data, key->n) ||
         msgpack_pack_array(&pk, added->n)
     ) goto fail_pack;
 
@@ -146,7 +146,7 @@ fail_pack:
     return -1;
 }
 
-int ti_task_add_set(ti_task_t * task, ti_name_t * name, ti_val_t * val)
+int ti_task_add_set(ti_task_t * task, ti_raw_t * key, ti_val_t * val)
 {
     ti_data_t * data;
     msgpack_packer pk;
@@ -163,7 +163,7 @@ int ti_task_add_set(ti_task_t * task, ti_name_t * name, ti_val_t * val)
         msgpack_pack_map(&pk, 1)
     ) goto fail_pack;
 
-    if (mp_pack_strn(&pk, name->str, name->n) ||
+    if (mp_pack_strn(&pk, key->data, key->n) ||
         ti_val_to_pk(val, &pk, TI_VAL_PACK_TASK)
     ) goto fail_pack;
 
@@ -1334,11 +1334,11 @@ fail_data:
     return -1;
 }
 
-int ti_task_add_remove(ti_task_t * task, ti_name_t * name, vec_t * removed)
+int ti_task_add_remove(ti_task_t * task, ti_raw_t * key, vec_t * removed)
 {
     assert (removed->n);
-    assert (name);
-    size_t alloc = 64 + name->n + removed->n * 9;
+    assert (key);
+    size_t alloc = 64 + key->n + removed->n * 9;
     ti_data_t * data;
     msgpack_packer pk;
     msgpack_sbuffer buffer;
@@ -1352,7 +1352,7 @@ int ti_task_add_remove(ti_task_t * task, ti_name_t * name, vec_t * removed)
     mp_pack_str(&pk, "remove");
     msgpack_pack_map(&pk, 1);
 
-    mp_pack_strn(&pk, name->str, name->n);
+    mp_pack_strn(&pk, key->data, key->n);
     msgpack_pack_array(&pk, removed->n);
 
     for (vec_each(removed, ti_thing_t, thing))
@@ -1644,7 +1644,7 @@ fail_data:
 
 int ti_task_add_splice(
         ti_task_t * task,
-        ti_name_t * name,
+        ti_raw_t * key,
         ti_varr_t * varr,
         uint32_t i,  /* start index */
         uint32_t c,  /* number of items to remove */
@@ -1652,9 +1652,9 @@ int ti_task_add_splice(
 {
     assert (!varr || varr->tp == TI_VAL_ARR);
     assert ((n && varr) || !n);
-    assert (name);
+    assert (key);
     ti_val_t * val;
-    size_t alloc = n ? 8192 : (name->n + 64);
+    size_t alloc = n ? 8192 : (key->n + 64);
     ti_data_t * data;
     msgpack_packer pk;
     msgpack_sbuffer buffer;
@@ -1667,7 +1667,7 @@ int ti_task_add_splice(
     mp_pack_str(&pk, "splice");
 
     msgpack_pack_map(&pk, 1);
-    mp_pack_strn(&pk, name->str, name->n);
+    mp_pack_strn(&pk, key->data, key->n);
 
     msgpack_pack_array(&pk, 2 + n);
 

--- a/src/ti/thing.c
+++ b/src/ti/thing.c
@@ -186,7 +186,7 @@ ti_thing_t * ti_thing_i_create(uint64_t id, ti_collection_t * collection)
 
     thing->ref = 1;
     thing->tp = TI_VAL_THING;
-    thing->flags = TI_THING_FLAG_SWEEP|TI_THING_FLAG_ITEMS;
+    thing->flags = TI_THING_FLAG_SWEEP|TI_THING_FLAG_DICT;
     thing->type_id = TI_SPEC_OBJECT;
 
     thing->id = id;
@@ -289,7 +289,7 @@ void ti_thing_destroy(ti_thing_t * thing)
      *
      * In this case the `thing` will be removed while the list stays alive.
      */
-    if (ti_thing_is_object_i(thing))
+    if (ti_thing_is_dict(thing))
         smap_destroy(thing->items.smap, (smap_destroy_cb) thing__item_destroy);
     else
         vec_destroy(thing->items.vec, ti_thing_is_object(thing)
@@ -304,7 +304,7 @@ void ti_thing_clear(ti_thing_t * thing)
 {
     if (ti_thing_is_object(thing))
     {
-        if (ti_thing_is_object_i(thing))
+        if (ti_thing_is_dict(thing))
         {
             smap_clear(thing->items.smap, (smap_destroy_cb) ti_item_destroy);
         }
@@ -337,7 +337,7 @@ int ti_thing_to_items(ti_thing_t * thing)
         if (smap_add(smap, prop->name->str, prop))
             goto fail0;
 
-    thing->flags |= TI_THING_FLAG_ITEMS;
+    thing->flags |= TI_THING_FLAG_DICT;
     free(thing->items.vec);
     thing->items.smap = smap;
     return 0;
@@ -590,7 +590,7 @@ int ti_thing_i_set_val_from_strn(
         return e->nr;
     }
 
-    assert (ti_thing_is_object_i(thing));
+    assert (ti_thing_is_dict(thing));
 
     if (ti_val_make_assignable(val, thing, key, e))
         return e->nr;
@@ -632,7 +632,7 @@ int ti_thing_o_set_val_from_valid_strn(
     if (ti_val_make_assignable(val, thing, name, e))
         return e->nr;
 
-    if (ti_thing_is_object_i(thing)
+    if (ti_thing_is_dict(thing)
             ? thing_i__item_set_e(thing, (ti_raw_t *) name, *val, e)
             : thing_p__prop_set_e(thing, name, *val, e))
     {
@@ -706,7 +706,7 @@ _Bool ti_thing_o_del(ti_thing_t * thing, ti_name_t * name)
 ti_item_t * ti_thing_o_del_e(ti_thing_t * thing, ti_raw_t * rname, ex_t * e)
 {
     assert (ti_thing_is_object(thing));
-    if (ti_thing_is_object_i(thing))
+    if (ti_thing_is_dict(thing))
     {
         ti_item_t * item = smap_popn(
                 thing->items.smap,
@@ -824,7 +824,7 @@ _Bool ti_thing_get_by_raw(ti_witem_t * witem, ti_thing_t * thing, ti_raw_t * r)
 {
     ti_name_t * name;
 
-    if (ti_thing_is_object_i(thing))
+    if (ti_thing_is_dict(thing))
         return thing_i__get_by_key(witem, thing, r);
 
     name = r->tp == TI_VAL_NAME
@@ -843,7 +843,7 @@ int ti_thing_get_by_raw_e(
 {
     ti_name_t * name;
 
-    if (ti_thing_is_object_i(thing))
+    if (ti_thing_is_dict(thing))
     {
         if (!thing_i__get_by_key(witem, thing, r))
             ti_thing_o_set_not_found(thing, r, e);
@@ -1136,7 +1136,7 @@ int ti_thing__to_pk(ti_thing_t * thing, msgpack_packer * pk, int options)
 
     if (ti_thing_is_object(thing))
     {
-        if (ti_thing_is_object_i(thing))
+        if (ti_thing_is_dict(thing))
         {
             thing__pk_cb_t w = {
                     .options = options,

--- a/src/ti/thing.c
+++ b/src/ti/thing.c
@@ -822,7 +822,12 @@ ti_val_t * ti_thing_weak_val_by_name(ti_thing_t * thing, ti_name_t * name)
 
 _Bool ti_thing_get_by_raw(ti_witem_t * witem, ti_thing_t * thing, ti_raw_t * r)
 {
-    ti_name_t * name = r->tp == TI_VAL_NAME
+    ti_name_t * name;
+
+    if (ti_thing_is_object_i(thing))
+        return thing_i__get_by_key(witem, thing, r);
+
+    name = r->tp == TI_VAL_NAME
             ? (ti_name_t *) r
             : ti_names_weak_from_raw(r);
     return name && (ti_thing_is_object(thing)

--- a/src/ti/thing.c
+++ b/src/ti/thing.c
@@ -768,27 +768,35 @@ int ti_thing_t_set_val_from_strn(
     return 0;
 }
 
-/* Returns true if the property is removed, false if not found */
-_Bool ti_thing_o_del(ti_thing_t * thing, ti_name_t * name)
+/* Deletes a property */
+void ti_thing_o_del(ti_thing_t * thing, const char * str, size_t n)
 {
-    assert (ti_thing_is_object(thing));
-
-    uint32_t i = 0;
-    for (vec_each(thing->items.vec, ti_prop_t, prop), ++i)
+    if (ti_thing_is_dict(thing))
     {
-        if (prop->name == name)
+        ti_item_t * item = smap_popn(thing->items.smap, str, n);
+        ti_item_destroy(item);
+    }
+    else
+    {
+        uint32_t idx = 0;
+        ti_name_t * name = ti_names_weak_get_strn(str, n);
+        if (!name)
+            return;
+
+        for (vec_each(thing->items.vec, ti_prop_t, prop), ++idx)
         {
-            ti_prop_destroy(vec_swap_remove(thing->items.vec, i));
-            return true;
+            if (prop->name == name)
+            {
+                ti_prop_destroy(vec_swap_remove(thing->items.vec, idx));
+                return;
+            }
         }
     }
-    return false;
 }
 
 /* Returns the removed property or NULL in case of an error */
 ti_item_t * ti_thing_o_del_e(ti_thing_t * thing, ti_raw_t * rname, ex_t * e)
 {
-    assert (ti_thing_is_object(thing));
     if (ti_thing_is_dict(thing))
     {
         ti_item_t * item = smap_popn(

--- a/src/ti/things.c
+++ b/src/ti/things.c
@@ -184,7 +184,7 @@ ti_thing_t * ti_things_thing_t_from_vup(ti_vup_t * vup, ex_t * e)
             return NULL;
         }
 
-        VEC_push(thing->items, val);
+        VEC_push(thing->items.vec, val);
     }
 
     return thing;

--- a/src/ti/things.c
+++ b/src/ti/things.c
@@ -73,20 +73,6 @@ ti_thing_t * ti_things_thing_o_from_vup(
         return thing;
     }
 
-    if (vup->isclient)
-    {
-        /*
-         * If not unpacking from an event, then new things should be created
-         * without an id.
-         */
-        ex_set(e, EX_LOOKUP_ERROR,
-                "thing "TI_THING_ID" not found; "
-                "if you want to create a new thing then remove the id (`#`) "
-                "and try again",
-                thing_id);
-        return NULL;
-    }
-
     --sz;  /* decrease one to unpack the remaining properties */
 
     thing = ti_things_create_thing_o(thing_id, sz, vup->collection);
@@ -112,12 +98,6 @@ ti_thing_t * ti_things_thing_t_from_vup(ti_vup_t * vup, ex_t * e)
     ti_thing_t * thing;
     ti_type_t * type;
     mp_obj_t obj, mp_thing_id, mp_type_id;
-
-    if (vup->isclient)
-    {
-        ex_set(e, EX_BAD_DATA, "cannot unpack a type from a client request");
-        return NULL;
-    }
 
     if (mp_next(vup->up, &mp_type_id) != MP_U64 ||
         mp_skip(vup->up) != MP_STR ||   /* `#` */

--- a/src/ti/things.c
+++ b/src/ti/things.c
@@ -73,6 +73,20 @@ ti_thing_t * ti_things_thing_o_from_vup(
         return thing;
     }
 
+    if (vup->isclient)
+    {
+        /*
+         * If not unpacking from an event, then new things should be created
+         * without an id.
+         */
+        ex_set(e, EX_LOOKUP_ERROR,
+                "thing "TI_THING_ID" not found; "
+                "if you want to create a new thing then remove the id (`#`) "
+                "and try again",
+                thing_id);
+        return NULL;
+    }
+
     --sz;  /* decrease one to unpack the remaining properties */
 
     thing = ti_things_create_thing_o(thing_id, sz, vup->collection);

--- a/src/ti/types.c
+++ b/src/ti/types.c
@@ -154,14 +154,10 @@ uint16_t ti_types_get_new_id(ti_types_t * types, ti_raw_t * rname, ex_t * e)
 {
     uintptr_t utype;
     void * ptype;
-    char name[TI_NAME_MAX+1];
 
     assert (rname->n <= TI_NAME_MAX);
 
-    memcpy(name, rname->data, rname->n);
-    name[rname->n] = '\0';
-
-    ptype = smap_pop(types->removed, name);
+    ptype = smap_popn(types->removed, (const char *) rname->data, rname->n);
     if (!ptype)
     {
         if (types->next_id == TI_SPEC_ANY)

--- a/src/ti/val.c
+++ b/src/ti/val.c
@@ -96,18 +96,15 @@ static ti_val_t * val__unp_map(ti_vup_t * vup, size_t sz, ex_t * e)
         return NULL;
     }
 
-    /*
-     *  TODO: UTF-8 encoding depends on correct msgpack data, decide if we
-     *  want to keep this check, or rely on correct usage of msgpack.
-     */
-    if (!strx_is_utf8n(mp_key.via.str.data, mp_key.via.str.n))
-    {
-        ex_set(e, EX_VALUE_ERROR, "properties must have valid UTF-8 encoding");
-        return NULL;
-    }
-
     if (!ti_is_reserved_key_strn(mp_key.via.str.data, mp_key.via.str.n))
     {
+        if (!strx_is_utf8n(mp_key.via.str.data, mp_key.via.str.n))
+        {
+            ex_set(e, EX_VALUE_ERROR,
+                    "properties must have valid UTF-8 encoding");
+            return NULL;
+        }
+
         /* restore the unpack pointer to the first property */
         vup->up->pt = restore_point;
         return (ti_val_t *) ti_thing_new_from_vup(vup, sz, e);

--- a/src/ti/val.c
+++ b/src/ti/val.c
@@ -380,7 +380,7 @@ static int val__push(ti_varr_t * varr, ti_val_t * val, ex_t * e)
     {
     case TI_VAL_THING:
     case TI_VAL_WRAP:
-        varr->flags |= TI_VFLAG_ARR_MHT;
+        varr->flags |= TI_VARR_FLAG_MHT;
         break;
     case TI_VAL_NIL:
     case TI_VAL_INT:
@@ -401,8 +401,8 @@ static int val__push(ti_varr_t * varr, ti_val_t * val, ex_t * e)
          * may-have-things flags to the parent.
          */
         ti_varr_t * arr = (ti_varr_t *) val;
-        arr->flags |= TI_VFLAG_ARR_TUPLE;
-        varr->flags |= arr->flags & TI_VFLAG_ARR_MHT;
+        arr->flags |= TI_VARR_FLAG_TUPLE;
+        varr->flags |= arr->flags & TI_VARR_FLAG_MHT;
         break;
     }
     case TI_VAL_SET:
@@ -414,7 +414,7 @@ static int val__push(ti_varr_t * varr, ti_val_t * val, ex_t * e)
         return e->nr;
     case TI_VAL_MEMBER:
         if (ti_val_is_thing(VMEMBER(val)))
-            varr->flags |= TI_VFLAG_ARR_MHT;
+            varr->flags |= TI_VARR_FLAG_MHT;
         break;
     case TI_VAL_FUTURE:
     case TI_VAL_TEMPLATE:
@@ -1355,9 +1355,9 @@ _Bool ti_val_as_bool(ti_val_t * val)
     case TI_VAL_SET:
         return !!VSET(val)->n;
     case TI_VAL_THING:
-        return !!((ti_thing_t *) val)->items->n;
+        return !!ti_thing_n((ti_thing_t *) val);
     case TI_VAL_WRAP:
-        return !!((ti_wrap_t *) val)->thing->items->n;
+        return !!ti_thing_n(((ti_wrap_t *) val)->thing);
     case TI_VAL_CLOSURE:
     case TI_VAL_FUTURE:
         return true;
@@ -1395,9 +1395,9 @@ size_t ti_val_get_len(ti_val_t * val)
     case TI_VAL_REGEX:
         break;
     case TI_VAL_THING:
-        return ((ti_thing_t *) val)->items->n;
+        return ti_thing_n((ti_thing_t *) val);
     case TI_VAL_WRAP:
-        return ((ti_wrap_t *) val)->thing->items->n;
+        return ti_thing_n(((ti_wrap_t *) val)->thing);
     case TI_VAL_ARR:
         return VARR(val)->n;
     case TI_VAL_SET:

--- a/src/ti/varr.c
+++ b/src/ti/varr.c
@@ -16,12 +16,12 @@ static int varr__to_tuple(ti_varr_t ** varr)
 {
     ti_varr_t * tuple = *varr;
 
-    if (tuple->flags & TI_VFLAG_ARR_TUPLE)
+    if (tuple->flags & TI_VARR_FLAG_TUPLE)
         return 0;  /* tuples cannot change so we do not require a copy */
 
     if (tuple->ref == 1)
     {
-        tuple->flags |= TI_VFLAG_ARR_TUPLE;
+        tuple->flags |= TI_VARR_FLAG_TUPLE;
         tuple->parent = NULL;  /* make sure no parent is set */
         return 0;  /* with only one reference we do not require a copy */
     }
@@ -32,7 +32,7 @@ static int varr__to_tuple(ti_varr_t ** varr)
 
     tuple->ref = 1;
     tuple->tp = TI_VAL_ARR;
-    tuple->flags = TI_VFLAG_ARR_TUPLE | ((*varr)->flags & TI_VFLAG_ARR_MHT);
+    tuple->flags = TI_VARR_FLAG_TUPLE | ((*varr)->flags & TI_VARR_FLAG_MHT);
     tuple->spec = (*varr)->spec;  /* no harm to set `spec`, but useless */
     tuple->vec = vec_dup((*varr)->vec);
     /*
@@ -183,7 +183,7 @@ int ti_varr_val_prepare(ti_varr_t * to, void ** v, ex_t * e)
             ex_set_mem(e);
             return e->nr;
         }
-        to->flags |= ((ti_varr_t *) *v)->flags & TI_VFLAG_ARR_MHT;
+        to->flags |= ((ti_varr_t *) *v)->flags & TI_VARR_FLAG_MHT;
         break;
     case TI_VAL_CLOSURE:
         if (ti_closure_unbound((ti_closure_t *) *v, e))
@@ -199,10 +199,10 @@ int ti_varr_val_prepare(ti_varr_t * to, void ** v, ex_t * e)
             ex_set_mem(e);
             return e->nr;
         }
-        to->flags |= ((ti_varr_t *) *v)->flags & TI_VFLAG_ARR_MHT;
+        to->flags |= ((ti_varr_t *) *v)->flags & TI_VARR_FLAG_MHT;
         break;
     case TI_VAL_THING:
-        to->flags |= TI_VFLAG_ARR_MHT;
+        to->flags |= TI_VARR_FLAG_MHT;
         break;
     case TI_VAL_FUTURE:
         ti_val_unsafe_drop(*v);
@@ -234,7 +234,7 @@ int ti_varr_to_list(ti_varr_t ** varr)
     {
         /* This can never happen to a tuple since a tuple is always nested
          * and therefore always has more than one reference; */
-        assert (~list->flags & TI_VFLAG_ARR_TUPLE);
+        assert (~list->flags & TI_VARR_FLAG_TUPLE);
         return 0;
     }
 
@@ -244,7 +244,7 @@ int ti_varr_to_list(ti_varr_t ** varr)
 
     list->ref = 1;
     list->tp = TI_VAL_ARR;
-    list->flags = (*varr)->flags & TI_VFLAG_ARR_MHT;
+    list->flags = (*varr)->flags & TI_VARR_FLAG_MHT;
     list->spec = (*varr)->spec;
     list->vec = vec_dup((*varr)->vec);
     list->parent = NULL;

--- a/src/ti/vset.c
+++ b/src/ti/vset.c
@@ -81,7 +81,7 @@ int ti_vset_to_list(ti_vset_t ** vsetaddr)
 
     list->ref = 1;
     list->tp = TI_VAL_ARR;
-    list->flags = vec->n ? TI_VFLAG_ARR_MHT : 0;
+    list->flags = vec->n ? TI_VARR_FLAG_MHT : 0;
     list->spec = TI_SPEC_ANY;
     list->vec = vec;
     list->parent = NULL;
@@ -112,7 +112,7 @@ int ti_vset_to_tuple(ti_vset_t ** vsetaddr)
 
     tuple->ref = 1;
     tuple->tp = TI_VAL_ARR;
-    tuple->flags = TI_VFLAG_ARR_TUPLE | (vec->n ? TI_VFLAG_ARR_MHT : 0);
+    tuple->flags = TI_VARR_FLAG_TUPLE | (vec->n ? TI_VARR_FLAG_MHT : 0);
     tuple->spec = TI_SPEC_ANY;
     tuple->vec = vec;
 

--- a/src/ti/wrap.c
+++ b/src/ti/wrap.c
@@ -204,7 +204,7 @@ int ti__wrap_field_thing(
             ti_field_t * field;
             ti_prop_t * prop;
         } map_prop_t;
-        size_t n = ti_min(t_type->fields->n, thing->items->n);
+        size_t n = ti_min(t_type->fields->n, ti_thing_n(thing));
         map_prop_t * map_props = malloc(sizeof(map_prop_t) * n);
         map_prop_t * map_set = map_props;
         map_prop_t * map_get = map_props;
@@ -285,7 +285,7 @@ int ti__wrap_field_thing(
                 wrap__field_val(
                         mapping->t_field,
                         &mapping->t_field->spec,
-                        VEC_get(thing->items, mapping->f_field->idx),
+                        VEC_get(thing->items.vec, mapping->f_field->idx),
                         pk,
                         options)
             ) goto fail;

--- a/test/test_smap/test_smap.c
+++ b/test/test_smap/test_smap.c
@@ -116,11 +116,6 @@ int main()
         _assert (smap_get(smap, entries[2]) == entries[2]);
     }
 
-    /* test if empty keys return correct error code */
-    {
-        _assert (smap_add(smap, "", "empty key") == SMAP_ERR_EMPTY_KEY);
-    }
-
     /* test longest key length */
     {
         _assert (smap_longest_key_size(smap) == strlen(entries[7]));


### PR DESCRIPTION
Currently, all properties on a `thing` must follow the name convention of ThingsDB. Although this is fine for types, it prevents ThingsDB from being compatible with for example JSON. It is also not really possible to use a "thing" as dictionary since it would only accept certain keys.

Besides the above, the current implementation of a thing is be storing key/value pairs in a vector. ThingsDB ensures that each key has a valid name convention and exists only once in memory. This makes finding a key/value by key relatively fast since although ThingsDB needs to walk through the vector, the compare takes place by just checking the pointer. 

It is only when a thing contains many key/value pairs, that finding a key takes longer. (the lookup time grows linear).

Instead, we could implement type `smap_t` for storing key/vaule pairs. Where the `key` in this case may also contain a raw key. With this new type there are new clean rules:

```
typedef struct {
  ti_name_t *,   // unique name according the name convention
  ti_val_t *,       // value
} ti_prop_t;
```

and for the `smap_t` implementation:

```
typedef struct {
  ti_raw_t *,   // unique name according the name convention
  ti_val_t *,       // value
} ti_item_t;
```

In the above, it is possible to cast type `ti_name_t` to type `ti_raw_t` and therefore is is also possible to case type `ti_prop_t` to type `ti_item_t`.

ThingsDB does not have a syntax to create arbitrary properties, just by creating a thing, for example:

```
// Only properties according the name convention can be used like this:
thing = {
  name: "x"
}; 
```

There are two ways to assign arbitrary names:

```
thing = {};
thing["by using [ ]."] = 1;
thing.set("by using the '.set' method", 2;
```

Similarly, it is required to use the bracket [ ] notation or the `get` function to read some arbitrary key.

Functions like `each`, `map`, `assign` etc. should all be made compatible with the smap implementation. Also ThingsDB must take care of the `set` event to handle the arbitrary keys correctly.
 
