### PR TITLE
Added to_thing function, #278 and fixed conversoin error, #277

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v1.2.4
 
-* Added `to_thing()` function, issue #.
+* Fixed restriction mismatch after type removal, issue #277.
+* Added `to_thing()` function, issue #278.
 
 # v1.2.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v1.2.4
+
+* Added `to_thing()` function, issue #.
+
 # v1.2.3
 
 * Added `closure(..)` function to create closures from string, issue #273.

--- a/inc/doc.h
+++ b/inc/doc.h
@@ -283,6 +283,7 @@
 #define DOC_THING_RESTRICT          DOC_SEE("data-types/thing/restrict")
 #define DOC_THING_RESTRICTION       DOC_SEE("data-types/thing/restriction")
 #define DOC_THING_SET               DOC_SEE("data-types/thing/set")
+#define DOC_THING_TO_THING          DOC_SEE("data-types/thing/to_thing")
 #define DOC_THING_TO_TYPE           DOC_SEE("data-types/thing/to_type")
 #define DOC_THING_VALUES            DOC_SEE("data-types/thing/values")
 #define DOC_THING_WRAP              DOC_SEE("data-types/thing/wrap")

--- a/inc/ti/fn/fntothing.h
+++ b/inc/ti/fn/fntothing.h
@@ -1,0 +1,41 @@
+#include <ti/fn/fn.h>
+
+static int do__f_to_thing(ti_query_t * query, cleri_node_t * nd, ex_t * e)
+{
+    const int nargs = fn_get_nargs(nd);
+    ti_task_t * task;
+    ti_thing_t * thing;
+
+    if (!ti_val_is_instance(query->rval))
+        return fn_call_try("to_thing", query, nd, e);
+
+    thing = (ti_thing_t *) query->rval;
+
+    if (fn_nargs("to_thing", DOC_THING_TO_TYPE, 0, nargs, e) ||
+        ti_type_use(thing->via.type, e) ||
+        ti_val_try_lock(query->rval, e))
+        return e->nr;
+
+    if (thing->via.type->selfref || thing->via.type->refcount)
+    {
+        ex_set(e, EX_OPERATION,
+                "conversion `to_thing` has failed; "
+                "type `%s` is used as restriction and therefore ThingsDB is "
+                "not able to guarantee the typed thing can be converted",
+                thing->via.type->name);
+        goto fail0;
+    }
+
+    ti_thing_t_to_object(thing);
+
+    if (thing->id)
+    {
+        task = ti_task_get_task(query->change, thing);
+        if (!task || ti_task_add_to_thing(task))
+            ex_set_mem(e);
+    }
+
+fail0:
+    ti_val_unlock((ti_val_t *) thing, true  /* lock was set */);
+    return e->nr;
+}

--- a/inc/ti/fn/fntothing.h
+++ b/inc/ti/fn/fntothing.h
@@ -16,6 +16,8 @@ static int do__f_to_thing(ti_query_t * query, cleri_node_t * nd, ex_t * e)
         ti_val_try_lock(query->rval, e))
         return e->nr;
 
