### PR TITLE
Add `extend_unique() function`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # v0.10.13
 
-* Added `regex()` function, issue #189.
+* Added `extend_unique()` function, issue #189.
 
 # v0.10.12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.10.13
+
+* Added `regex()` function, issue #189.
+
 # v0.10.12
 
 * Fixed bug in query-cache when hitting the query-recursion-depth, issue #188.

--- a/inc/doc.h
+++ b/inc/doc.h
@@ -191,6 +191,7 @@
 #define DOC_LIST_EACH               DOC_SEE("data-types/list/each")
 #define DOC_LIST_EVERY              DOC_SEE("data-types/list/every")
 #define DOC_LIST_EXTEND             DOC_SEE("data-types/list/extend")
+#define DOC_LIST_EXTEND_UNIQUE      DOC_SEE("data-types/list/extend_unique")
 #define DOC_LIST_FILTER             DOC_SEE("data-types/list/filter")
 #define DOC_LIST_FIND               DOC_SEE("data-types/list/find")
 #define DOC_LIST_FIND_INDEX         DOC_SEE("data-types/list/find_index")

--- a/inc/ti/fn/fnextendunique.h
+++ b/inc/ti/fn/fnextendunique.h
@@ -1,15 +1,15 @@
 #include <ti/fn/fn.h>
 
-static int do__f_extend(ti_query_t * query, cleri_node_t * nd, ex_t * e)
+static int do__f_extend_unique(ti_query_t * query, cleri_node_t * nd, ex_t * e)
 {
     const int nargs = fn_get_nargs(nd);
-    uint32_t current_n, source_n;
+    uint32_t current_n, n = 0;
     ti_varr_t * varr_dest, * varr_source;
 
     if (!ti_val_is_list(query->rval))
-        return fn_call_try("extend", query, nd, e);
+        return fn_call_try("extend_unique", query, nd, e);
 
-    if (fn_nargs("extend", DOC_LIST_EXTEND, 1, nargs, e) ||
+    if (fn_nargs("extend_unique", DOC_LIST_EXTEND_UNIQUE, 1, nargs, e) ||
         ti_val_try_lock(query->rval, e))
         return e->nr;
 
@@ -24,10 +24,10 @@ static int do__f_extend(ti_query_t * query, cleri_node_t * nd, ex_t * e)
     if (!ti_val_is_array(query->rval))
     {
         ex_set(e, EX_TYPE_ERROR,
-                "function `extend` expects argument 1 to be of "
+                "function `extend_unique` expects argument 1 to be of "
                 "type `"TI_VAL_LIST_S"` or type `"TI_VAL_TUPLE_S"` "
                 "but got type `%s` instead"
-                DOC_LIST_EXTEND,
+                DOC_LIST_EXTEND_UNIQUE,
                 ti_val_str(query->rval));
         goto fail1;
     }
@@ -35,22 +35,22 @@ static int do__f_extend(ti_query_t * query, cleri_node_t * nd, ex_t * e)
     varr_source = (ti_varr_t *) query->rval;
     query->rval = NULL;
 
-    source_n = varr_source->vec->n;
-
-    if (vec_reserve(&varr_dest->vec, source_n))
-        goto alloc_err;
-
     for (vec_each(varr_source->vec, ti_val_t, v))
     {
+        if (ti_varr_has_val(varr_dest, v))
+            continue;
+
         ti_incref(v);
         if (ti_varr_append(varr_dest, (void **) &v, e))
         {
             ti_decref(v);
             goto undo;
         }
+
+        ++n;
     }
 
-    if (varr_dest->parent && varr_dest->parent->id && source_n)
+    if (varr_dest->parent && varr_dest->parent->id && n)
     {
         ti_task_t * task = ti_task_get_task(query->ev, varr_dest->parent);
         if (!task || ti_task_add_splice(
@@ -59,7 +59,7 @@ static int do__f_extend(ti_query_t * query, cleri_node_t * nd, ex_t * e)
                 varr_dest,
                 current_n,
                 0,
-                source_n))
+                n))
             goto alloc_err;  /* we do not need to cleanup task, since the task
                                 is added to `query->ev->tasks` */
     }

--- a/inc/ti/fn/fnhas.h
+++ b/inc/ti/fn/fnhas.h
@@ -66,14 +66,7 @@ static int do__f_has_list(ti_query_t * query, cleri_node_t * nd, ex_t * e)
     if (ti_do_statement(query, nd->children->node, e))
         goto fail1;
 
-    for (vec_each(varr->vec, ti_val_t, v))
-    {
-        if (ti_opr_eq(v, query->rval))
-        {
-            has = true;
-            break;
-        }
-    }
+    has = ti_varr_has_val(varr, query->rval);
 
     ti_val_unsafe_drop(query->rval);
     query->rval = (ti_val_t *) ti_vbool_get(has);

--- a/inc/ti/varr.h
+++ b/inc/ti/varr.h
@@ -6,8 +6,9 @@
 
 #include <ex.h>
 #include <stdint.h>
-#include <ti/varr.t.h>
 #include <ti/thing.h>
+#include <ti/val.t.h>
+#include <ti/varr.t.h>
 #include <util/vec.h>
 
 ti_varr_t * ti_varr_create(size_t sz);
@@ -25,6 +26,7 @@ int ti_varr_dup(ti_varr_t ** varr, uint8_t deep);
 int ti_varr_val_prepare(ti_varr_t * to, void ** v, ex_t * e);
 int ti_varr_set(ti_varr_t * to, void ** v, size_t idx, ex_t * e);
 _Bool ti__varr_eq(ti_varr_t * varra, ti_varr_t * varrb);
