### PR TITLE
No copy set with relations

### DIFF
--- a/inc/ti/closure.inline.h
+++ b/inc/ti/closure.inline.h
@@ -47,21 +47,17 @@ static inline int ti_closure_do_statement(
     return e->nr;
 }
 
+static inline _Bool ti_closure_wse(ti_closure_t * closure)
+{
+    return closure->flags & TI_CLOSURE_FLAG_WSE;
+}
+
 static inline int ti_closure_try_wse(
         ti_closure_t * closure,
         ti_query_t * query,
         ex_t * e)
 {
-    /*
-     * The current implementation never sets the `WSE` flag when bound to a
-     * scope, but nevertheless we still check explicit so this still works
-     * if we later decide to change the code.
-     */
-    if (!query->change && ((closure->flags & (
-                TI_CLOSURE_FLAG_BTSCOPE|
-                TI_CLOSURE_FLAG_BCSCOPE|
-                TI_CLOSURE_FLAG_WSE
-            )) == TI_CLOSURE_FLAG_WSE))
+    if (!query->change && (closure->flags & TI_CLOSURE_FLAG_WSE))
     {
         ex_set(e, EX_OPERATION,
             "closures with side effects require a change but none is created; "

--- a/inc/ti/fn/fn.h
+++ b/inc/ti/fn/fn.h
@@ -65,6 +65,7 @@
 #include <ti/vfloat.h>
 #include <ti/vint.h>
 #include <ti/vset.h>
+#include <ti/vset.inline.h>
 #include <ti/vtask.h>
 #include <ti/vtask.inline.h>
 #include <ti/warn.h>

--- a/inc/ti/fn/fneach.h
+++ b/inc/ti/fn/fneach.h
@@ -131,7 +131,8 @@ static int do__f_each(ti_query_t * query, cleri_node_t * nd, ex_t * e)
                 .closure = closure,
                 .query = query,
         };
-        if (ti_vset_has_relation((ti_vset_t *) iterval)
+        if ((   ti_closure_wse(closure) &&
+                ti_vset_has_relation((ti_vset_t *) iterval))
                 ? imap_walk_cp(VSET(iterval),
                         (imap_cb) each__walk_set,
                         &w,

--- a/inc/ti/fn/fneach.h
+++ b/inc/ti/fn/fneach.h
@@ -131,13 +131,13 @@ static int do__f_each(ti_query_t * query, cleri_node_t * nd, ex_t * e)
                 .closure = closure,
                 .query = query,
         };
-        if ((   ti_closure_wse(closure) &&
-                ti_vset_has_relation((ti_vset_t *) iterval))
-                ? imap_walk_cp(VSET(iterval),
-                        (imap_cb) each__walk_set,
-                        &w,
-                        (imap_destroy_cb) ti_val_unsafe_drop)
-                : imap_walk(VSET(iterval), (imap_cb) each__walk_set, &w))
+
+        if (ti_vset_walk(
+                (ti_vset_t *) iterval,
+                query,
+                closure,
+                (imap_cb) each__walk_set,
+                &w))
         {
             if (!e->nr)
                 ex_set_mem(e);

--- a/inc/ti/fn/fnevery.h
+++ b/inc/ti/fn/fnevery.h
@@ -91,7 +91,9 @@ static int do__f_every(ti_query_t * query, cleri_node_t * nd, ex_t * e)
                 .closure = closure,
                 .query = query,
         };
-        int rc = ti_vset_has_relation((ti_vset_t *) iterval)
+        int rc = (
+            ti_closure_wse(closure) &&
+            ti_vset_has_relation((ti_vset_t *) iterval))
                 ? imap_walk_cp(VSET(iterval),
                         (imap_cb) every__walk_set,
                         &w,

--- a/inc/ti/fn/fnfilter.h
+++ b/inc/ti/fn/fnfilter.h
@@ -206,7 +206,8 @@ static int do__f_filter(ti_query_t * query, cleri_node_t * nd, ex_t * e)
 
         retval = (ti_val_t *) w.vset;
 
-        if (ti_vset_has_relation((ti_vset_t *) iterval)
+        if ((   ti_closure_wse(closure) &&
+                ti_vset_has_relation((ti_vset_t *) iterval))
                 ? imap_walk_cp(VSET(iterval),
                         (imap_cb) filter__walk_set,
                         &w,

--- a/inc/ti/fn/fnfind.h
+++ b/inc/ti/fn/fnfind.h
@@ -98,7 +98,9 @@ static int do__f_find(ti_query_t * query, cleri_node_t * nd, ex_t * e)
                 .query = query,
         };
 
-        rc = ti_vset_has_relation((ti_vset_t *) iterval)
+        rc = (
+            ti_closure_wse(closure) &&
+            ti_vset_has_relation((ti_vset_t *) iterval))
                 ? imap_walk_cp(VSET(iterval),
                         (imap_cb) find__walk_set,
                         &w,

--- a/inc/ti/fn/fnmap.h
+++ b/inc/ti/fn/fnmap.h
@@ -137,7 +137,8 @@ static int do__f_map(ti_query_t * query, cleri_node_t * nd, ex_t * e)
                 .query = query,
                 .varr = retvarr,
         };
-        if (ti_vset_has_relation((ti_vset_t *) iterval)
+        if ((   ti_closure_wse(closure) &&
+                ti_vset_has_relation((ti_vset_t *) iterval))
                 ? imap_walk_cp(VSET(iterval),
                         (imap_cb) map__walk_set,
                         &w,

--- a/inc/ti/fn/fnreduce.h
+++ b/inc/ti/fn/fnreduce.h
@@ -173,7 +173,8 @@ static int do__f_reduce(ti_query_t * query, cleri_node_t * nd, ex_t * e)
                 .query = query,
         };
 
-        if (ti_vset_has_relation((ti_vset_t *) lockval))
+        if (ti_closure_wse(closure) &&
+            ti_vset_has_relation((ti_vset_t *) lockval))
         {
             if (imap_walk_cp(
                     imap,

--- a/inc/ti/fn/fnremove.h
+++ b/inc/ti/fn/fnremove.h
@@ -214,7 +214,7 @@ static int do__f_remove_set_from_closure(
             .limit = limit,
     };
 
-    if (ti_vset_has_relation(vset))
+    if (ti_closure_wse(closure) && ti_vset_has_relation(vset))
     {
         if (limit && imap_walk_cp(
                 vset->imap,

--- a/inc/ti/fn/fnsome.h
+++ b/inc/ti/fn/fnsome.h
@@ -90,7 +90,9 @@ static int do__f_some(ti_query_t * query, cleri_node_t * nd, ex_t * e)
                 .closure = closure,
                 .query = query,
         };
-        int rc = ti_vset_has_relation((ti_vset_t *) iterval)
+        int rc = (
+            ti_closure_wse(closure) &&
+            ti_vset_has_relation((ti_vset_t *) iterval))
                 ? imap_walk_cp(VSET(iterval),
                         (imap_cb) some__walk_set,
                         &w,

--- a/inc/ti/fn/fnwse.h
+++ b/inc/ti/fn/fnwse.h
@@ -13,7 +13,5 @@ static int do__f_wse(ti_query_t * query, cleri_node_t * nd, ex_t * e)
         return e->nr;
     }
 
-    (void) ti_do_statement(query, nd->children, e);
-
-    return e->nr;
+    return ti_do_statement(query, nd->children, e);
 }

--- a/inc/ti/version.h
+++ b/inc/ti/version.h
@@ -25,7 +25,7 @@
  *  "-rc0"
  *  ""
  */
-#define TI_VERSION_PRE_RELEASE "-alpha0"
+#define TI_VERSION_PRE_RELEASE "-alpha1"
 
 #define TI_MAINTAINER \
     "Jeroen van der Heijden <jeroen@cesbit.com>"

--- a/inc/ti/vset.inline.h
+++ b/inc/ti/vset.inline.h
@@ -1,0 +1,42 @@
+/*
+ * ti/vset.inline.h
+ */
+#ifndef TI_VSET_INLINE_H_
+#define TI_VSET_INLINE_H_
+
+#include <ti/vset.h>
+#include <ti/query.t.h>
+#include <ti/change.t.h>
+#include <ti/closure.t.h>
+#include <util/imap.h>
+
+
+static inline int ti_vset_walk(
+        ti_vset_t * vset,
+        ti_query_t * query,
+        ti_closure_t * closure,
+        imap_cb cb,
+        void * arg)
+{
+    if (ti_vset_has_relation(vset))
+    {
+        if (ti_closure_wse(closure))
+            return imap_walk_cp(
+                    vset->imap,
+                    cb,
+                    arg,
+                    (imap_destroy_cb) ti_val_unsafe_drop);
+        else if (query->change)
+        {
+            int rc;
+            ti_change_t * change = query->change;
+            query->change = NULL;
+            rc = imap_walk(vset->imap, cb, arg);
+            query->change = change;
+            return rc;
+        }
+    }
+    return imap_walk(vset->imap, cb, arg);
+}
+
+#endif  /* TI_VSET_INLINE_H_ */

--- a/itest/test_advanced.py
+++ b/itest/test_advanced.py
@@ -2117,17 +2117,19 @@ new_procedure('multiply', |a, b| a * b);
             });
 
             mod_type('A', 'rel', 'b', 'a');
+
+            .a = A{};
+            .b = B{};
+            .b.a.add(.a);
+            .clr = || {
+                .a.b.clear();
+            }
         """)
 
         res = await client.query("""//ti
-            a = A{};
-            b = B{a: set(a)};
-
-            b.a.each(|| {
-                a.b.clear();
-            });
-
-            b.a.len();  // 0
+            wse();
+            .b.a.each(|| .clr());
+            .b.a.len();  // 0
         """)
         self.assertEqual(res, 0)
 

--- a/itest/test_advanced.py
+++ b/itest/test_advanced.py
@@ -2127,11 +2127,18 @@ new_procedure('multiply', |a, b| a * b);
         """)
 
         res = await client.query("""//ti
-            wse();
-            .b.a.each(|| .clr());
+            .b.a.each(|| wse(.clr()));
             .b.a.len();  // 0
         """)
         self.assertEqual(res, 0)
+
+        await client.query('.b.a.add(.a);')
+
+        with self.assertRaises(OperationError):
+            res = await client.query("""//ti
+                wse();
+                .b.a.each(|| .clr());
+            """)
 
 
 if __name__ == '__main__':

--- a/itest/test_advanced.py
+++ b/itest/test_advanced.py
@@ -2103,6 +2103,34 @@ new_procedure('multiply', |a, b| a * b);
                 foo.people.some(|| assert(0));
             """)
 
+    async def test_cope_on_wse_relation(self, client):
+        await client.query("""//ti
+            new_type('A');
+            new_type('B');
+
+            set_type('A', {
+                b: '{B}'
+            });
+
+            set_type('B', {
+                a: '{A}'
+            });
+
+            mod_type('A', 'rel', 'b', 'a');
+        """)
+
+        res = await client.query("""//ti
+            a = A{};
+            b = B{a: set(a)};
+
+            b.a.each(|| {
+                a.b.clear();
+            });
+
+            b.a.len();  // 0
+        """)
+        self.assertEqual(res, 0)
+
 
 if __name__ == '__main__':
     run_test(TestAdvanced())

--- a/src/ti/do.c
+++ b/src/ti/do.c
@@ -809,11 +809,14 @@ int ti_do_closure(ti_query_t * query, cleri_node_t * nd, ex_t * e)
 
     if (!*data)
     {
+        intptr_t closure_wse = (intptr_t) nd->children->next->data;
+
         *data = (ti_val_t *) ti_closure_from_node(
                 nd,
-                (query->qbind.flags & TI_QBIND_FLAG_THINGSDB)
+                ((query->qbind.flags & TI_QBIND_FLAG_THINGSDB)
                     ? TI_CLOSURE_FLAG_BTSCOPE
-                    : TI_CLOSURE_FLAG_BCSCOPE);
+                    : TI_CLOSURE_FLAG_BCSCOPE) | closure_wse);
+
         if (!*data)
         {
             ex_set_mem(e);

--- a/src/ti/qbind.c
+++ b/src/ti/qbind.c
@@ -1007,20 +1007,24 @@ static inline void qbind__thing(ti_qbind_t * qbind, cleri_node_t * nd)
 
 static inline void qbind__closure(ti_qbind_t * qbind, cleri_node_t * nd)
 {
-    uint8_t for_loop_flag = qbind->flags & TI_QBIND_FLAG_FOR_LOOP;
+    intptr_t closure_wse;
+    uint8_t flags = qbind->flags & (TI_QBIND_FLAG_FOR_LOOP|TI_QBIND_FLAG_WSE);
 
     nd->data = ti_do_closure;
     nd->children->data = NULL;
 
-    qbind->flags &= ~TI_QBIND_FLAG_FOR_LOOP;
+    qbind->flags &= ~(TI_QBIND_FLAG_FOR_LOOP|TI_QBIND_FLAG_WSE);
 
     /* investigate the statement, the rest can be skipped */
     qbind__statement(
             qbind,
             nd->children->next->next->next);
 
+    closure_wse = (qbind->flags & TI_QBIND_FLAG_WSE) ? TI_CLOSURE_FLAG_WSE : 0;
+    nd->children->next->data = (void *) closure_wse;
+
     ++qbind->immutable_n;
-    qbind->flags |= for_loop_flag;
+    qbind->flags |= flags;
 }
 
 /*


### PR DESCRIPTION
## Description

When a `set` has a relation, ThingsDB always makes an internal copy of that `set` when looping over the `set`. This is not required when no change is made.

## Type of change

- [x] Performance increase

## How Has This Been Tested?

- [x] Added a few tests

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