+    query->rval = (ti_val_t *) ti_nil_get();
+
     if (thing->via.type->selfref || thing->via.type->refcount)
     {
         ex_set(e, EX_OPERATION,
@@ -37,5 +39,6 @@ static int do__f_to_thing(ti_query_t * query, cleri_node_t * nd, ex_t * e)
 
 fail0:
     ti_val_unlock((ti_val_t *) thing, true  /* lock was set */);
+    ti_val_unsafe_drop((ti_val_t *) thing);
     return e->nr;
 }

--- a/inc/ti/fn/fntotype.h
+++ b/inc/ti/fn/fntotype.h
@@ -63,10 +63,7 @@ static int do__f_to_type(ti_query_t * query, cleri_node_t * nd, ex_t * e)
     {
         task = ti_task_get_task(query->change, thing);
         if (!task || ti_task_add_to_type(task, type))
-        {
             ex_set_mem(e);
-            goto fail1;
-        }
     }
 
 fail1:

--- a/inc/ti/task.h
+++ b/inc/ti/task.h
@@ -31,6 +31,7 @@ int ti_task_add_arr_clear(ti_task_t * task, ti_raw_t * key);
 int ti_task_add_set_clear(ti_task_t * task, ti_raw_t * key);
 int ti_task_add_set(ti_task_t * task, ti_raw_t * key, ti_val_t * val);
 int ti_task_add_new_type(ti_task_t * task, ti_type_t * type);
+int ti_task_add_to_thing(ti_task_t * task);
 int ti_task_add_to_type(ti_task_t * task, ti_type_t * type);
 int ti_task_add_restrict(ti_task_t * task, uint16_t spec);
 int ti_task_add_set_type(ti_task_t * task, ti_type_t * type);

--- a/inc/ti/task.t.h
+++ b/inc/ti/task.t.h
@@ -80,6 +80,7 @@ typedef enum
     TI_TASK_THING_REMOVE,                   /* 67  */
     TI_TASK_SET_DEFAULT_DEEP,               /* 68  */
     TI_TASK_RESTORE_FINISHED,               /* 69  */
+    TI_TASK_TO_THING,                       /* 70  */
 } ti_task_enum;
 
 typedef struct ti_task_s ti_task_t;

--- a/inc/ti/type.t.h
+++ b/inc/ti/type.t.h
@@ -28,7 +28,7 @@ struct ti_type_s
                                included in this counter */
     uint16_t type_id;       /* type id */
     uint8_t flags;          /* type flags */
-    uint8_t pad0_;
+    uint8_t selfref;        /* self reference counter */
     uint64_t created_at;    /* UNIX time-stamp in seconds */
     uint64_t modified_at;   /* UNIX time-stamp in seconds */
     char * name;            /* name (null terminated) */

--- a/inc/ti/version.h
+++ b/inc/ti/version.h
@@ -6,7 +6,7 @@
 
 #define TI_VERSION_MAJOR 1
 #define TI_VERSION_MINOR 2
-#define TI_VERSION_PATCH 3
+#define TI_VERSION_PATCH 4
 
 /* The syntax version is used to test compatibility with functions
  * using the `ti_nodes_check_syntax()` function */
@@ -25,7 +25,7 @@
  *  "-rc0"
  *  ""
  */
-#define TI_VERSION_PRE_RELEASE ""
+#define TI_VERSION_PRE_RELEASE "-alpha0"
 
 #define TI_MAINTAINER \
     "Jeroen van der Heijden <jeroen@cesbit.com>"

--- a/src/ti/ctask.c
+++ b/src/ti/ctask.c
@@ -535,6 +535,29 @@ static int ctask__set_type(ti_thing_t * thing, mp_unp_t * up)
 /*
  * Returns 0 on success
  */
+static int ctask__to_thing(ti_thing_t * thing, mp_unp_t * up)
+{
+    ti_collection_t * collection = thing->collection;
+
+    if (mp_skip(up) != MP_BOOL)
+    {
+        log_critical(
+            "task `to_thing` for "TI_COLLECTION_ID" is invalid",
+            collection->root->id);
+        return -1;
+    }
+
+    if (ti_thing_is_instance(thing))
+        ti_thing_t_to_object(thing);
+    else
+        log_error("thing "TI_THING_ID" is not an instance", thing->id);
+
+    return 0;
+}
+
+/*
+ * Returns 0 on success
+ */
 static int ctask__to_type(ti_thing_t * thing, mp_unp_t * up)
 {
     ex_t e = {0};
@@ -2669,6 +2692,7 @@ int ti_ctask_run(ti_thing_t * thing, mp_unp_t * up)
     case TI_TASK_THING_REMOVE:      return ctask__thing_remove(thing, up);
     case TI_TASK_SET_DEFAULT_DEEP:  break;
     case TI_TASK_RESTORE_FINISHED:  break;
+    case TI_TASK_TO_THING:          return ctask__to_thing(thing, up);
     }
 
     log_critical("unknown collection task: %"PRIu64, mp_task.via.u64);

--- a/src/ti/qbind.c
+++ b/src/ti/qbind.c
@@ -208,6 +208,7 @@
 #include <ti/fn/fnthing.h>
 #include <ti/fn/fntimezonesinfo.h>
 #include <ti/fn/fnto.h>
