### PR TITLE
Added regular expression support on `str.split(..)` function

### DIFF
--- a/inc/ti/fn/fnsplit.h
+++ b/inc/ti/fn/fnsplit.h
@@ -137,6 +137,92 @@ fail:
     return NULL;
 }
 
+ti_varr_t * splitrn(ti_raw_t * vstr, ti_regex_t * regex, ti_vint_t * vnum)
+{
+    assert (!vnum || vnum->int_ >= 0);
+
+    int rc;
+    size_t pos = 0, n = vnum ? (size_t) vnum->int_: SIZE_MAX;
+    ti_raw_t * part = NULL;
+    ti_varr_t * varr = ti_varr_create(15);
+    if (!varr)
+        return NULL;
+
+    while (n-- && (rc = pcre2_match(
+            regex->code,
+            (PCRE2_SPTR8) vstr->data,
+            vstr->n,
+            pos,                   /* start looking at this point */
+            0,                     /* OPTIONS */
+            regex->match_data,
+            NULL)) >= 0)
+    {
+        size_t i = 1, j = 0, sz = rc;
+        PCRE2_SIZE * ovector = pcre2_get_ovector_pointer(regex->match_data);
+        PCRE2_SPTR pt = vstr->data + pos;
+        PCRE2_SIZE n =  ovector[0] - pos;
+
+        part = ti_str_create((const char *) pt, n);
+        if (!part || vec_push(&varr->vec, part))
+            goto fail;
+
+        /* First, add the capture groups */
+       for (; i < sz; ++i, ++j)
+       {
+           PCRE2_SPTR pt = vstr->data + ovector[2*i];
+           PCRE2_SIZE n =  ovector[2*i+1] - ovector[2*i];
+
+           part = ti_str_create((const char *) pt, n);
+           if (!part || vec_push(&varr->vec, part))
+               goto fail;
+       }
+
+       if (pos == ovector[1])
+           break;
+       pos = ovector[1];
+    }
+
+    part = ti_str_create((const char *) vstr->data + pos, vstr->n - pos);
+    if (!part || vec_push(&varr->vec, part))
+        goto fail;
+
+    (void) vec_shrink(&varr->vec);
+    return varr;
+
+fail:
+    ti_val_drop((ti_val_t* ) part);
+    ti_varr_destroy(varr);
+    return NULL;
+}
+
+static int do__split_get_int(ti_query_t * query, cleri_node_t * nd, ex_t * e)
+{
+    if (ti_do_statement(query, nd->children->next->next->node, e) ||
+        fn_arg_int("split", DOC_STR_SPLIT, 2, query->rval, e))
+        return e->nr;
+
+    if (((ti_vint_t *) query->rval)->int_ == LLONG_MIN)
+        ex_set(e, EX_OVERFLOW, "integer overflow");
+
+    return e->nr;
+}
+
+static int do__split_get_rint(ti_query_t * query, cleri_node_t * nd, ex_t * e)
+{
+
+    if (ti_do_statement(query, nd->children->next->next->node, e) ||
+        fn_arg_int("split", DOC_STR_SPLIT, 2, query->rval, e))
+        return e->nr;
+
+    if (((ti_vint_t *) query->rval)->int_ < 0)
+        ex_set(e, EX_VALUE_ERROR,
+            "function `split` does not support backward (negative) "
+            "splits when used with a regular expression"
+            DOC_STR_SPLIT);
+
+    return e->nr;
+}
+
 static int do__f_split(ti_query_t * query, cleri_node_t * nd, ex_t * e)
 {
     const int nargs = fn_get_nargs(nd);
@@ -177,57 +263,83 @@ static int do__f_split(ti_query_t * query, cleri_node_t * nd, ex_t * e)
                 "argument is of type `"TI_VAL_INT_S"`"DOC_STR_SPLIT);
             goto fail0;
         }
-        break;
+
+        vnum = (ti_vint_t *) query->rval;
+        if (vnum->int_ == LLONG_MIN)
+        {
+            ex_set(e, EX_OVERFLOW, "integer overflow");
+            goto fail0;
+        }
+
+        varr = (vnum->int_ >= 0)
+            ? splitn(str, NULL, vnum)
+            : splitr(str, NULL, llabs(vnum->int_));
+
+        ti_val_unsafe_drop(query->rval);
+        goto done;
     case TI_VAL_NAME:
     case TI_VAL_STR:
-        if (((ti_raw_t *) query->rval)->n == 0)
-        {
-            ex_set(e, EX_VALUE_ERROR, "empty separator");
-            goto fail;
-        }
-        /* fall through */
-    case TI_VAL_REGEX:
-
         sep = query->rval;
