### PR TITLE
Syntax changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Upgrade to **libcleri v1.0.0**, issue #263.
 * Configurable `deep` value per scope and changed defaults, issue #261.
 * Set time zone per scope instead of collection only, issue #260.
+* Syntax changes, pr #264.
 
 # v1.1.2
 

--- a/grammar/grammar.py
+++ b/grammar/grammar.py
@@ -51,9 +51,6 @@ class LangDef(Grammar):
     x_ternary = Token('?')
     x_thing = Token('{')
 
-    # r_single_quote =
-    # r_double_quote = Regex(r'')
-
     template = Sequence(
         '`',
         Repeat(Choice(

--- a/grammar/grammar.py
+++ b/grammar/grammar.py
@@ -139,6 +139,9 @@ class LangDef(Grammar):
         Optional(chain),
     )
 
+    end_statement = \
+        Regex(r'(;\s*)*((((?s)\/\/.*?(\r?\n|$))|((?s)\/\*.*?\*\/))\s*)*')
+
     # By adding an optional THIS at the end of this sequence, we are able
     # to support a block without explicit ending with `;`. In qbind, we then
     # should add the address of the child to `qbind__statement` which can be
@@ -148,8 +151,9 @@ class LangDef(Grammar):
     block = Sequence(
         x_block,
         comments,
-        List(THIS, delimiter=Sequence(';', comments), mi=1),
-        '}')
+        List(THIS, delimiter=end_statement, mi=1),
+        '}',
+        Optional(THIS))
 
     parenthesis = Sequence(x_parenthesis, THIS, ')')
 
@@ -218,7 +222,7 @@ class LangDef(Grammar):
             expression,
         ),
         operations)
-    statements = List(statement, delimiter=Sequence(';', comments))
+    statements = List(statement, delimiter=end_statement)
 
     START = Sequence(comments, statements)
 

--- a/grammar/grammar.py
+++ b/grammar/grammar.py
@@ -19,7 +19,7 @@ from pyleri import (
 )
 
 # names have a max length of 255 characters
-RE_NAME = r'^[A-Za-z_][0-9A-Za-z_]{0,254}'
+RE_NAME = r'^[A-Za-z_][0-9A-Za-z_]{0,254}(?![0-9A-Za-z_])'
 
 
 class Choice(Choice_):
@@ -51,8 +51,8 @@ class LangDef(Grammar):
     x_ternary = Token('?')
     x_thing = Token('{')
 
-    r_single_quote = Regex(r"(?:'(?:[^']*)')+")
-    r_double_quote = Regex(r'(?:"(?:[^"]*)")+')
+    # r_single_quote =
+    # r_double_quote = Regex(r'')
 
     template = Sequence(
         '`',
@@ -65,12 +65,15 @@ class LangDef(Grammar):
 
     t_false = Keyword('false')
     t_float = Regex(
-        r'[-+]?((inf|nan)([^0-9A-Za-z_]|$)|[0-9]*\.[0-9]+(e[+-][0-9]+)?)')
+        r'[-+]?(inf|nan|[0-9]*\.[0-9]+(e[+-][0-9]+)?)'
+        r'(?![0-9A-Za-z_])')
     t_int = Regex(
-        r'[-+]?((0b[01]+)|(0o[0-8]+)|(0x[0-9a-fA-F]+)|([0-9]+))')
+        r'[-+]?((0b[01]+)|(0o[0-8]+)|(0x[0-9a-fA-F]+)|([0-9]+))'
+        r'(?![0-9A-Za-z_])')
+
     t_nil = Keyword('nil')
     t_regex = Regex(r'/((?:.(?!(?<![\\])/))*.?)/[a-z]*')
-    t_string = Choice(r_single_quote, r_double_quote)
+    t_string = Regex(r"""(((?:'(?:[^']*)')+)|((?:"(?:[^"]*)")+))""")
     t_true = Keyword('true')
 
     # It would be nice if the leri family had support for advanced white space.
@@ -140,20 +143,13 @@ class LangDef(Grammar):
     )
 
     end_statement = \
-        Regex(r'(;\s*)*((((?s)\/\/.*?(\r?\n|$))|((?s)\/\*.*?\*\/))\s*)*')
+        Regex(r'((;|((?s)\/\/.*?(\r?\n|$))|((?s)\/\*.*?\*\/))\s*)*')
 