+#include <ti/fn/fntothing.h>
 #include <ti/fn/fntotype.h>
 #include <ti/fn/fntrim.h>
 #include <ti/fn/fntrimleft.h>
@@ -262,7 +263,7 @@ static void qbind__statement(ti_qbind_t * qbind, cleri_node_t * nd);
  */
 enum
 {
-    TOTAL_KEYWORDS = 237,
+    TOTAL_KEYWORDS = 238,
     MIN_WORD_LENGTH = 2,
     MAX_WORD_LENGTH = 17,
     MIN_HASH_VALUE = 22,
@@ -659,6 +660,7 @@ qbind__fmap_t qbind__fn_mapping[TOTAL_KEYWORDS] = {
     {.name="thing",             .fn=do__f_thing,                ROOT_NE},
     {.name="time_zones_info",   .fn=do__f_time_zones_info,      ROOT_NE},
     {.name="timeval",           .fn=do__f_timeval,              ROOT_NE},
+    {.name="to_thing",          .fn=do__f_to_thing,             CHAIN_CE},
     {.name="to_type",           .fn=do__f_to_type,              CHAIN_CE},
     {.name="to",                .fn=do__f_to,                   CHAIN_NE},
     {.name="trim_left",         .fn=do__f_trim_left,            CHAIN_NE},

--- a/src/ti/task.c
+++ b/src/ti/task.c
@@ -282,6 +282,36 @@ fail_data:
     return -1;
 }
 
+int ti_task_add_to_thing(ti_task_t * task)
+{
+    size_t alloc = 32;
+    ti_data_t * data;
+    msgpack_packer pk;
+    msgpack_sbuffer buffer;
+
+    if (mp_sbuffer_alloc_init(&buffer, alloc, sizeof(ti_data_t)))
+        return -1;
+    msgpack_packer_init(&pk, &buffer, msgpack_sbuffer_write);
+
+    msgpack_pack_array(&pk, 2);
+
+    msgpack_pack_uint8(&pk, TI_TASK_TO_THING);
+    msgpack_pack_true(&pk);
+
+    data = (ti_data_t *) buffer.data;
+    ti_data_init(data, buffer.size);
+
+    if (vec_push(&task->list, data))
+        goto fail_data;
+
+    task__upd_approx_sz(task, data);
+    return 0;
+
+fail_data:
+    free(data);
+    return -1;
+}
+
 int ti_task_add_to_type(ti_task_t * task, ti_type_t * type)
 {
     size_t alloc = 32;

--- a/src/ti/thing.c
+++ b/src/ti/thing.c
@@ -951,6 +951,7 @@ void ti_thing_t_to_object(ti_thing_t * thing)
         *val = (ti_val_t *) prop;
     }
     thing->type_id = TI_SPEC_OBJECT;
+    thing->via.spec = TI_SPEC_ANY;  /* fixes bug #277 */
 }
 
 typedef struct

--- a/src/ti/ttask.c
+++ b/src/ti/ttask.c
@@ -1555,6 +1555,7 @@ int ti_ttask_run(ti_change_t * change, mp_unp_t * up)
     case TI_TASK_THING_REMOVE:      break;
     case TI_TASK_SET_DEFAULT_DEEP:  return ttask__set_default_deep(up);
     case TI_TASK_RESTORE_FINISHED:  return ttask__restore_finished(up);
+    case TI_TASK_TO_THING:          break;
     }
 
     log_critical("unknown thingsdb task: %"PRIu64, mp_task.via.u64);

--- a/src/ti/type.c
+++ b/src/ti/type.c
@@ -48,6 +48,7 @@ ti_type_t * ti_type_create(
 
     type->refcount = 0;  /* only incremented when this type
                             is used by another type */
+    type->selfref = 0;  /* increment on self references */
     type->type_id = type_id;
     type->flags = flags;
     type->name = strndup(name, name_n);


### PR DESCRIPTION
## Description

Adds the function `to_thing(..)` and fixes a restriction bug. 

Resolves:
- #277 
- #278.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

- [x] test_collection_functions.py (test_to_thing)
- [x] test_advanced.py (test_self_ref_max, test_convert_to_thing)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
