### PR TITLE
Improve memory usage for the internal imap_t objects

### DIFF
--- a/inc/ti/version.h
+++ b/inc/ti/version.h
@@ -23,7 +23,7 @@
  *  "-alpha-1"
  *  ""
  */
-#define TI_VERSION_PRE_RELEASE "-alpha-3"
+#define TI_VERSION_PRE_RELEASE "-alpha-4"
 
 #define TI_MAINTAINER \
     "Jeroen van der Heijden <jeroen@transceptor.technology>"

--- a/inc/util/imap.h
+++ b/inc/util/imap.h
@@ -57,7 +57,10 @@ int imap_symmdiff_make(imap_t * dest, imap_t * a, imap_t * b);
 
 struct imap_node_s
 {
-    size_t sz;
+    uint32_t sz;
+    uint8_t key;
+    uint8_t pad8;
+    uint16_t pad16;
     void * data;
     imap_node_t * nodes;
 };

--- a/itest/test_types.py
+++ b/itest/test_types.py
@@ -326,22 +326,26 @@ class TestTypes(TestBase):
             ( set([.a]) != set([.b]) )
         '''))
         await client.query(r'''
-            anna = {};
-            cato = {};
-            iris = {};
+            anna = {name: 'anne'};
+            cato = {name: 'cato'};
+            iris = {name: 'iris'};
 
             a = set(cato, iris);
             b = set(cato, anna);
 
-            //assert (a | b == set(anna, cato, iris));    // Union
-            //assert (a & b == set(cato));                // Intersection
-            //assert (a - b == set(iris));                // Difference
-            //assert (a ^ b == set(anna, iris));          // Symmetric difference
+            assert (a | b == set(anna, cato, iris));    // Union
+            assert (a & b == set(cato));                // Intersection
+            assert (a - b == set(iris));                // Difference
+            assert (a ^ b == set(anna, iris));          // Symmetric difference
 
-            assert ((set(cato, iris) | set(cato, anna)) == set(anna, cato, iris));    // Union move
-            //assert (a &= b == set(cato));                // Intersection
-            //assert (a -= b == set(iris));                // Difference
-            //assert (a ^= b == set(anna, iris));          // Symmetric difference
+            assert ((set(cato, iris) | set(cato, anna))
+                        == set(anna, cato, iris));      // Union move
+            assert ((set(cato, iris) & set(cato, anna))
+                        == set(cato));                  // Intersection inplace
+            assert ((set(cato, iris) - set(cato, anna))
+                        == set(iris));                  // Difference inplace
+            assert ((set(cato, iris) ^ set(cato, anna))
+                        == set(anna, iris));            // Symmetric difference
 
 
         ''')

--- a/itest/test_types.py
+++ b/itest/test_types.py
@@ -333,10 +333,17 @@ class TestTypes(TestBase):
             a = set(cato, iris);
             b = set(cato, anna);
 
-            assert (a | b == set(anna, cato, iris));    // Union
-            assert (a & b == set(cato));                // Intersection
-            assert (a - b == set(iris));                // Difference
-            assert (a ^ b == set(anna, iris));          // Symmetric difference
+            //assert (a | b == set(anna, cato, iris));    // Union
+            //assert (a & b == set(cato));                // Intersection
+            //assert (a - b == set(iris));                // Difference
+            //assert (a ^ b == set(anna, iris));          // Symmetric difference
+
+            assert ((set(cato, iris) | set(cato, anna)) == set(anna, cato, iris));    // Union move
+            //assert (a &= b == set(cato));                // Intersection
+            //assert (a -= b == set(iris));                // Difference
+            //assert (a ^= b == set(anna, iris));          // Symmetric difference
+
+
         ''')
 
 


### PR DESCRIPTION
Type `imap_t` is used for the set type in ThingsDB and more. These object are very fast for get functions but may improve on walking over all objects and take relatively much memory since each node is allocated to hold 32 items while only a single item might be used.
 