### PR TITLE
Support computed properties on wrapped type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   - `timer_args`: https://docs.thingsdb.net/v0/timers-api/timer_args/
   - `timer_info`: https://docs.thingsdb.net/v0/timers-api/timer_info/
   - `timers_info`: https://docs.thingsdb.net/v0/timers-api/timers_info/
+* Support computed properties on wrapped type, issue #164.
 
 # v0.10.4
 

--- a/inc/ti/closure.h
+++ b/inc/ti/closure.h
@@ -40,6 +40,11 @@ int ti_closure_call(
         ti_query_t * query,
         vec_t * args,
         ex_t * e);
+int ti_closure_call_one_arg(
+        ti_closure_t * closure,
+        ti_query_t * query,
+        ti_val_t * arg,
+        ex_t * e);
 ti_raw_t * ti_closure_doc(ti_closure_t * closure);
 ti_raw_t * ti_closure_def(ti_closure_t * closure);
 

--- a/inc/ti/enum.h
+++ b/inc/ti/enum.h
@@ -11,6 +11,7 @@
 #include <ti/member.t.h>
 #include <ti/thing.t.h>
 #include <ti/val.t.h>
+#include <ti/vp.t.h>
 #include <ti/vup.t.h>
 
 ti_enum_t * ti_enum_create(
@@ -27,14 +28,14 @@ int ti_enum_add_member(ti_enum_t * enum_, ti_member_t * member, ex_t * e);
 void ti_enum_del_member(ti_enum_t * enum_, ti_member_t * member);
 int ti_enum_init_from_thing(ti_enum_t * enum_, ti_thing_t * thing, ex_t * e);
 int ti_enum_init_from_vup(ti_enum_t * enum_, ti_vup_t * vup, ex_t * e);
-int ti_enum_members_to_pk(ti_enum_t * enum_, msgpack_packer * pk, int options);
+int ti_enum_members_to_pk(ti_enum_t * enum_, ti_vp_t * vp, int options);
 ti_member_t * ti_enum_member_by_val(ti_enum_t * enum_, ti_val_t * val);
 ti_member_t * ti_enum_member_by_val_e(
         ti_enum_t * enum_,
         ti_val_t * val,
         ex_t * e);
 ti_val_t * ti_enum_as_mpval(ti_enum_t * enum_);
-int ti_enum_to_pk(ti_enum_t * enum_, msgpack_packer * pk);
+int ti_enum_to_pk(ti_enum_t * enum_, ti_vp_t * vp);
 
 
 #endif  /* TI_MEMBER_H_ */

--- a/inc/ti/enums.h
+++ b/inc/ti/enums.h
@@ -10,6 +10,7 @@
 #include <ti/enum.t.h>
 #include <ti/enums.t.h>
 #include <ti/varr.t.h>
+#include <ti/vp.t.h>
 #include <util/mpack.h>
 
 ti_enums_t * ti_enums_create(ti_collection_t * collection);
@@ -19,6 +20,6 @@ int ti_enums_rename(ti_enums_t * enums, ti_enum_t * enum_, ti_raw_t * nname);
 void ti_enums_del(ti_enums_t * enums, ti_enum_t * enum_);
 uint16_t ti_enums_get_new_id(ti_enums_t * enums, ex_t * e);
 ti_varr_t * ti_enums_info(ti_enums_t * enums);
-int ti_enums_to_pk(ti_enums_t * enums, msgpack_packer * pk);
+int ti_enums_to_pk(ti_enums_t * enums, ti_vp_t * vp);
 
 #endif /* TI_ENUMS_H_ */

--- a/inc/ti/fn/fnemit.h
+++ b/inc/ti/fn/fnemit.h
@@ -95,7 +95,7 @@ static int do__f_emit(ti_query_t * query, cleri_node_t * nd, ex_t * e)
     if (thing->id)
     {
         ti_task_t * task = ti_task_get_task(query->ev, thing);
-        if (!task || ti_task_add_event(task, revent, vec, deep))
+        if (!task || ti_task_add_event(task, query, revent, vec, deep))
             ex_set_mem(e);
     }
 

--- a/inc/ti/fn/fnnewmodule.h
+++ b/inc/ti/fn/fnnewmodule.h
@@ -53,7 +53,7 @@ static int do__f_new_module(ti_query_t * query, cleri_node_t * nd, ex_t * e)
 
         if (!ti_val_is_nil(query->rval))
         {
-            pkg = ti_module_conf_pkg(query->rval);
+            pkg = ti_module_conf_pkg(query->rval, query);
             if (!pkg)
             {
                 ex_set_mem(e);

--- a/inc/ti/fn/fnsetmoduleconf.h
+++ b/inc/ti/fn/fnsetmoduleconf.h
@@ -35,7 +35,7 @@ static int do__f_set_module_conf(ti_query_t * query, cleri_node_t * nd, ex_t * e
     }
     else
     {
-        pkg = ti_module_conf_pkg(query->rval);
+        pkg = ti_module_conf_pkg(query->rval, query);
         if (!pkg)
         {
             ex_set_mem(e);

--- a/inc/ti/future.inline.h
+++ b/inc/ti/future.inline.h
@@ -7,18 +7,19 @@
 #include <ti/future.t.h>
 #include <ti/val.inline.h>
 #include <ti/closure.inline.h>
+#include <ti/vp.t.h>
 #include <util/mpack.h>
 #include <util/link.h>
 
 static inline int ti_future_to_pk(
         ti_future_t * future,
-        msgpack_packer * pk,
+        ti_vp_t * vp,
         int options)
 {
     assert (options >= 0);
     return future->rval
-            ? ti_val_to_pk(future->rval, pk, options)
-            : msgpack_pack_nil(pk);
+            ? ti_val_to_pk(future->rval, vp, options)
+            : msgpack_pack_nil(&vp->pk);
 }
 
 static inline int ti_future_register(ti_future_t * future)

--- a/inc/ti/member.inline.h
+++ b/inc/ti/member.inline.h
@@ -6,6 +6,7 @@
 
 #include <ti/member.h>
 #include <ti/val.h>
+#include <ti/vp.t.h>
 #include <tiinc.h>
 #include <util/mpack.h>
 
@@ -29,16 +30,16 @@ static inline ti_raw_t * ti_member_enum_get_rname(ti_member_t * member)
 
 static inline int ti_member_to_pk(
         ti_member_t * member,
-        msgpack_packer * pk,
+        ti_vp_t * vp,
         int options)
 {
     return options >= 0
-        ? ti_val_to_pk(member->val, pk, options)
-        : -(msgpack_pack_map(pk, 1) ||
-            mp_pack_strn(pk, TI_KIND_S_MEMBER, 1) ||
-            msgpack_pack_array(pk, 2) ||
-            msgpack_pack_uint16(pk, member->enum_->enum_id) ||
-            msgpack_pack_uint16(pk, member->idx));
+        ? ti_val_to_pk(member->val, vp, options)
+        : -(msgpack_pack_map(&vp->pk, 1) ||
+            mp_pack_strn(&vp->pk, TI_KIND_S_MEMBER, 1) ||
+            msgpack_pack_array(&vp->pk, 2) ||
+            msgpack_pack_uint16(&vp->pk, member->enum_->enum_id) ||
+            msgpack_pack_uint16(&vp->pk, member->idx));
 }
 
 #endif  /* TI_MEMBER_INLINE_H_ */

--- a/inc/ti/module.h
+++ b/inc/ti/module.h
@@ -4,10 +4,11 @@
 #ifndef TI_MODULE_H_
 #define TI_MODULE_H_
 
-#include <ti/pkg.t.h>
-#include <ti/val.t.h>
-#include <ti/scope.t.h>
 #include <ti/module.t.h>
+#include <ti/pkg.t.h>
+#include <ti/query.t.h>
+#include <ti/scope.t.h>
+#include <ti/val.t.h>
 #include <util/mpack.h>
 
 ti_module_t * ti_module_create(
@@ -29,7 +30,7 @@ void ti_module_load(ti_module_t * module);
 void ti_module_restart(ti_module_t * module);
 void ti_module_update_conf(ti_module_t * module);
 const char * ti_module_status_str(ti_module_t * module);
-ti_pkg_t * ti_module_conf_pkg(ti_val_t * val);
+ti_pkg_t * ti_module_conf_pkg(ti_val_t * val, ti_query_t * query);
 void ti_module_on_pkg(ti_module_t * module, ti_pkg_t * pkg);
 int ti_module_info_to_pk(
         ti_module_t * module,

--- a/inc/ti/task.h
+++ b/inc/ti/task.h
@@ -132,6 +132,7 @@ int ti_task_add_mod_enum_ren(ti_task_t * task, ti_member_t * member);
 int ti_task_add_del_enum(ti_task_t * task, ti_enum_t * enum_);
 int ti_task_add_event(
         ti_task_t * task,
+        ti_query_t * query,
         ti_raw_t * revent,
         vec_t * vec,
         int deep);

--- a/inc/ti/thing.h
+++ b/inc/ti/thing.h
@@ -17,6 +17,7 @@
 #include <ti/thing.t.h>
 #include <ti/type.t.h>
 #include <ti/val.t.h>
+#include <ti/vp.t.h>
 #include <ti/vup.t.h>
 #include <ti/watch.t.h>
 #include <ti/wprop.t.h>
@@ -84,8 +85,8 @@ int ti_thing_unwatch_fwd(
         uint16_t pkg_id);
 int ti_thing_watch_init(ti_thing_t * thing, ti_stream_t * stream);
 int ti_thing_unwatch(ti_thing_t * thing, ti_stream_t * stream);
-int ti_thing__to_pk(ti_thing_t * thing, msgpack_packer * pk, int options);
-int ti_thing_t_to_pk(ti_thing_t * thing, msgpack_packer * pk, int options);
+int ti_thing__to_pk(ti_thing_t * thing, ti_vp_t * vp, int options);
+int ti_thing_t_to_pk(ti_thing_t * thing, ti_vp_t * vp, int options);
 ti_val_t * ti_thing_val_by_strn(ti_thing_t * thing, const char * str, size_t n);
 _Bool ti__thing_has_watchers_(ti_thing_t * thing);
 _Bool ti_thing_equals(ti_thing_t * thing, ti_val_t * other, uint8_t deep);

--- a/inc/ti/thing.inline.h
+++ b/inc/ti/thing.inline.h
@@ -11,6 +11,7 @@
 #include <ti/raw.inline.h>
 #include <ti/thing.h>
 #include <ti/thing.t.h>
+#include <ti/vp.t.h>
 #include <ti/witem.t.h>
 #include <util/strx.h>
 #include <doc.h>
@@ -189,7 +190,7 @@ static inline ti_val_t * ti_thing_val_weak_by_name(
 
 static inline int ti_thing_to_pk(
         ti_thing_t * thing,
-        msgpack_packer * pk,
+        ti_vp_t * vp,
         int options)
 {
     if (options == TI_VAL_PACK_TASK)
@@ -198,13 +199,13 @@ static inline int ti_thing_to_pk(
         {
             ti_thing_unmark_new(thing);
             return ti_thing_is_object(thing)
-                    ? ti_thing__to_pk(thing, pk, options)
-                    : ti_thing_t_to_pk(thing, pk, options);
+                    ? ti_thing__to_pk(thing, vp, options)
+                    : ti_thing_t_to_pk(thing, vp, options);
         }
     }
     return options <= 0 || (thing->flags & TI_VFLAG_LOCK)
-            ? ti_thing_id_to_pk(thing, pk)
-            : ti_thing__to_pk(thing, pk, options);
+            ? ti_thing_id_to_pk(thing, &vp->pk)
+            : ti_thing__to_pk(thing, vp, options);
 }
 
 static inline void ti_thing_may_push_gc(ti_thing_t * thing)

--- a/inc/ti/val.h
+++ b/inc/ti/val.h
@@ -7,6 +7,7 @@
 #include <ex.h>
 #include <stdint.h>
 #include <ti/val.t.h>
+#include <ti/vp.t.h>
 #include <ti/vup.t.h>
 #include <util/vec.h>
 
@@ -44,7 +45,7 @@ int ti_val_convert_to_set(ti_val_t ** val, ex_t * e);
 _Bool ti_val_as_bool(ti_val_t * val);
 size_t ti_val_get_len(ti_val_t * val);
 int ti_val_gen_ids(ti_val_t * val);
-int ti_val_to_pk(ti_val_t * val, msgpack_packer * pk, int options);
+int ti_val_to_pk(ti_val_t * val, ti_vp_t * vp, int options);
 void ti_val_may_change_pack_sz(ti_val_t * val, size_t * sz);
 const char * ti_val_str(ti_val_t * val);
 ti_val_t * ti_val_strv(ti_val_t * val);

--- a/inc/ti/version.h
+++ b/inc/ti/version.h
@@ -23,7 +23,7 @@
  *  "-alpha-1"
  *  ""
  */
-#define TI_VERSION_PRE_RELEASE "-alpha-2"
+#define TI_VERSION_PRE_RELEASE "-alpha-3"
 
 #define TI_MAINTAINER \
     "Jeroen van der Heijden <jeroen@transceptor.technology>"

--- a/inc/ti/vp.t.h
+++ b/inc/ti/vp.t.h
@@ -1,0 +1,18 @@
+/*
+ * ti/vp.t.h
+ */
+#ifndef TI_VP_T_H_
+#define TI_VP_T_H_
+
+typedef struct ti_vp_s ti_vp_t;
+
+#include <util/mpack.h>
+#include <ti/query.t.h>
+
+struct ti_vp_s
+{
+    msgpack_packer pk;
+    ti_query_t * query;                 /* may be undefined */
+};
+
+#endif  /* TI_VP_T_H_ */

--- a/inc/ti/vset.h
+++ b/inc/ti/vset.h
@@ -12,12 +12,13 @@ typedef struct ti_vset_s ti_vset_t;
 #include <inttypes.h>
 #include <ti/thing.h>
 #include <ti/val.h>
+#include <ti/vp.t.h>
 #include <util/imap.h>
 #include <util/mpack.h>
 
 ti_vset_t * ti_vset_create(void);
 void ti_vset_destroy(ti_vset_t * vset);
-int ti_vset_to_pk(ti_vset_t * vset, msgpack_packer * pk, int options);
+int ti_vset_to_pk(ti_vset_t * vset, ti_vp_t * vp, int options);
 int ti_vset_to_list(ti_vset_t ** vsetaddr);
 int ti_vset_to_tuple(ti_vset_t ** vsetaddr);
 int ti_vset_to_file(ti_vset_t * vset, FILE * f);

--- a/inc/ti/wrap.h
+++ b/inc/ti/wrap.h
@@ -8,13 +8,14 @@ typedef struct ti_wrap_s  ti_wrap_t;
 
 #include <inttypes.h>
 #include <ti/thing.h>
+#include <ti/vp.t.h>
 #include <util/mpack.h>
 
 ti_wrap_t * ti_wrap_create(ti_thing_t * thing, uint16_t type_id);
 void ti_wrap_destroy(ti_wrap_t * wrap);
 int ti__wrap_field_thing(
         ti_thing_t * thing,
-        msgpack_packer * pk,
+        ti_vp_t * vp,
         uint16_t spec,
         int options);
 

--- a/inc/ti/wrap.inline.h
+++ b/inc/ti/wrap.inline.h
@@ -4,8 +4,9 @@
 #ifndef TI_WRAP_INLINE_H_
 #define TI_WRAP_INLINE_H_
 
-#include <ti/wrap.h>
 #include <ti/thing.inline.h>
+#include <ti/vp.t.h>
+#include <ti/wrap.h>
 #include <util/mpack.h>
 
 /*
@@ -43,24 +44,24 @@ static inline ti_raw_t * ti_wrap_strv(ti_wrap_t * wrap)
 
 static inline int ti_wrap_to_pk(
         ti_wrap_t * wrap,
-        msgpack_packer * pk,
+        ti_vp_t * vp,
         int options)
 {
     return  /* for a client */
             options > 0
-            ? ti__wrap_field_thing(wrap->thing, pk, wrap->type_id, options)
+            ? ti__wrap_field_thing(wrap->thing, vp, wrap->type_id, options)
 
             /* no nesting, just the id */
             : options == 0
-            ? ti_thing_id_to_pk(wrap->thing, pk)
+            ? ti_thing_id_to_pk(wrap->thing, &vp->pk)
 
             /* when packing for an event or store to disk */
             : (
-                    msgpack_pack_map(pk, 1) ||
-                    mp_pack_strn(pk, TI_KIND_S_WRAP, 1) ||
-                    msgpack_pack_array(pk, 2) ||
-                    msgpack_pack_uint16(pk, wrap->type_id) ||
-                    ti_thing_to_pk(wrap->thing, pk, options)
+                    msgpack_pack_map(&vp->pk, 1) ||
+                    mp_pack_strn(&vp->pk, TI_KIND_S_WRAP, 1) ||
+                    msgpack_pack_array(&vp->pk, 2) ||
+                    msgpack_pack_uint16(&vp->pk, wrap->type_id) ||
+                    ti_thing_to_pk(wrap->thing, vp, options)
     );
 }
 

--- a/itest/test_wrap.py
+++ b/itest/test_wrap.py
@@ -195,6 +195,31 @@ class TestWrap(TestBase):
             }]
         })
 
+    async def test_wrap_methods(self, client):
+        await client.query(r'''
+            set_type('Person', {
+                name: 'str',
+                messages: '[str]',
+            });
+            set_type('_Person', {
+                name: 'any',
+                mcount: |p| p.messages.len()
+            }, true);
+        ''')
+
+        res = await client.query(r'''
+            p = Person{
+                name: 'iris',
+                messages: ['hi', 'hello', 'bye']
+            };
+            p.wrap('_Person');
+        ''')
+
+        self.assertEqual(res, {
+            "name": "iris",
+            "mcount": 3
+        })
+
 
 if __name__ == '__main__':
     run_test(TestWrap())

--- a/itest/test_wrap.py
+++ b/itest/test_wrap.py
@@ -201,24 +201,126 @@ class TestWrap(TestBase):
                 name: 'str',
                 messages: '[str]',
             });
-            set_type('_Person', {
+            set_type('_Pmcount', {
                 name: 'any',
                 mcount: |p| p.messages.len()
             }, true);
+            set_type('_Pmul', {
+                name: 'any',
+                mul: |a, b| a * b
+            }, true);
+            set_type('_Pnoargs', {
+                name: 'any',
+                noargs: || "hi!"
+            }, true);
+            set_type('_Pmore', {
+                name: |p| p.name.upper(),
+                other: || {other: 123},
+            }, true);
+            set_type('_Pwse', {
+                wse: || wse(.x = 1234)
+            }, true);
+            set_type('_Pfut', {
+                fut: || future(|| .x = 1234)
+            }, true);
         ''')
 
+        # _Pmcount
         res = await client.query(r'''
             p = Person{
                 name: 'iris',
                 messages: ['hi', 'hello', 'bye']
             };
-            p.wrap('_Person');
+            p.wrap('_Pmcount');
         ''')
 
         self.assertEqual(res, {
             "name": "iris",
             "mcount": 3
         })
+
+        # _Pmul
+        res = await client.query(r'''
+            p = Person{
+                name: 'iris',
+                messages: ['hi', 'hello', 'bye']
+            };
+            p.wrap('_Pmul');
+        ''')
+
+        self.assertEqual(res, {
+            "name": "iris",
+            "mul": {
+                '!': 'type_err()',
+                'error_code': -61,
+                'error_msg': '`*` not supported between `Person` and `nil`'
+            }
+        })
+
+        # _Pnoargs
+        res = await client.query(r'''
+            p = Person{
+                name: 'iris',
+                messages: ['hi', 'hello', 'bye']
+            };
+            p.wrap('_Pnoargs');
+        ''')
+
+        self.assertEqual(res, {
+            "name": "iris",
+            "noargs": "hi!"
+        })
+
+        # _Pmore
+        res = await client.query(r'''
+            p = Person{
+                name: 'iris',
+                messages: ['hi', 'hello', 'bye']
+            };
+            return(p.wrap('_Pmore'), 2);
+        ''')
+
+        self.assertEqual(res, {
+            "name": "IRIS",
+            "other": {'other': 123},
+        })
+
+        # _Pwse
+        res = await client.query(r'''
+            p = Person{
+                name: 'iris',
+                messages: ['hi', 'hello', 'bye']
+            };
+            p.wrap('_Pwse');
+        ''')
+
+        self.assertEqual(res, {
+            "wse": {
+                '!': 'bad_data_err()',
+                'error_code': -53,
+                'error_msg':
+                    'failed to compute property; method has side effects'
+            }
+        })
+
+        # _Pfut
+        res = await client.query(r'''
+            p = Person{
+                name: 'iris',
+                messages: ['hi', 'hello', 'bye']
+            };
+            p.wrap('_Pfut');
+        ''')
+
+        self.assertEqual(res, {
+            "fut": {
+                '!': 'bad_data_err()',
+                'error_code': -53,
+                'error_msg':
+                    'failed to compute property; method contains futures'
+            }
+        })
+
 
 
 if __name__ == '__main__':

--- a/src/ti/closure.c
+++ b/src/ti/closure.c
@@ -516,6 +516,33 @@ int ti_closure_call(
     return e->nr;
 }
 
+int ti_closure_call_one_arg(
+        ti_closure_t * closure,
+        ti_query_t * query,
+        ti_val_t * arg,
+        ex_t * e)
+{
+    assert (closure);
+    assert (closure->vars);
+
+    if (ti_closure_try_wse(closure, query, e) ||
+        ti_closure_inc(closure, query, e))
+        return e->nr;
+
+    if (closure->vars->n)
+    {
+        ti_prop_t * prop = VEC_first(closure->vars);
+        ti_val_unsafe_drop(prop->val);
+        prop->val = arg;
+        ti_incref(arg);
+    }
+
+    (void) ti_closure_do_statement(closure, query, e);
+    ti_closure_dec(closure, query);
+
+    return e->nr;
+}
+
 ti_raw_t * ti_closure_doc(ti_closure_t * closure)
 {
     ti_raw_t * doc = NULL;

--- a/src/ti/enums.c
+++ b/src/ti/enums.c
@@ -122,11 +122,11 @@ ti_varr_t * ti_enums_info(ti_enums_t * enums)
     return varr;
 }
 
-int ti_enums_to_pk(ti_enums_t * enums, msgpack_packer * pk)
+int ti_enums_to_pk(ti_enums_t * enums, ti_vp_t * vp)
 {
     return (
-        msgpack_pack_array(pk, enums->imap->n) ||
-        imap_walk(enums->imap, (imap_cb) ti_enum_to_pk, pk)
+        msgpack_pack_array(&vp->pk, enums->imap->n) ||
+        imap_walk(enums->imap, (imap_cb) ti_enum_to_pk, vp)
     );
 }
 

--- a/src/ti/field.c
+++ b/src/ti/field.c
@@ -155,20 +155,20 @@ static _Bool field__spec_is_ascii(
 static ti_data_t * field___set_job(ti_name_t * name, ti_val_t * val)
 {
     ti_data_t * data;
-    msgpack_packer pk;
+    ti_vp_t vp;
     msgpack_sbuffer buffer;
 
     mp_sbuffer_alloc_init(&buffer, sizeof(ti_data_t), sizeof(ti_data_t));
-    msgpack_packer_init(&pk, &buffer, msgpack_sbuffer_write);
+    msgpack_packer_init(&vp.pk, &buffer, msgpack_sbuffer_write);
 
-    if (msgpack_pack_array(&pk, 1) ||
-        msgpack_pack_map(&pk, 1) ||
-        mp_pack_str(&pk, "set") ||
-        msgpack_pack_map(&pk, 1)
+    if (msgpack_pack_array(&vp.pk, 1) ||
+        msgpack_pack_map(&vp.pk, 1) ||
+        mp_pack_str(&vp.pk, "set") ||
+        msgpack_pack_map(&vp.pk, 1)
     ) goto fail_pack;
 
-    if (mp_pack_strn(&pk, name->str, name->n) ||
-        ti_val_to_pk(val, &pk, 0)
+    if (mp_pack_strn(&vp.pk, name->str, name->n) ||
+        ti_val_to_pk(val, &vp, 0)
     ) goto fail_pack;
 
     data = (ti_data_t *) buffer.data;

--- a/src/ti/query.c
+++ b/src/ti/query.c
@@ -957,10 +957,12 @@ static inline int query__pack_response(
         msgpack_sbuffer * buffer,
         ex_t * e)
 {
-    msgpack_packer pk;
-    msgpack_packer_init(&pk, buffer, msgpack_sbuffer_write);
+    ti_vp_t vp = {
+            .query=query
+    };
+    msgpack_packer_init(&vp.pk, buffer, msgpack_sbuffer_write);
 
-    if (ti_val_to_pk(query->rval, &pk, (int) query->qbind.deep))
+    if (ti_val_to_pk(query->rval, &vp, (int) query->qbind.deep))
     {
         if (buffer->size > ti.cfg->result_size_limit)
             ex_set(e, EX_RESULT_TOO_LARGE,

--- a/src/ti/store/storeenums.c
+++ b/src/ti/store/storeenums.c
@@ -12,25 +12,26 @@
 #include <ti/store/storeenums.h>
 #include <ti/things.h>
 #include <ti/val.inline.h>
+#include <ti/vp.t.h>
 #include <util/fx.h>
 #include <util/mpack.h>
 
-static int mkenum_cb(ti_enum_t * enum_, msgpack_packer * pk)
+static int mkenum_cb(ti_enum_t * enum_, ti_vp_t * vp)
 {
     uintptr_t p;
-    if (msgpack_pack_array(pk, 5) ||
-        msgpack_pack_uint16(pk, enum_->enum_id) ||
-        msgpack_pack_uint64(pk, enum_->created_at) ||
-        msgpack_pack_uint64(pk, enum_->modified_at) ||
-        mp_pack_strn(pk, enum_->rname->data, enum_->rname->n) ||
-        msgpack_pack_map(pk, enum_->members->n)
+    if (msgpack_pack_array(&vp->pk, 5) ||
+        msgpack_pack_uint16(&vp->pk, enum_->enum_id) ||
+        msgpack_pack_uint64(&vp->pk, enum_->created_at) ||
+        msgpack_pack_uint64(&vp->pk, enum_->modified_at) ||
+        mp_pack_strn(&vp->pk, enum_->rname->data, enum_->rname->n) ||
+        msgpack_pack_map(&vp->pk, enum_->members->n)
     ) return -1;
 
     for (vec_each(enum_->members, ti_member_t, member))
     {
         p = (uintptr_t) member->name;
-        if (msgpack_pack_uint64(pk, p) ||
-            ti_val_to_pk(member->val, pk, TI_VAL_PACK_FILE)
+        if (msgpack_pack_uint64(&vp->pk, p) ||
+            ti_val_to_pk(member->val, vp, TI_VAL_PACK_FILE)
         ) return -1;
     }
 
@@ -39,7 +40,7 @@ static int mkenum_cb(ti_enum_t * enum_, msgpack_packer * pk)
 
 int ti_store_enums_store(ti_enums_t * enums, const char * fn)
 {
-    msgpack_packer pk;
+    ti_vp_t vp;
     FILE * f = fopen(fn, "w");
     if (!f)
     {
@@ -47,13 +48,13 @@ int ti_store_enums_store(ti_enums_t * enums, const char * fn)
         return -1;
     }
 
-    msgpack_packer_init(&pk, f, msgpack_fbuffer_write);
+    msgpack_packer_init(&vp.pk, f, msgpack_fbuffer_write);
 
-    if (msgpack_pack_map(&pk, 1) ||
+    if (msgpack_pack_map(&vp.pk, 1) ||
         /* active enums */
-        mp_pack_str(&pk, "enums") ||
-        msgpack_pack_array(&pk, enums->imap->n) ||
-        imap_walk(enums->imap, (imap_cb) mkenum_cb, &pk)
+        mp_pack_str(&vp.pk, "enums") ||
+        msgpack_pack_array(&vp.pk, enums->imap->n) ||
+        imap_walk(enums->imap, (imap_cb) mkenum_cb, &vp)
     ) goto fail;
 
     log_debug("stored enumerators to file: `%s`", fn);

--- a/src/ti/store/storegcollect.c
+++ b/src/ti/store/storegcollect.c
@@ -59,49 +59,49 @@ done:
     return 0;
 }
 
-static int store__walk_i(ti_item_t * item, msgpack_packer * pk)
+static int store__walk_i(ti_item_t * item, ti_vp_t * vp)
 {
     uintptr_t p = (uintptr_t) item->key;
 
     return -((ti_raw_is_name(item->key)
-        ? msgpack_pack_uint64(pk, p)
-        : mp_pack_strn(pk, item->key->data, item->key->n)) ||
-        ti_val_to_pk(item->val, pk, TI_VAL_PACK_FILE));
+        ? msgpack_pack_uint64(&vp->pk, p)
+        : mp_pack_strn(&vp->pk, item->key->data, item->key->n)) ||
+        ti_val_to_pk(item->val, vp, TI_VAL_PACK_FILE));
 }
 
 
-static int store__walk_data(ti_thing_t * thing, msgpack_packer * pk)
+static int store__walk_data(ti_thing_t * thing, ti_vp_t * vp)
 {
-    if (msgpack_pack_uint64(pk, thing->id))
+    if (msgpack_pack_uint64(&vp->pk, thing->id))
         return -1;
 
     if (ti_thing_is_object(thing))
     {
-        if (msgpack_pack_map(pk, ti_thing_n(thing)))
+        if (msgpack_pack_map(&vp->pk, ti_thing_n(thing)))
             return -1;
 
         if (ti_thing_is_dict(thing))
             return smap_values(
                     thing->items.smap,
                     (smap_val_cb) store__walk_i,
-                    pk);
+                    vp);
 
 
         for (vec_each(thing->items.vec, ti_prop_t, prop))
         {
             uintptr_t p = (uintptr_t) prop->name;
-            if (msgpack_pack_uint64(pk, p) ||
-                ti_val_to_pk(prop->val, pk, TI_VAL_PACK_FILE)
+            if (msgpack_pack_uint64(&vp->pk, p) ||
+                ti_val_to_pk(prop->val, vp, TI_VAL_PACK_FILE)
             ) return -1;
         }
         return 0;
     }
     /* type */
-    if (msgpack_pack_array(pk, ti_thing_n(thing)))
+    if (msgpack_pack_array(&vp->pk, ti_thing_n(thing)))
         return -1;
 
     for (vec_each(thing->items.vec, ti_val_t, val))
-        if (ti_val_to_pk(val, pk, TI_VAL_PACK_FILE))
+        if (ti_val_to_pk(val, vp, TI_VAL_PACK_FILE))
             return -1;
 
     return 0;
@@ -109,7 +109,7 @@ static int store__walk_data(ti_thing_t * thing, msgpack_packer * pk)
 
 int ti_store_gcollect_store_data(queue_t * queue, const char * fn)
 {
-    msgpack_packer pk;
+    ti_vp_t vp;
     FILE * f = fopen(fn, "w");
     if (!f)
     {
@@ -117,15 +117,15 @@ int ti_store_gcollect_store_data(queue_t * queue, const char * fn)
         return -1;
     }
 
-    msgpack_packer_init(&pk, f, msgpack_fbuffer_write);
+    msgpack_packer_init(&vp.pk, f, msgpack_fbuffer_write);
 
     if (
-        msgpack_pack_map(&pk, 1) ||
-        mp_pack_str(&pk, "data") ||
-        msgpack_pack_map(&pk, queue->n)
+        msgpack_pack_map(&vp.pk, 1) ||
+        mp_pack_str(&vp.pk, "data") ||
+        msgpack_pack_map(&vp.pk, queue->n)
     ) goto fail;
 
-    if (ti_gc_walk(queue, (queue_cb) store__walk_data, &pk))
+    if (ti_gc_walk(queue, (queue_cb) store__walk_data, &vp))
         goto fail;
 
     log_debug("stored garbage collected data to file: `%s`", fn);

--- a/src/ti/store/storethings.c
+++ b/src/ti/store/storethings.c
@@ -56,54 +56,54 @@ done:
     return 0;
 }
 
-static int store__walk_i(ti_item_t * item, msgpack_packer * pk)
+static int store__walk_i(ti_item_t * item, ti_vp_t * vp)
 {
     uintptr_t p = (uintptr_t) item->key;
 
     return -((ti_raw_is_name(item->key)
-        ? msgpack_pack_uint64(pk, p)
-        : mp_pack_strn(pk, item->key->data, item->key->n)) ||
-        ti_val_to_pk(item->val, pk, TI_VAL_PACK_FILE));
+        ? msgpack_pack_uint64(&vp->pk, p)
+        : mp_pack_strn(&vp->pk, item->key->data, item->key->n)) ||
+        ti_val_to_pk(item->val, vp, TI_VAL_PACK_FILE));
 }
 
-static int store__walk_data(ti_thing_t * thing, msgpack_packer * pk)
+static int store__walk_data(ti_thing_t * thing, ti_vp_t * vp)
 {
-    if (msgpack_pack_uint64(pk, thing->id))
+    if (msgpack_pack_uint64(&vp->pk, thing->id))
         return -1;
 
     if (ti_thing_is_object(thing))
     {
-        if (msgpack_pack_map(pk, ti_thing_n(thing)))
+        if (msgpack_pack_map(&vp->pk, ti_thing_n(thing)))
             return -1;
 
         if (ti_thing_is_dict(thing))
             return smap_values(
                     thing->items.smap,
                     (smap_val_cb) store__walk_i,
-                    pk);
+                    vp);
 
         for (vec_each(thing->items.vec, ti_prop_t, prop))
         {
             uintptr_t p = (uintptr_t) prop->name;
-            if (msgpack_pack_uint64(pk, p) ||
-                ti_val_to_pk(prop->val, pk, TI_VAL_PACK_FILE)
+            if (msgpack_pack_uint64(&vp->pk, p) ||
+                ti_val_to_pk(prop->val, vp, TI_VAL_PACK_FILE)
             ) return -1;
         }
         return 0;
     }
     /* type */
-    if (msgpack_pack_array(pk, ti_thing_n(thing)))
+    if (msgpack_pack_array(&vp->pk, ti_thing_n(thing)))
         return -1;
 
     for (vec_each(thing->items.vec, ti_val_t, val))
-        if (ti_val_to_pk(val, pk, TI_VAL_PACK_FILE))
+        if (ti_val_to_pk(val, vp, TI_VAL_PACK_FILE))
             return -1;
     return 0;
 }
 
 int ti_store_things_store_data(imap_t * things, const char * fn)
 {
-    msgpack_packer pk;
+    ti_vp_t vp;
     FILE * f = fopen(fn, "w");
     if (!f)
     {
@@ -111,15 +111,15 @@ int ti_store_things_store_data(imap_t * things, const char * fn)
         return -1;
     }
 
-    msgpack_packer_init(&pk, f, msgpack_fbuffer_write);
+    msgpack_packer_init(&vp.pk, f, msgpack_fbuffer_write);
 
     if (
-        msgpack_pack_map(&pk, 1) ||
-        mp_pack_str(&pk, "data") ||
-        msgpack_pack_map(&pk, things->n)
+        msgpack_pack_map(&vp.pk, 1) ||
+        mp_pack_str(&vp.pk, "data") ||
+        msgpack_pack_map(&vp.pk, things->n)
     ) goto fail;
 
-    if (imap_walk(things, (imap_cb) store__walk_data, &pk))
+    if (imap_walk(things, (imap_cb) store__walk_data, &vp))
         goto fail;
 
     log_debug("stored things data to file: `%s`", fn);

--- a/src/ti/thing.c
+++ b/src/ti/thing.c
@@ -22,6 +22,7 @@
 #include <ti/types.h>
 #include <ti/val.h>
 #include <ti/val.inline.h>
+#include <ti/vp.t.h>
 #include <ti/watch.h>
 #include <util/logger.h>
 #include <util/mpack.h>
@@ -999,7 +1000,7 @@ int ti_thing_watch_init(ti_thing_t * thing, ti_stream_t * stream)
 {
     ti_pkg_t * pkg;
     vec_t * pkgs_queue;
-    msgpack_packer pk;
+    ti_vp_t vp;
     msgpack_sbuffer buffer;
     ti_collection_t * collection = thing->collection;
     _Bool is_collection = thing == collection->root;
@@ -1010,30 +1011,30 @@ int ti_thing_watch_init(ti_thing_t * thing, ti_stream_t * stream)
     if (mp_sbuffer_alloc_init(&buffer, 8192, sizeof(ti_pkg_t)))
         return -1;
 
-    msgpack_packer_init(&pk, &buffer, msgpack_sbuffer_write);
+    msgpack_packer_init(&vp.pk, &buffer, msgpack_sbuffer_write);
 
-    msgpack_pack_map(&pk, is_collection ? 6 : 3);
+    msgpack_pack_map(&vp.pk, is_collection ? 6 : 3);
 
-    mp_pack_str(&pk, "event");
-    msgpack_pack_uint64(&pk, ti.node->cevid);
+    mp_pack_str(&vp.pk, "event");
+    msgpack_pack_uint64(&vp.pk, ti.node->cevid);
 
-    mp_pack_str(&pk, "thing");
+    mp_pack_str(&vp.pk, "thing");
 
-    if (ti_thing__to_pk(thing, &pk, TI_VAL_PACK_TASK /* options */) ||
-        mp_pack_str(&pk, "collection") ||
-        mp_pack_strn(&pk, collection->name->data, collection->name->n))
+    if (ti_thing__to_pk(thing, &vp, TI_VAL_PACK_TASK /* options */) ||
+        mp_pack_str(&vp.pk, "collection") ||
+        mp_pack_strn(&vp.pk, collection->name->data, collection->name->n))
     {
         msgpack_sbuffer_destroy(&buffer);
         return -1;
     }
 
     if (is_collection && (
-            mp_pack_str(&pk, "enums") ||
-            ti_enums_to_pk(collection->enums, &pk) ||
-            mp_pack_str(&pk, "types") ||
-            ti_types_to_pk(collection->types, &pk) ||
-            mp_pack_str(&pk, "procedures") ||
-            ti_procedures_to_pk(collection->procedures, &pk)))
+            mp_pack_str(&vp.pk, "enums") ||
+            ti_enums_to_pk(collection->enums, &vp) ||
+            mp_pack_str(&vp.pk, "types") ||
+            ti_types_to_pk(collection->types, &vp.pk) ||
+            mp_pack_str(&vp.pk, "procedures") ||
+            ti_procedures_to_pk(collection->procedures, &vp.pk)))
     {
         msgpack_sbuffer_destroy(&buffer);
         return -1;
@@ -1151,18 +1152,18 @@ void ti_thing_t_to_object(ti_thing_t * thing)
 typedef struct
 {
     int options;
-    msgpack_packer * pk;
+    ti_vp_t * vp;
 } thing__pk_cb_t;
 
 static int thing__pk_cb(ti_item_t * item, thing__pk_cb_t * w)
 {
     return (
-        mp_pack_strn(w->pk, item->key->data, item->key->n) ||
-        ti_val_to_pk(item->val, w->pk, w->options)
+        mp_pack_strn(&w->vp->pk, item->key->data, item->key->n) ||
+        ti_val_to_pk(item->val, w->vp, w->options)
     );
 }
 
-int ti_thing__to_pk(ti_thing_t * thing, msgpack_packer * pk, int options)
+int ti_thing__to_pk(ti_thing_t * thing, ti_vp_t * vp, int options)
 {
     assert (options);  /* should be either positive or negative, not 0 */
 
@@ -1173,18 +1174,19 @@ int ti_thing__to_pk(ti_thing_t * thing, msgpack_packer * pk, int options)
          * The correct error is not set here, but instead the size should be
          * checked again to set either a `memory` or `too_much_data` error.
          */
-        if (((msgpack_sbuffer *) pk->data)->size > ti.cfg->result_size_limit)
+        if (((msgpack_sbuffer *) vp->pk.data)->size >
+                    ti.cfg->result_size_limit)
             return -1;
 
         --options;
     }
 
-    if (msgpack_pack_map(pk, (!!thing->id) + ti_thing_n(thing)))
+    if (msgpack_pack_map(&vp->pk, (!!thing->id) + ti_thing_n(thing)))
         return -1;
 
     if (thing->id && (
-            mp_pack_strn(pk, TI_KIND_S_THING, 1) ||
-            msgpack_pack_uint64(pk, thing->id)
+            mp_pack_strn(&vp->pk, TI_KIND_S_THING, 1) ||
+            msgpack_pack_uint64(&vp->pk, thing->id)
     )) return -1;
 
     thing->flags |= TI_VFLAG_LOCK;
@@ -1195,7 +1197,7 @@ int ti_thing__to_pk(ti_thing_t * thing, msgpack_packer * pk, int options)
         {
             thing__pk_cb_t w = {
                     .options = options,
-                    .pk = pk,
+                    .vp = vp,
             };
             if (smap_values(
                     thing->items.smap,
@@ -1207,8 +1209,8 @@ int ti_thing__to_pk(ti_thing_t * thing, msgpack_packer * pk, int options)
         {
             for (vec_each(thing->items.vec, ti_prop_t, prop))
             {
-                if (mp_pack_strn(pk, prop->name->str, prop->name->n) ||
-                    ti_val_to_pk(prop->val, pk, options)
+                if (mp_pack_strn(&vp->pk, prop->name->str, prop->name->n) ||
+                    ti_val_to_pk(prop->val, vp, options)
                 ) goto fail;
             }
         }
@@ -1219,8 +1221,8 @@ int ti_thing__to_pk(ti_thing_t * thing, msgpack_packer * pk, int options)
         ti_val_t * val;
         for (thing_t_each(thing, name, val))
         {
-            if (mp_pack_strn(pk, name->str, name->n) ||
-                ti_val_to_pk(val, pk, options)
+            if (mp_pack_strn(&vp->pk, name->str, name->n) ||
+                ti_val_to_pk(val, vp, options)
             ) goto fail;
         }
     }
@@ -1232,23 +1234,23 @@ fail:
     return -1;
 }
 
-int ti_thing_t_to_pk(ti_thing_t * thing, msgpack_packer * pk, int options)
+int ti_thing_t_to_pk(ti_thing_t * thing, ti_vp_t * vp, int options)
 {
     assert (options < 0);  /* should only be called when options < 0 */
     assert (!ti_thing_is_object(thing));
     assert (thing->id);   /* no need to check, options < 0 must have id */
 
-    if (msgpack_pack_map(pk, 3) ||
-        mp_pack_strn(pk, TI_KIND_S_INSTANCE, 1) ||
-        msgpack_pack_uint16(pk, thing->type_id) ||
-        mp_pack_strn(pk, TI_KIND_S_THING, 1) ||
-        msgpack_pack_uint64(pk, thing->id) ||
-        msgpack_pack_str(pk, 0) ||
-        msgpack_pack_array(pk, ti_thing_n(thing)))
+    if (msgpack_pack_map(&vp->pk, 3) ||
+        mp_pack_strn(&vp->pk, TI_KIND_S_INSTANCE, 1) ||
+        msgpack_pack_uint16(&vp->pk, thing->type_id) ||
+        mp_pack_strn(&vp->pk, TI_KIND_S_THING, 1) ||
+        msgpack_pack_uint64(&vp->pk, thing->id) ||
+        msgpack_pack_str(&vp->pk, 0) ||
+        msgpack_pack_array(&vp->pk, ti_thing_n(thing)))
         return -1;
 
     for (vec_each(thing->items.vec, ti_val_t, val))
-        if (ti_val_to_pk(val, pk, options))
+        if (ti_val_to_pk(val, vp, options))
             return -1;
 
     return 0;

--- a/src/ti/val.c
+++ b/src/ti/val.c
@@ -1526,31 +1526,31 @@ int ti_val_gen_ids(ti_val_t * val)
     return 0;
 }
 
-int ti_val_to_pk(ti_val_t * val, msgpack_packer * pk, int options)
+int ti_val_to_pk(ti_val_t * val, ti_vp_t * vp, int options)
 {
     switch ((ti_val_enum) val->tp)
     {
-    TI_VAL_PACK_CASE_IMMUTABLE(val, pk, options)
+    TI_VAL_PACK_CASE_IMMUTABLE(val, &vp->pk, options)
     case TI_VAL_THING:
-        return ti_thing_to_pk((ti_thing_t *) val, pk, options);
+        return ti_thing_to_pk((ti_thing_t *) val, vp, options);
     case TI_VAL_WRAP:
-        return ti_wrap_to_pk((ti_wrap_t *) val, pk, options);
+        return ti_wrap_to_pk((ti_wrap_t *) val, vp, options);
     case TI_VAL_ARR:
     {
         ti_varr_t * varr = (ti_varr_t *) val;
-        if (msgpack_pack_array(pk, varr->vec->n))
+        if (msgpack_pack_array(&vp->pk, varr->vec->n))
             return -1;
         for (vec_each(varr->vec, ti_val_t, v))
-            if (ti_val_to_pk(v, pk, options))
+            if (ti_val_to_pk(v, vp, options))
                 return -1;
         return 0;
     }
     case TI_VAL_SET:
-        return ti_vset_to_pk((ti_vset_t *) val, pk, options);
+        return ti_vset_to_pk((ti_vset_t *) val, vp, options);
     case TI_VAL_MEMBER:
-        return ti_member_to_pk((ti_member_t *) val, pk, options);
+        return ti_member_to_pk((ti_member_t *) val, vp, options);
     case TI_VAL_FUTURE:
-        return ti_future_to_pk((ti_future_t * ) val, pk, options);
+        return ti_future_to_pk((ti_future_t * ) val, vp, options);
     }
     assert(0);
     return -1;

--- a/src/ti/vset.c
+++ b/src/ti/vset.c
@@ -42,29 +42,29 @@ void ti_vset_destroy(ti_vset_t * vset)
 
 typedef struct
 {
-    msgpack_packer * pk;
+    ti_vp_t * vp;
     int options;
 } vset__walk_to_pk_t;
 
 static inline int vset__walk_to_pk(ti_thing_t * thing, vset__walk_to_pk_t * w)
 {
-    return ti_thing_to_pk(thing, w->pk, w->options);
+    return ti_thing_to_pk(thing, w->vp, w->options);
 }
 
-int ti_vset_to_pk(ti_vset_t * vset, msgpack_packer * pk, int options)
+int ti_vset_to_pk(ti_vset_t * vset, ti_vp_t * vp, int options)
 {
     vset__walk_to_pk_t w = {
-            .pk = pk,
+            .vp = vp,
             .options = options,
     };
     /*
      * Pack as a `map` when options < 0, otherwise pack the set as an array.
      */
     return ((options < 0 && (
-                msgpack_pack_map(pk, 1) ||
-                mp_pack_strn(pk, TI_KIND_S_SET, 1)
+                msgpack_pack_map(&vp->pk, 1) ||
+                mp_pack_strn(&vp->pk, TI_KIND_S_SET, 1)
         )) ||
-        msgpack_pack_array(pk, vset->imap->n)
+        msgpack_pack_array(&vp->pk, vset->imap->n)
     ) ? -1 : imap_walk(vset->imap, (imap_cb) vset__walk_to_pk, &w);
 }
 

--- a/src/ti/wrap.c
+++ b/src/ti/wrap.c
@@ -168,10 +168,12 @@ int ti__wrap_methods_to_pk(
     int rc = 0;
     ex_t e = {0};
     ti_val_t * rval = vp->query->rval;
+    uint8_t deep = vp->query->qbind.deep;
 
     for (vec_each(t_type->methods, ti_method_t, method))
     {
         vp->query->rval = NULL;
+        vp->query->qbind.deep = (uint8_t) options;
 
         if (method->closure->flags & TI_CLOSURE_FLAG_WSE)
         {
@@ -209,7 +211,7 @@ int ti__wrap_methods_to_pk(
                 &vp->pk,
                 method->name->str,
                 method->name->n) ||
-            ti_val_to_pk(vp->query->rval, vp, options);
+            ti_val_to_pk(vp->query->rval, vp, vp->query->qbind.deep);
 
         ti_val_gc_drop(vp->query->rval);
 
@@ -217,6 +219,7 @@ int ti__wrap_methods_to_pk(
             break;
     }
 
+    vp->query->qbind.deep = deep;
     vp->query->rval = rval;
     return rc;
 }


### PR DESCRIPTION
Sometimes you want to wrap a type and compute some additional properties. A good example might be the count for some messages.

For example:

```javascript
set_type('Person', {
    name: 'str',
    messages: '[str]',
});

// Now we want to return a person but only need the number of message,
// not the actual messages...

// Create a `wrap-only` type and specify the name and an additional `mcount` method
set_type('_Pmcount', {
    name: 'any',
    mcount: |p| p.messages.len()
}, true);
```

If we now, with the above in place, create a person and wrap the person with `_Pmcount`:

```javascript
p = Person{
    name: 'iris',
    messages: ['hi', 'hello', 'bye']
};
p.wrap('_Pmcount');
```

We get the following result: 
```json
{
            "name": "iris",
            "mcount": 3
}
```

It is also possible to *overwrite* the same property name, for example:

```javascript
set_type('_Poverwrite', {
    name: |p| p.name.upper(),
    messages: |p| p.messages.len(),
}, true);
```

```javascript
p = Person{
    name: 'iris',
    messages: ['hi', 'hello', 'bye']
};
p.wrap('_Poverwrite');
```

Will give the following result: 
```json
{
            "name": "IRIS",
            "messages": 3
}
```

Computed properties may have their own `depth` which does not affect the other properties

```javascript
set_type('_Pexample', {
    other: || return({a: {b: 5}}, 2)
}, true);