+_Bool ti_varr_has_val(ti_varr_t * varr, ti_val_t * val);
 
 static inline _Bool ti_varr_may_have_things(ti_varr_t * varr)
 {
@@ -52,13 +54,16 @@ static inline _Bool ti_varr_eq(ti_varr_t * va, ti_varr_t * vb)
  */
 static inline int ti_varr_append(ti_varr_t * to, void ** v, ex_t * e)
 {
+    if (vec_reserve(&to->vec, 1))
+    {
+        ex_set_mem(e);
+        return e->nr;
+    }
     if (ti_varr_val_prepare(to, v, e))
         return e->nr;
 
-    if (vec_push(&to->vec, *v))
-        ex_set_mem(e);
-
-    return e->nr;
+    VEC_push(to->vec, *v);
+    return 0;
 }
 
 static inline uint16_t ti_varr_unsafe_spec(ti_varr_t * varr)

--- a/inc/ti/version.h
+++ b/inc/ti/version.h
@@ -6,7 +6,7 @@
 
 #define TI_VERSION_MAJOR 0
 #define TI_VERSION_MINOR 10
-#define TI_VERSION_PATCH 12
+#define TI_VERSION_PATCH 13
 
 /* The syntax version is used to test compatibility with functions
  * using the `ti_nodes_check_syntax()` function */
@@ -23,7 +23,7 @@
  *  "-alpha-1"
  *  ""
  */
-#define TI_VERSION_PRE_RELEASE ""
+#define TI_VERSION_PRE_RELEASE "-alpha-0"
 
 #define TI_MAINTAINER \
     "Jeroen van der Heijden <jeroen@transceptor.technology>"

--- a/itest/test_advanced.py
+++ b/itest/test_advanced.py
@@ -79,6 +79,18 @@ class TestAdvanced(TestBase):
                     1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1];
             """)
 
+    async def test_extend_restrict(self, client):
+        res = await client.query(r"""//ti
+            set_type('A', {arr: '[str]'});
+        """)
+        with self.assertRaisesRegex(
+                TypeError,
+                r'type `int` is not allowed in restricted array'):
+            await client.query(r"""//ti
+                a = A{};
+                a.arr.extend(range(3));
+            """)
+
     async def test_closure_scope(self, client):
         res = await client.query(r'''
             a = 1;

--- a/src/ti/qbind.c
+++ b/src/ti/qbind.c
@@ -59,6 +59,7 @@
 #include <ti/fn/fnevery.h>
 #include <ti/fn/fnexport.h>
 #include <ti/fn/fnextend.h>
+#include <ti/fn/fnextendunique.h>
 #include <ti/fn/fnextract.h>
 #include <ti/fn/fnfilter.h>
 #include <ti/fn/fnfind.h>
@@ -240,7 +241,7 @@ static void qbind__statement(ti_qbind_t * qbind, cleri_node_t * nd);
  */
 enum
 {
-    TOTAL_KEYWORDS = 220,
+    TOTAL_KEYWORDS = 221,
     MIN_WORD_LENGTH = 2,
     MAX_WORD_LENGTH = 17,
     MIN_HASH_VALUE = 8,
@@ -264,7 +265,7 @@ static inline unsigned int qbind__hash(
         476, 476, 476, 476, 476, 476, 476, 476, 476, 476,
         476, 476, 476, 476, 476,   1, 476,   5,  36,  41,
          14,   1,  76, 170, 115,   1,   2,  86,   9,  25,
-         18,  33, 126,  57,   2,   1,   7,   9, 197, 106,
+         18,  33, 126, 166,   2,   1,   7,   9, 197, 106,
          36, 130,  17, 476, 476, 476, 476, 476, 476, 476,
         476, 476, 476, 476, 476, 476, 476, 476, 476, 476,
         476, 476, 476, 476, 476, 476, 476, 476, 476, 476,
@@ -466,6 +467,7 @@ qbind__fmap_t qbind__fn_mapping[TOTAL_KEYWORDS] = {
     {.name="every",             .fn=do__f_every,                CHAIN_NE},
     {.name="export",            .fn=do__f_export,               ROOT_NE},
     {.name="extend",            .fn=do__f_extend,               CHAIN_CE_XVAR},
+    {.name="extend_unique",     .fn=do__f_extend_unique,        CHAIN_CE_XVAR},
     {.name="extract",           .fn=do__f_extract,              CHAIN_NE},
     {.name="filter",            .fn=do__f_filter,               CHAIN_NE},
     {.name="find_index",        .fn=do__f_find_index,           CHAIN_NE},

--- a/src/ti/varr.c
+++ b/src/ti/varr.c
@@ -154,6 +154,14 @@ void ti_varr_destroy(ti_varr_t * varr)
     free(varr);
 }
 
+_Bool ti_varr_has_val(ti_varr_t * varr, ti_val_t * val)
+{
+    for (vec_each(varr->vec, ti_val_t, v))
+        if (ti_opr_eq(v, val))
+            return true;
+    return false;
+}
+
 int ti_varr_val_prepare(ti_varr_t * to, void ** v, ex_t * e)
 {
     assert (ti_varr_is_list(to));  /* `to` must be a list */


### PR DESCRIPTION
ThingsDB has the functions `unique()` and `is_unique()`. As addition to these functions the `extend_unique()` function is added to extend an existing `list` with values, only when the values are unique. 

It is not required to have `push_unique()` and `unshift_unique()` since they may be handled by using a call to `has()`. The `extend_unique()` is different since the alternative might be the following code:

```
.my_unique_list.extend(other_list);   // creates a task to extend the list with all values
.my_unique_list = .my_unique_list.unique();  // assign a new list, and again create a task
```

## Function Check List

- [x] Test code
- [x] Documentation
- [x] Code
- [x] Syntax Highlighting
  - [x] VSCode
  - [x] Highlight.js
  - [x] Create issue for ThingsGUI