-    # By adding an optional THIS at the end of this sequence, we are able
-    # to support a block without explicit ending with `;`. In qbind, we then
-    # should add the address of the child to `qbind__statement` which can be
-    # NULL everywhere except for in `ti_qbind_probe` and parsing `BLOCK`
-    # statements. In a block statement, we then should "insert" the THIS part
-    # to the parent.
     block = Sequence(
         x_block,
         comments,
         List(THIS, delimiter=end_statement, mi=1),
-        '}',
-        Optional(THIS))
+        '}')
 
     parenthesis = Sequence(x_parenthesis, THIS, ')')
 
@@ -204,7 +200,6 @@ class LangDef(Grammar):
             var_opt_more,
             thing,
             array,
-            block,
             parenthesis,
         ),
         index,
@@ -220,6 +215,7 @@ class LangDef(Grammar):
             for_statement,
             closure,
             expression,
+            block,
         ),
         operations)
     statements = List(statement, delimiter=end_statement)

--- a/inc/langdef/langdef.h
+++ b/inc/langdef/langdef.h
@@ -5,7 +5,7 @@
  * should be used with the libcleri module.
  *
  * Source class: LangDef
- * Created at: 2022-01-04 14:10:52
+ * Created at: 2022-01-04 18:35:59
  */
 #ifndef CLERI_EXPORT_LANGDEF_H_
 #define CLERI_EXPORT_LANGDEF_H_
