### PR TITLE
Add regular expression support to `str.replace(..)` function and fixed regular expression syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Added `extend_unique()` function, issue #189.
 * Lookup procedures by name, issue #192.
+* Fixed bug with regular expression syntax, issue #193.
+* Added regular expression support on `str.replace(..)` function, issue #194.
 
 # v0.10.12
 

--- a/Debug/src/util/subdir.mk
+++ b/Debug/src/util/subdir.mk
@@ -19,6 +19,7 @@ C_SRCS += \
 ../src/util/olist.c \
 ../src/util/omap.c \
 ../src/util/queue.c \
+../src/util/rbuf.c \
 ../src/util/smap.c \
 ../src/util/strx.c \
 ../src/util/syncpart.c \
@@ -41,6 +42,7 @@ OBJS += \
 ./src/util/olist.o \
 ./src/util/omap.o \
 ./src/util/queue.o \
+./src/util/rbuf.o \
 ./src/util/smap.o \
 ./src/util/strx.o \
 ./src/util/syncpart.o \
@@ -63,6 +65,7 @@ C_DEPS += \
 ./src/util/olist.d \
 ./src/util/omap.d \
 ./src/util/queue.d \
+./src/util/rbuf.d \
 ./src/util/smap.d \
 ./src/util/strx.d \
 ./src/util/syncpart.d \

--- a/Release/src/util/subdir.mk
+++ b/Release/src/util/subdir.mk
@@ -19,6 +19,7 @@ C_SRCS += \
 ../src/util/olist.c \
 ../src/util/omap.c \
 ../src/util/queue.c \
+../src/util/rbuf.c \
 ../src/util/smap.c \
 ../src/util/strx.c \
 ../src/util/syncpart.c \
@@ -41,6 +42,7 @@ OBJS += \
 ./src/util/olist.o \
 ./src/util/omap.o \
 ./src/util/queue.o \
+./src/util/rbuf.o \
 ./src/util/smap.o \
 ./src/util/strx.o \
 ./src/util/syncpart.o \
@@ -63,6 +65,7 @@ C_DEPS += \
 ./src/util/olist.d \
 ./src/util/omap.d \
 ./src/util/queue.d \
+./src/util/rbuf.d \
 ./src/util/smap.d \
 ./src/util/strx.d \
 ./src/util/syncpart.d \

--- a/grammar/grammar.py
+++ b/grammar/grammar.py
@@ -71,7 +71,8 @@ class LangDef(Grammar):
     t_int = Regex(
         r'[-+]?((0b[01]+)|(0o[0-8]+)|(0x[0-9a-fA-F]+)|([0-9]+))')
     t_nil = Keyword('nil')
-    t_regex = Regex('/[^/\\\\]+(?:\\\\.[^/\\\\]*)*/[a-z]*')
+    # t_regex = Regex('/[^/]+(?:\\\\.[^/]*)*/[a-z]*')
+    t_regex = Regex(r'/((?:.(?!(?<![\\])/))*.?)/[a-z]*')
     t_string = Choice(r_single_quote, r_double_quote)
     t_true = Keyword('true')
 

--- a/grammar/grammar.py
+++ b/grammar/grammar.py
@@ -71,7 +71,6 @@ class LangDef(Grammar):
     t_int = Regex(
         r'[-+]?((0b[01]+)|(0o[0-8]+)|(0x[0-9a-fA-F]+)|([0-9]+))')
     t_nil = Keyword('nil')
-    # t_regex = Regex('/[^/]+(?:\\\\.[^/]*)*/[a-z]*')
     t_regex = Regex(r'/((?:.(?!(?<![\\])/))*.?)/[a-z]*')
     t_string = Choice(r_single_quote, r_double_quote)
     t_true = Keyword('true')

--- a/inc/langdef/langdef.h
+++ b/inc/langdef/langdef.h
@@ -5,7 +5,7 @@
  * should be used with the libcleri module.
  *
  * Source class: LangDef
- * Created at: 2021-02-01 14:01:23
+ * Created at: 2021-06-12 12:20:53
  */
 #ifndef CLERI_EXPORT_LANGDEF_H_
 #define CLERI_EXPORT_LANGDEF_H_