+        if (((ti_raw_t *) sep)->n == 0)
+        {
+            ex_set(e, EX_VALUE_ERROR, "empty separator"DOC_STR_SPLIT);
+            goto fail0;
+        }
         query->rval = NULL;
 
         if (nargs == 2)
         {
-            if (ti_do_statement(query, nd->children->next->next->node, e) ||
-                fn_arg_int("split", DOC_STR_SPLIT, 2, query->rval, e))
-                goto fail;
+            if (do__split_get_int(query, nd, e))
+            {
+                ti_val_unsafe_drop(sep);
+                goto fail0;
+            }
+
+            vnum = (ti_vint_t *) query->rval;
+            varr = (vnum->int_ >= 0)
+                ? splitn(str, (ti_raw_t *) sep, vnum)
+                : splitr(str, (ti_raw_t *) sep, llabs(vnum->int_));
+
+            ti_val_unsafe_drop(sep);
+            ti_val_unsafe_drop(query->rval);
+            goto done;
         }
-        break;
+
+        varr = splitn(str, (ti_raw_t *) sep, NULL);
+        ti_val_unsafe_drop(sep);
+        goto done;
+    case TI_VAL_REGEX:
+        sep = query->rval;
+        query->rval = NULL;
+        if (nargs == 2)
+        {
+            if (do__split_get_rint(query, nd, e))
+            {
+                ti_val_unsafe_drop(sep);
+                goto fail0;
+            }
+
+            vnum = (ti_vint_t *) query->rval;
+            varr = splitrn(str, (ti_regex_t *) sep, vnum);
+
+            ti_val_unsafe_drop(sep);
+            ti_val_unsafe_drop(query->rval);
+            LOGC("HERE4");
+            goto done;
+        }
+
+        varr = splitrn(str, (ti_regex_t *) sep, NULL);
+        ti_val_unsafe_drop(sep);
+        goto done;
     default:
         ex_set(e, EX_TYPE_ERROR,
             "function `split` expects argument 1 to be of "
             "type `"TI_VAL_STR_S"` or type `"TI_VAL_INT_S"` "
             "but got type `%s` instead"DOC_STR_SPLIT,
-            ti_val_str(sep));
-        goto fail;
+            ti_val_str(query->rval));
+        goto fail0;
     }
 
-        vnum = (ti_vint_t *) query->rval;
-        if (vnum)
-        {
-            query->rval = NULL;
-            if (vnum->int_ == LLONG_MIN)
-            {
-                ex_set(e, EX_OVERFLOW, "integer overflow");
-                goto fail;
-            }
-            else if (vnum->int_ < 0 && (sep && ))
-        }
-    }
-
-    varr = (!vnum || vnum->int_ >= 0)
-        ? splitn(str, (ti_raw_t *) sep, vnum)
-        : splitr(str, (ti_raw_t *) sep, llabs(vnum->int_));
-
-
-fail1:
-    ti_val_drop(sep);
-    ti_val_drop((ti_val_t *) vnum);
 done:
     query->rval = (ti_val_t *) varr;
     if (!varr)

--- a/inc/ti/fn/fnsplit.h
+++ b/inc/ti/fn/fnsplit.h
@@ -249,10 +249,6 @@ static int do__f_split(ti_query_t * query, cleri_node_t * nd, ex_t * e)
     if (ti_do_statement(query, nd->children->node, e))
         goto fail0;
 
-    /*
-     * TODO: It would be a nice feature if the `separator` argument could
-     *       also be a regular expression, instead of only type string.
-     */
     switch((ti_val_enum) query->rval->tp)
     {
     case TI_VAL_INT:

--- a/inc/ti/version.h
+++ b/inc/ti/version.h
@@ -23,7 +23,7 @@
  *  "-alpha-1"
  *  ""
  */
-#define TI_VERSION_PRE_RELEASE "-alpha-1"
+#define TI_VERSION_PRE_RELEASE "-alpha-2"
 
 #define TI_MAINTAINER \
     "Jeroen van der Heijden <jeroen@transceptor.technology>"


### PR DESCRIPTION
If separator is a [regular expression](../../regex) with capturing parentheses, then each time separator matches, the results of the capturing parentheses are added into the output list.

Example with capture groups:

```javascript
'Found 143 songs of 3 minutes and 45 seconds.'.split(/\s*(\d+)\s*/);
```

Result: 

```json
[
    "Found",
    "143",
    "songs of",
    "3",
    "minutes and",
    "45",
    "seconds."
]
```