@@ -51,8 +51,6 @@ enum cleri_grammar_ids {
     CLERI_GID_OPR8_TERNARY,
     CLERI_GID_PARENTHESIS,
     CLERI_GID_RETURN_STATEMENT,
-    CLERI_GID_R_DOUBLE_QUOTE,
-    CLERI_GID_R_SINGLE_QUOTE,
     CLERI_GID_SLICE,
     CLERI_GID_START,
     CLERI_GID_STATEMENT,

--- a/inc/langdef/langdef.h
+++ b/inc/langdef/langdef.h
@@ -5,7 +5,7 @@
  * should be used with the libcleri module.
  *
  * Source class: LangDef
- * Created at: 2022-01-02 15:00:42
+ * Created at: 2022-01-04 14:10:52
  */
 #ifndef CLERI_EXPORT_LANGDEF_H_
 #define CLERI_EXPORT_LANGDEF_H_
@@ -22,6 +22,7 @@ enum cleri_grammar_ids {
     CLERI_GID_CHAIN,
     CLERI_GID_CLOSURE,
     CLERI_GID_COMMENTS,
+    CLERI_GID_END_STATEMENT,
     CLERI_GID_ENUM_,
     CLERI_GID_EXPRESSION,
     CLERI_GID_FOR_STATEMENT,

--- a/inc/ti/closure.h
+++ b/inc/ti/closure.h
@@ -29,7 +29,6 @@ void ti_closure_destroy(ti_closure_t * closure);
 int ti_closure_unbound(ti_closure_t * closure, ex_t * e);
 int ti_closure_to_client_pk(ti_closure_t * closure, msgpack_packer * pk);
 int ti_closure_to_store_pk(ti_closure_t * closure, msgpack_packer * pk);
-char * ti_closure_char(ti_closure_t * closure, size_t * n);
 int ti_closure_inc(ti_closure_t * closure, ti_query_t * query, ex_t * e);
 void ti_closure_dec(ti_closure_t * closure, ti_query_t * query);
 int ti_closure_vars_nameval(

--- a/inc/ti/do.h
+++ b/inc/ti/do.h
@@ -23,6 +23,7 @@ int ti_do_for_loop(ti_query_t * query, cleri_node_t * nd, ex_t * e);
 int ti_do_continue(ti_query_t * query, cleri_node_t * nd, ex_t * e);
 int ti_do_break(ti_query_t * query, cleri_node_t * nd, ex_t * e);
 int ti_do_closure(ti_query_t * query, cleri_node_t * nd, ex_t * e);
+int ti_do_block(ti_query_t * query, cleri_node_t * nd, ex_t * e);
 int ti_do_prepare_for_loop(ti_query_t * query, cleri_node_t * vars_nd);
 int ti_do_init(void);
 void ti_do_drop(void);

--- a/inc/ti/qbind.t.h
+++ b/inc/ti/qbind.t.h
@@ -8,7 +8,7 @@ typedef enum
 {
     /* Flag THINGSDB and COLLECTION are exclusive, only one may be set.
      * The order is important since the order is used in function binding */
-    TI_QBIND_BIT_ILL_BLOCK,
+    TI_QBIND_BIT_UNUSED,
 
     TI_QBIND_BIT_THINGSDB=1,      /* must be one (see qbind, FN__FLAG_EV_T) */
     TI_QBIND_BIT_COLLECTION=2,    /* must be two (see qbind, FN__FLAG_EV_C) */
@@ -24,7 +24,7 @@ typedef enum
 typedef enum
 {
     /* first three flags are exclusive, only one may be set */
-    TI_QBIND_FLAG_ILL_BLOCK     =1<<TI_QBIND_BIT_ILL_BLOCK,
+    TI_QBIND_FLAG_UNUSED        =1<<TI_QBIND_BIT_UNUSED,
 
     TI_QBIND_FLAG_THINGSDB      =1<<TI_QBIND_BIT_THINGSDB,
     TI_QBIND_FLAG_COLLECTION    =1<<TI_QBIND_BIT_COLLECTION,

--- a/inc/ti/version.h
+++ b/inc/ti/version.h
@@ -25,7 +25,7 @@
  *  "-rc0"
  *  ""
  */
-#define TI_VERSION_PRE_RELEASE "-alpha7"
+#define TI_VERSION_PRE_RELEASE "-alpha8"
 
 #define TI_MAINTAINER \
     "Jeroen van der Heijden <jeroen@cesbit.com>"

--- a/itest/test_advanced.py
+++ b/itest/test_advanced.py
@@ -1019,11 +1019,11 @@ class TestAdvanced(TestBase):
         '''), 5)
 
         self.assertIs(await client.query(r'''
-            !!{
+            !!({
                 x = [{}];
                 bool(x[0].x = x[0]);
                 x.pop()
-            };
+            });
         '''), True)
 
         self.assertIs(await client.query(r'''

--- a/itest/test_advanced.py
+++ b/itest/test_advanced.py
@@ -1035,11 +1035,11 @@ class TestAdvanced(TestBase):
         '''), True)
 
         self.assertIs(await client.query(r'''
-            {
+            ({
                 x = [{}];
                 bool(x[0].x = x[0]);
                 x.pop()
-            }.id();
+            }).id();
         '''), None)
 
         self.assertEqual(await client.query(r'''
@@ -1057,7 +1057,7 @@ class TestAdvanced(TestBase):
             x = {};
             x.  y = {};
             x.y.y = x.y;
-            {x.del('y')}.id();
+            {x.del('y')}
             5;
         '''), 5)
 

--- a/itest/test_collection_functions.py
+++ b/itest/test_collection_functions.py
@@ -922,12 +922,6 @@ class TestCollectionFunctions(TestBase):
 
         self.assertEqual(await client.query('(||{"test!"}).doc();'), 'test!')
         self.assertEqual(await client.query('(||nil).doc();'), '')
-        self.assertEqual(await client.query(r'''
-            (||wse(return({
-                "Test!";
-                nil;
-            }, 2))).doc();
-        '''), 'Test!')
 
     async def test_ends_with(self, client):
         with self.assertRaisesRegex(

--- a/itest/test_enum.py
+++ b/itest/test_enum.py
@@ -643,6 +643,16 @@ class TestEnum(TestBase):
             await client.query('Color{"RED"};')
 
         with self.assertRaisesRegex(
+                LookupError,
+                r'enum `Unknown` is undefined'):
+            await client.query('Unknown{RED};')
+
+        with self.assertRaisesRegex(
+                LookupError,
+                r'enum `Unknown` is undefined'):
+            await client.query('Unknown{||"RED"};')
+
+        with self.assertRaisesRegex(
                 TypeError,
                 r'enumerator lookup is expecting type `str` but '
                 r'got type `int` instead'):

--- a/itest/test_enum.py
+++ b/itest/test_enum.py
@@ -633,13 +633,13 @@ class TestEnum(TestBase):
             '''), None)
 
         with self.assertRaisesRegex(
-                SyntaxError,
-                r'error at line 1, position 6, unexpected character `1`'):
+                LookupError,
+                r'variable `Color` is undefined'):
             await client.query('Color{1};')
 
         with self.assertRaisesRegex(
-                SyntaxError,
-                r'error at line 1, position 6, unexpected character'):
+                LookupError,
+                r'variable `Color` is undefined'):
             await client.query('Color{"RED"};')
 
         with self.assertRaisesRegex(

--- a/itest/test_procedures.py
+++ b/itest/test_procedures.py
@@ -58,7 +58,7 @@ class TestProcedures(TestBase):
             'iris',
             scope='@thingsdb')
 
-        await client0.query(r'''
+        await client0.query(r"""//ti
             // First set properties which we can later verify
             .r = 'Test Raw String';
             .t = {test: 'Thing', nested: {found: true}};
@@ -73,11 +73,13 @@ class TestProcedures(TestBase):
             .upd_list = |i| .l = .l.map(|x| (x + i));
 
             // Create a procedure which calls a closure
-            new_procedure('upd_list', |i| wse({
+            new_procedure('upd_list', |i| {
                 "Add a given value `i` to all values in `.l`";
-                .upd_list.call(i);
+                wse({
+                    .upd_list.call(i);
+                });
                 nil;  // Return nil
-            }));
+            });
 
             /*********************************
              * Create some extra procedures. *
@@ -105,7 +107,7 @@ class TestProcedures(TestBase):
                 "Return two levels deep.";
                 return(thing(.t.id()), 2);
             });
-        ''')
+        """)
 
         self.assertEqual(
             await client0.query('procedure_doc("upd_list");'),

--- a/itest/test_syntax.py
+++ b/itest/test_syntax.py
@@ -40,16 +40,12 @@ class TestSyntax(TestBase):
 
         with self.assertRaisesRegex(
                 SyntaxError,
-                r'error at line 1, position 256, '
-                r'unexpected `aaaaaaaaaaaaaaaaaaaa...`, '
-                r'expecting: ; or end_of_statement'):
+                r'error at line 1, position 1, unexpected character `a`'):
             await client.query('.{} = 1'.format('a'*1000))
 
         with self.assertRaisesRegex(
                 SyntaxError,
-                r'error at line 1, position 256, '
-                r'unexpected character `a`, '
-                r'expecting: ; or end_of_statement'):
+                r'error at line 1, position 1, unexpected character `a`'):
             await client.query('.{} = 1'.format('a'*256))
 
         await client.query('thing(.id())[prop] = 1', prop='b'*255)
@@ -66,20 +62,6 @@ class TestSyntax(TestBase):
                 SyntaxError,
                 r'error at line 1, position 17, expecting: :'):
             await client.query('|x| is_err(x)?x+2')
-
-    async def test_other_invalid_syntax(self, client):
-
-        with self.assertRaisesRegex(
-                SyntaxError,
-                r'error at line 1, position 2, unexpected character `1`, '
-                r'expecting: ; or end_of_statemen'):
-            await client.query('1 1;' * 150)
-
-        with self.assertRaisesRegex(
-                SyntaxError,
-                r'error at line 1, position 2, unexpected character `1`, '
-                r'expecting: ; or end_of_statemen'):
-            await client.query('1 1;' * 150)
 
     async def test_weird_closure(self, client):
         with self.assertRaisesRegex(

--- a/itest/test_types.py
+++ b/itest/test_types.py
@@ -228,7 +228,7 @@ class TestTypes(TestBase):
         '''), 4)
 
         self.assertEqual(await client.query(r'''
-            {{}.t = [1, 2, 3]}.push(4);
+            ({{}.t = [1, 2, 3]}).push(4);
         '''), 4)
 
         self.assertEqual(await client.query(r'''
@@ -236,7 +236,7 @@ class TestTypes(TestBase):
         '''), 4)
 
         self.assertEqual(await client.query(r'''
-            {{}['some key'] = [1, 2, 3]}.push(4);
+            ({{}['some key'] = [1, 2, 3]}).push(4);
         '''), 4)
 
         await client.query(r'''
@@ -248,7 +248,7 @@ class TestTypes(TestBase):
         '''), 4)
 
         self.assertEqual(await client.query(r'''
-            {T{}.arr = [1, 2, 3]}.push(4);
+            ({T{}.arr = [1, 2, 3]}).push(4);
         '''), 4)
 
     async def test_closure(self, client):

--- a/src/langdef/langdef.c
+++ b/src/langdef/langdef.c
@@ -5,7 +5,7 @@
  * should be used with the libcleri module.
  *
  * Source class: LangDef
- * Created at: 2022-01-02 15:00:42
+ * Created at: 2022-01-04 14:10:52
  */
 
 #include <langdef/langdef.h>
@@ -204,18 +204,15 @@ cleri_grammar_t * compile_langdef(void)
             CLERI_THIS
         ))
     ), 0, 0);
+    cleri_t * end_statement = cleri_regex(CLERI_GID_END_STATEMENT, "^(;\\s*)*((((?s)\\/\\/.*?(\\r?\\n|$))|((?s)\\/\\*.*?\\*\\/))\\s*)*");
     cleri_t * block = cleri_sequence(
         CLERI_GID_BLOCK,
-        4,
+        5,
         x_block,
         comments,
-        cleri_list(CLERI_NONE, CLERI_THIS, cleri_sequence(
-            CLERI_NONE,
-            2,
-            cleri_token(CLERI_NONE, ";"),
-            comments
-        ), 1, 0, 1),
-        cleri_token(CLERI_NONE, "}")
+        cleri_list(CLERI_NONE, CLERI_THIS, end_statement, 1, 0, 1),
+        cleri_token(CLERI_NONE, "}"),
+        cleri_optional(CLERI_NONE, CLERI_THIS)
     );
     cleri_t * parenthesis = cleri_sequence(
         CLERI_GID_PARENTHESIS,
@@ -312,12 +309,7 @@ cleri_grammar_t * compile_langdef(void)
         ),
         operations
     );
-    cleri_t * statements = cleri_list(CLERI_GID_STATEMENTS, statement, cleri_sequence(
-        CLERI_NONE,
-        2,
-        cleri_token(CLERI_NONE, ";"),
-        comments
-    ), 0, 0, 1);
+    cleri_t * statements = cleri_list(CLERI_GID_STATEMENTS, statement, end_statement, 0, 0, 1);
     cleri_t * START = cleri_sequence(
         CLERI_GID_START,
         2,

--- a/src/langdef/langdef.c
+++ b/src/langdef/langdef.c
@@ -5,7 +5,7 @@
  * should be used with the libcleri module.
  *
  * Source class: LangDef
- * Created at: 2022-01-04 14:10:52
+ * Created at: 2022-01-04 18:35:59
  */
 
 #include <langdef/langdef.h>
@@ -30,8 +30,6 @@ cleri_grammar_t * compile_langdef(void)
     cleri_t * x_preopr = cleri_regex(CLERI_GID_X_PREOPR, "^(\\s*!|\\s*[\\-+](?=[^0-9]))*");
     cleri_t * x_ternary = cleri_token(CLERI_GID_X_TERNARY, "?");
     cleri_t * x_thing = cleri_token(CLERI_GID_X_THING, "{");
-    cleri_t * r_single_quote = cleri_regex(CLERI_GID_R_SINGLE_QUOTE, "^(?:\'(?:[^\']*)\')+");
-    cleri_t * r_double_quote = cleri_regex(CLERI_GID_R_DOUBLE_QUOTE, "^(?:\"(?:[^\"]*)\")+");
     cleri_t * template = cleri_sequence(
         CLERI_GID_TEMPLATE,
         3,
@@ -52,17 +50,11 @@ cleri_grammar_t * compile_langdef(void)
         cleri_token(CLERI_NONE, "`")
     );
     cleri_t * t_false = cleri_keyword(CLERI_GID_T_FALSE, "false", CLERI_CASE_SENSITIVE);
-    cleri_t * t_float = cleri_regex(CLERI_GID_T_FLOAT, "^[-+]?((inf|nan)([^0-9A-Za-z_]|$)|[0-9]*\\.[0-9]+(e[+-][0-9]+)?)");
-    cleri_t * t_int = cleri_regex(CLERI_GID_T_INT, "^[-+]?((0b[01]+)|(0o[0-8]+)|(0x[0-9a-fA-F]+)|([0-9]+))");
+    cleri_t * t_float = cleri_regex(CLERI_GID_T_FLOAT, "^[-+]?(inf|nan|[0-9]*\\.[0-9]+(e[+-][0-9]+)?)(?![0-9A-Za-z_])");
+    cleri_t * t_int = cleri_regex(CLERI_GID_T_INT, "^[-+]?((0b[01]+)|(0o[0-8]+)|(0x[0-9a-fA-F]+)|([0-9]+))(?![0-9A-Za-z_])");
     cleri_t * t_nil = cleri_keyword(CLERI_GID_T_NIL, "nil", CLERI_CASE_SENSITIVE);
     cleri_t * t_regex = cleri_regex(CLERI_GID_T_REGEX, "^/((?:.(?!(?<![\\\\])/))*.?)/[a-z]*");
-    cleri_t * t_string = cleri_choice(
-        CLERI_GID_T_STRING,
-        CLERI_FIRST_MATCH,
-        2,
-        r_single_quote,
-        r_double_quote
-    );
+    cleri_t * t_string = cleri_regex(CLERI_GID_T_STRING, "^(((?:\'(?:[^\']*)\')+)|((?:\"(?:[^\"]*)\")+))");
     cleri_t * t_true = cleri_keyword(CLERI_GID_T_TRUE, "true", CLERI_CASE_SENSITIVE);
     cleri_t * comments = cleri_repeat(CLERI_GID_COMMENTS, cleri_choice(
         CLERI_NONE,
@@ -71,8 +63,8 @@ cleri_grammar_t * compile_langdef(void)
         cleri_regex(CLERI_NONE, "^(?s)//.*?(\\r?\\n|$)"),
         cleri_regex(CLERI_NONE, "^(?s)/\\*.*?\\*/")
     ), 0, 0);
-    cleri_t * name = cleri_regex(CLERI_GID_NAME, "^[A-Za-z_][0-9A-Za-z_]{0,254}");
-    cleri_t * var = cleri_regex(CLERI_GID_VAR, "^[A-Za-z_][0-9A-Za-z_]{0,254}");
+    cleri_t * name = cleri_regex(CLERI_GID_NAME, "^[A-Za-z_][0-9A-Za-z_]{0,254}(?![0-9A-Za-z_])");
+    cleri_t * var = cleri_regex(CLERI_GID_VAR, "^[A-Za-z_][0-9A-Za-z_]{0,254}(?![0-9A-Za-z_])");
     cleri_t * chain = cleri_ref();
     cleri_t * closure = cleri_sequence(
         CLERI_GID_CLOSURE,
@@ -204,15 +196,14 @@ cleri_grammar_t * compile_langdef(void)
             CLERI_THIS
         ))
     ), 0, 0);
-    cleri_t * end_statement = cleri_regex(CLERI_GID_END_STATEMENT, "^(;\\s*)*((((?s)\\/\\/.*?(\\r?\\n|$))|((?s)\\/\\*.*?\\*\\/))\\s*)*");
+    cleri_t * end_statement = cleri_regex(CLERI_GID_END_STATEMENT, "^((;|((?s)\\/\\/.*?(\\r?\\n|$))|((?s)\\/\\*.*?\\*\\/))\\s*)*");
     cleri_t * block = cleri_sequence(
         CLERI_GID_BLOCK,
-        5,
+        4,
         x_block,
         comments,
         cleri_list(CLERI_NONE, CLERI_THIS, end_statement, 1, 0, 1),
-        cleri_token(CLERI_NONE, "}"),
-        cleri_optional(CLERI_NONE, CLERI_THIS)
+        cleri_token(CLERI_NONE, "}")
     );
     cleri_t * parenthesis = cleri_sequence(
         CLERI_GID_PARENTHESIS,
@@ -273,7 +264,7 @@ cleri_grammar_t * compile_langdef(void)
         cleri_choice(
             CLERI_NONE,
             CLERI_FIRST_MATCH,
-            14,
+            13,
             chain,
             t_false,
             t_nil,
@@ -286,7 +277,6 @@ cleri_grammar_t * compile_langdef(void)
             var_opt_more,
             thing,
             array,
-            block,
             parenthesis
         ),
         index,
@@ -300,12 +290,13 @@ cleri_grammar_t * compile_langdef(void)
         cleri_choice(
             CLERI_NONE,
             CLERI_FIRST_MATCH,
-            5,
+            6,
             if_statement,
             return_statement,
             for_statement,
             closure,
-            expression
+            expression,
+            block
         ),
         operations
     );
@@ -325,7 +316,7 @@ cleri_grammar_t * compile_langdef(void)
         cleri_optional(CLERI_NONE, chain)
     ));
 
-    cleri_grammar_t * grammar = cleri_grammar(START, "^[A-Za-z_][0-9A-Za-z_]{0,254}");
+    cleri_grammar_t * grammar = cleri_grammar(START, "^[A-Za-z_][0-9A-Za-z_]{0,254}(?![0-9A-Za-z_])");
 
     return grammar;
 }

--- a/src/langdef/translate.c
+++ b/src/langdef/translate.c
@@ -8,8 +8,7 @@ const char * langdef_translate(cleri_t * elem)
 {
     switch (elem->gid)
     {
-    case CLERI_GID_R_DOUBLE_QUOTE:
-    case CLERI_GID_R_SINGLE_QUOTE:
+    case CLERI_GID_T_STRING:
     case CLERI_GID_T_INT:
     case CLERI_GID_T_TRUE:
     case CLERI_GID_T_FALSE:

--- a/src/ti/closure.c
+++ b/src/ti/closure.c
@@ -62,7 +62,7 @@ static cleri_node_t * closure__node_from_strn(
             ->children->next;               /* List of statements */
 
     /* we should have exactly one statement */
-    if (!node->children || node->children->next)
+    if (!node->children)
     {
         ex_set(e, EX_BAD_DATA, "closure is expecting exactly one node");
         goto fail1;

--- a/src/ti/do.c
+++ b/src/ti/do.c
@@ -577,12 +577,10 @@ static inline int do__function(ti_query_t * query, cleri_node_t * nd, ex_t * e)
             : do__function_call(query, nd, e);
 }
 
-static inline int do__block(ti_query_t * query, cleri_node_t * nd, ex_t * e)
+int ti_do_block(ti_query_t * query, cleri_node_t * nd, ex_t * e)
 {
-    assert (nd->cl_obj->gid == CLERI_GID_BLOCK);
-
     /* first child, not empty */
-    cleri_node_t * child= nd->children->next->next->children;
+    cleri_node_t * child = nd->children->next->next->children;
 
     do
     {
@@ -1656,10 +1654,6 @@ int ti_do_expression(ti_query_t * query, cleri_node_t * nd, ex_t * e)
         break;
     case CLERI_GID_ARRAY:
         if (do__array(query, nd, e))
-            return e->nr;
-        break;
-    case CLERI_GID_BLOCK:
-        if (do__block(query, nd, e))
             return e->nr;
         break;
     case CLERI_GID_PARENTHESIS:

--- a/src/ti/fmt.c
+++ b/src/ti/fmt.c
@@ -395,8 +395,6 @@ static int fmt__expr_choice(ti_fmt_t * fmt, cleri_node_t * nd)
         return fmt__thing(fmt, nd);
     case CLERI_GID_ARRAY:
         return fmt__array(fmt, nd);
-    case CLERI_GID_BLOCK:
-        return fmt__block(fmt, nd);
     case CLERI_GID_PARENTHESIS:
         return fmt__parenthesis(fmt, nd);
     }
@@ -563,6 +561,8 @@ static int fmt__statement(ti_fmt_t * fmt, cleri_node_t * nd)
         return buf_append_str(&fmt->buf, "break");
     case CLERI_GID_CLOSURE:
         return fmt__closure(fmt, nd);
+    case CLERI_GID_BLOCK:
+        return fmt__block(fmt, nd);
     case CLERI_GID_EXPRESSION:
         return fmt__expression(fmt, nd);
     case CLERI_GID_OPERATIONS:

--- a/src/ti/ncache.c
+++ b/src/ti/ncache.c
@@ -332,12 +332,6 @@ static int ncache__expr_choice(
                 vcache,
                 nd->children->next->children,
                 e);
-    case CLERI_GID_BLOCK:
-        return ncache__list(
-                syntax,
-                vcache,
-                nd->children->next->next->children,
-                e);
     case CLERI_GID_PARENTHESIS:
         return ncache__statement(syntax, vcache, nd->children->next, e);
     default:
@@ -473,6 +467,12 @@ static int ncache__statement(
             return 0;
         case CLERI_GID_CLOSURE:
             return ncache__closure(syntax, vcache, nd, e);
+        case CLERI_GID_BLOCK:
+            return ncache__list(
+                    syntax,
+                    vcache,
+                    nd->children->next->next->children,
+                    e);
         case CLERI_GID_EXPRESSION:
             return ncache__expression(syntax, vcache, nd, e);
         case CLERI_GID_OPERATIONS:

--- a/src/ti/query.c
+++ b/src/ti/query.c
@@ -514,16 +514,10 @@ static inline int ti_query_investigate(ti_query_t * query, ex_t * e)
 
     /* check if illegal statements are found */
     if (query->qbind.flags & (
-            TI_QBIND_FLAG_ILL_BLOCK|
             TI_QBIND_FLAG_ILL_CONTINUE|
             TI_QBIND_FLAG_ILL_BREAK))
     {
-        if (query->qbind.flags & TI_QBIND_FLAG_ILL_BLOCK)
-            ex_set(e, EX_SYNTAX_ERROR,
-                    "illegal use of `block` statement; "
-                    "most likely a semicolon or surrounding parenthesis are "
-                    "missing");
-        else if (query->qbind.flags & TI_QBIND_FLAG_ILL_CONTINUE)
+        if (query->qbind.flags & TI_QBIND_FLAG_ILL_CONTINUE)
             ex_set(e, EX_SYNTAX_ERROR,
                     "illegal `continue` statement; "
                     "no surrounding `for..in` statement");

--- a/src/ti/val.c
+++ b/src/ti/val.c
@@ -743,7 +743,7 @@ int ti_val_init_common(void)
         !val__smpdata || !val__sregex || !val__serror || !val__sclosure ||
         !val__slist || !val__stuple || !val__sset || !val__sthing ||
         !val__swthing || !val__tar_gz_str || !val__sany || !val__gs_str ||
-        !val__charset_str || !val__default_re || // !val__default_closure ||
+        !val__charset_str || !val__default_re || !val__default_closure ||
         !val__sroom || !val__stask || !val__year_name || !val__month_name ||
         !val__day_name || !val__hour_name || !val__minute_name ||
         !val__second_name || !val__gmt_offset_name || !val__sfuture ||

--- a/src/ti/val.c
+++ b/src/ti/val.c
@@ -743,7 +743,7 @@ int ti_val_init_common(void)
         !val__smpdata || !val__sregex || !val__serror || !val__sclosure ||
         !val__slist || !val__stuple || !val__sset || !val__sthing ||
         !val__swthing || !val__tar_gz_str || !val__sany || !val__gs_str ||
-        !val__charset_str || !val__default_re || !val__default_closure ||
+        !val__charset_str || !val__default_re || // !val__default_closure ||
         !val__sroom || !val__stask || !val__year_name || !val__month_name ||
         !val__day_name || !val__hour_name || !val__minute_name ||
         !val__second_name || !val__gmt_offset_name || !val__sfuture ||


### PR DESCRIPTION
Be more forgiving for missing semicolon at the end-of-a-statement. Especially after a "block" it is not obvious that a semicolon is required to end the statement. 

For example:
```javascript
for (x in range(10)) {
  // do something
}

return x;
```

The code above used to return with an error as a semicolon is missing after the `for..in` statement. This pull request solves this by being more forgiving.


**Warning:** With this change, a code block should no longer accept a direct followup as for example indexing or applying functions.

For example:

```javascript
{
  range(10);
}.len(); 
```

The code above used to return `10` as this is the length of range 10 in the code block above. The new syntax would return the *length of the collection*, as it sees `.len();` as a new statement.

To get the `10` like before, we now have to wrap the code in parenthesis, like this:

```javascript
({
  range(10);
}).len(); 
```

The same is true for *not (!)* or *sign (+/-)* conversions, thus:
```thingsdb
!!{
  true;
}; 
```
will raise an error *(It will try to parse the code block as a thing...)*. As a fix, the code block can be wrapped in parenthesis.
```thingsdb
!!({
  true;
}); 
```


 