--- a/inc/ti/closure.h
+++ b/inc/ti/closure.h
@@ -5,6 +5,9 @@
 #ifndef TI_CLOSURE_H_
 #define TI_CLOSURE_H_
 
+#define PCRE2_CODE_UNIT_WIDTH 8
+
+#include <pcre2.h>
 #include <cleri/cleri.h>
 #include <ex.h>
 #include <stdint.h>
@@ -34,6 +37,16 @@ int ti_closure_vars_nameval(
         ti_val_t * val,
         ex_t * e);
 int ti_closure_vars_val_idx(ti_closure_t * closure, ti_val_t * v, int64_t i);
+int ti_closure_vars_replace_str(
+        ti_closure_t * closure,
+        size_t pos,
+        size_t n,
+        ti_raw_t * vstr);
+int ti_closure_vars_replace_regex(
+        ti_closure_t * closure,
+        ti_raw_t * vstr,
+        PCRE2_SIZE * ovector,
+        uint32_t sz);
 int ti_closure_vars_vset(ti_closure_t * closure, ti_thing_t * t);
 int ti_closure_call(
         ti_closure_t * closure,

--- a/inc/ti/fn/fn.h
+++ b/inc/ti/fn/fn.h
@@ -67,8 +67,10 @@
 #include <ti/wrap.h>
 #include <ti/wrap.inline.h>
 #include <tiinc.h>
+#include <util/buf.h>
 #include <util/cryptx.h>
 #include <util/fx.h>
+#include <util/rbuf.h>
 #include <util/strx.h>
 #include <util/util.h>
 #include <uv.h>
@@ -267,6 +269,38 @@ static inline int fn_arg_datetime(
         ex_set(e, EX_TYPE_ERROR,
             "function `%s` expects argument %d to be of "
             "type `"TI_VAL_DATETIME_S"` or `"TI_VAL_TIMEVAL_S"` "
+            "but got type `%s` instead%s",
+            name, argn, ti_val_str(val), doc);
+    return e->nr;
+}
+
+static inline int fn_arg_str_regex(
+        const char * name,
+        const char * doc,
+        int argn,
+        ti_val_t * val,
+        ex_t * e)
+{
+    if (!ti_val_is_str_regex(val))
+        ex_set(e, EX_TYPE_ERROR,
+            "function `%s` expects argument %d to be of "
+            "type `"TI_VAL_STR_S"` or `"TI_VAL_REGEX_S"` "
+            "but got type `%s` instead%s",
+            name, argn, ti_val_str(val), doc);
+    return e->nr;
+}
+
+static inline int fn_arg_str_closure(
+        const char * name,
+        const char * doc,
+        int argn,
+        ti_val_t * val,
+        ex_t * e)
+{
+    if (!ti_val_is_str_closure(val))
+        ex_set(e, EX_TYPE_ERROR,
+            "function `%s` expects argument %d to be of "
+            "type `"TI_VAL_STR_S"` or `"TI_VAL_CLOSURE_S"` "
             "but got type `%s` instead%s",
             name, argn, ti_val_str(val), doc);
     return e->nr;

--- a/inc/ti/fn/fnreplace.h
+++ b/inc/ti/fn/fnreplace.h
@@ -130,7 +130,7 @@ ti_raw_t * replacescr(
             }
 
             if (ti_closure_do_statement(closure, query, e))
-                goto fail1;  /* TODO: add test */
+                goto fail1;
 
             if (!ti_val_is_str(query->rval))
             {
@@ -139,7 +139,7 @@ ti_raw_t * replacescr(
                         "type `"TI_VAL_STR_S"` but got type `%s` instead"
                         DOC_STR_REPLACE,
                         ti_val_str(query->rval));
-                goto fail1; /* TODO: add test */
+                goto fail1;
             }
 
             new = (ti_raw_t *) query->rval;
@@ -222,7 +222,7 @@ int replacescn(
             }
 
             if (ti_closure_do_statement(closure, query, e))
-                goto fail1;  /* TODO: add test */
+                goto fail1;
 
             if (!ti_val_is_str(query->rval))
             {
@@ -231,7 +231,7 @@ int replacescn(
                         "type `"TI_VAL_STR_S"` but got type `%s` instead"
                         DOC_STR_REPLACE,
                         ti_val_str(query->rval));
-                goto fail1; /* TODO: add test */
+                goto fail1;
             }
 
             new = (ti_raw_t *) query->rval;
@@ -366,7 +366,7 @@ int replacercn(
         }
 
         if (ti_closure_do_statement(closure, query, e))
-            goto fail1;  /* TODO: add test */
+            goto fail1;
 
         if (!ti_val_is_str(query->rval))
         {
@@ -375,7 +375,7 @@ int replacercn(
                     "type `"TI_VAL_STR_S"` but got type `%s` instead"
                     DOC_STR_REPLACE,
                     ti_val_str(query->rval));
-            goto fail1; /* TODO: add test */
+            goto fail1;
         }
 
         new = (ti_raw_t *) query->rval;
@@ -421,10 +421,6 @@ static int do__replace_str(ti_query_t * query, cleri_node_t * nd, ex_t * e)
     str = (ti_raw_t *) query->rval;
     query->rval = NULL;
 
-    /*
-     * TODO: It would be a nice feature if the `old` argument could also be
-     *       a regular expression, instead of only a type string.
-     */
     if (ti_do_statement(query, (child = nd->children)->node, e) ||
         fn_arg_str_regex("replace", DOC_STR_REPLACE, 1, query->rval, e))
         goto fail0;

--- a/inc/ti/regex.h
+++ b/inc/ti/regex.h
@@ -6,7 +6,6 @@
 
 #define PCRE2_CODE_UNIT_WIDTH 8
 
-
 typedef struct ti_regex_s ti_regex_t;
 
 #include <pcre2.h>

--- a/inc/ti/val.inline.h
+++ b/inc/ti/val.inline.h
@@ -121,6 +121,20 @@ static inline _Bool ti_val_is_str(ti_val_t * val)
     return val->tp == TI_VAL_STR || val->tp == TI_VAL_NAME;
 }
 
+static inline _Bool ti_val_is_str_regex(ti_val_t * val)
+{
+    return val->tp == TI_VAL_STR ||
+           val->tp == TI_VAL_NAME ||
+           val->tp == TI_VAL_REGEX;
+}
+
+static inline _Bool ti_val_is_str_closure(ti_val_t * val)
+{
+    return val->tp == TI_VAL_STR ||
+           val->tp == TI_VAL_NAME ||
+           val->tp == TI_VAL_CLOSURE;
+}
+
 static inline _Bool ti_val_is_bytes(ti_val_t * val)
 {
     return val->tp == TI_VAL_BYTES;

--- a/inc/ti/version.h
+++ b/inc/ti/version.h
@@ -23,7 +23,7 @@
  *  "-alpha-1"
  *  ""
  */
-#define TI_VERSION_PRE_RELEASE "-alpha-1"
+#define TI_VERSION_PRE_RELEASE "-alpha-2"
 
 #define TI_MAINTAINER \
     "Jeroen van der Heijden <jeroen@transceptor.technology>"

--- a/inc/util/rbuf.h
+++ b/inc/util/rbuf.h
@@ -1,0 +1,25 @@
+/*
+ * util/rbuf.h
+ */
+#ifndef RBUF_H_
+#define RBUF_H_
+
+#include <stddef.h>
+#include <string.h>
+
+typedef struct rbuf_s rbuf_t;
+
+void rbuf_init(rbuf_t * buf);
+int rbuf_append(rbuf_t * buf, const char * s, size_t n);
+int rbuf_write(rbuf_t * buf, const char c);
+
+struct rbuf_s
+{
+    size_t pos;
+    size_t cap;
+    char * data;
+};
+
+#define rbuf_len(__rbuf) ((__rbuf)->cap - (__rbuf)->pos)
+
+#endif  /* RBUF_H_ */

--- a/src/langdef/langdef.c
+++ b/src/langdef/langdef.c
@@ -5,7 +5,7 @@
  * should be used with the libcleri module.
  *
  * Source class: LangDef
- * Created at: 2021-02-01 14:01:23
+ * Created at: 2021-06-12 12:20:53
  */
 
 #include <langdef/langdef.h>
@@ -56,7 +56,7 @@ cleri_grammar_t * compile_langdef(void)
     cleri_t * t_float = cleri_regex(CLERI_GID_T_FLOAT, "^[-+]?((inf|nan)([^0-9A-Za-z_]|$)|[0-9]*\\.[0-9]+(e[+-][0-9]+)?)");
     cleri_t * t_int = cleri_regex(CLERI_GID_T_INT, "^[-+]?((0b[01]+)|(0o[0-8]+)|(0x[0-9a-fA-F]+)|([0-9]+))");
     cleri_t * t_nil = cleri_keyword(CLERI_GID_T_NIL, "nil", CLERI_CASE_SENSITIVE);
-    cleri_t * t_regex = cleri_regex(CLERI_GID_T_REGEX, "^/[^/\\\\]+(?:\\\\.[^/\\\\]*)*/[a-z]*");
+    cleri_t * t_regex = cleri_regex(CLERI_GID_T_REGEX, "^/((?:.(?!(?<![\\\\])/))*.?)/[a-z]*");
     cleri_t * t_string = cleri_choice(
         CLERI_GID_T_STRING,
         CLERI_FIRST_MATCH,

--- a/src/ti/closure.c
+++ b/src/ti/closure.c
@@ -529,6 +529,7 @@ int ti_closure_vars_replace_regex(
         prop = VEC_get(closure->vars, j+3);
         ti_val_unsafe_drop(prop->val);
         prop->val = (ti_val_t *) vstr;
+        ti_incref(vstr);
         /* fall through */
     case 3:
         prop = VEC_get(closure->vars, j+2);

--- a/src/util/rbuf.c
+++ b/src/util/rbuf.c
@@ -1,0 +1,73 @@
+/*
+ * util/rbuf.h
+ */
+#include <util/logger.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdarg.h>
+#include <util/rbuf.h>
+
+void rbuf_init(rbuf_t * buf)
+{
+    buf->pos = 0;
+    buf->cap = 0;
+    buf->data = NULL;
+}
+
+int rbuf_append(rbuf_t * buf, const char * s, size_t n)
+{
+    if (n > buf->pos)
+    {
+        char * tmp;
+        size_t nsize = buf->cap ? buf->cap << 1 : 8192;
+        size_t len = rbuf_len(buf);
+        size_t rsize = len + n;
+
+        while(rsize > nsize)
+            nsize <<= 1;
+
+        tmp = malloc(nsize);
+        if (!tmp)
+            return -1;
+
+        buf->pos = nsize - len;
+        buf->cap = nsize;
+
+        memcpy(tmp + buf->pos, buf->data, len);
+
+        free(buf->data);
+        buf->data = tmp;
+    }
+
+    buf->pos -= n;
+    memcpy(buf->data + buf->pos, s, n);
+
+    return 0;
+}
+
+int rbuf_write(rbuf_t * buf, const char c)
+{
+    if (!buf->pos)
+    {
+        char * tmp;
+        size_t nsize = buf->cap ? buf->cap << 1 : 8192;
+        size_t len = rbuf_len(buf);
+
+        tmp = realloc(buf->data, nsize);
+        if (!tmp)
+            return -1;
+
+        buf->pos = nsize - len;
+        buf->cap = nsize;
+
+        memcpy(tmp + buf->pos, buf->data, len);
+
+        free(buf->data);
+        buf->data = tmp;
+    }
+
+    buf->data[--buf->pos] = c;
+    return 0;
+}
+
+


### PR DESCRIPTION
Added regular expression support to the `str.replace(..)` function including capture groups.

This will support something like:

```
s = 'This is an _example_!!';
s.replace(/_(\w*)_/, |a| `<strong>{a}</strong>`);

// "This is an <strong>example</strong>!!"
```

Arguments to the additional closure:

Argument | Description
----- | -----------
groups `0..X` | The first arguments are all the capture groups. *(Only when `old` is a regular expression)*
full match | After the capture groups, the next argument will be the full match. *(Only when `old` is a regular expression)*
start position | Start position of the match in the original string.
end position | End position of the match in the original string.
original string | The original string. The full match thus is `original[start:end]`.


> **Note:** This pull request also fixes issue #193.

