### PR TITLE
Strictval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v1.3.4
+
+* Fixed mismatch in refcount, issue #309.
+* Fixed bug with relations between things without Id , issue #308.
+
 # v1.3.3
 
 * Definition must follow flags, issue #306.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * Fixed mismatch in refcount, issue #309.
 * Fixed bug with relations between things without Id, issue #308.
-* Improve performance, pr #311.
+* Improve performance, pr #313.
 
 # v1.3.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v1.3.4
+# v1.4.0
 
 * Fixed mismatch in refcount, issue #309.
 * Fixed bug with relations between things without Id, issue #308.

--- a/inc/ti/closure.h
+++ b/inc/ti/closure.h
@@ -31,15 +31,11 @@ int ti_closure_to_client_pk(ti_closure_t * closure, msgpack_packer * pk);
 int ti_closure_to_store_pk(ti_closure_t * closure, msgpack_packer * pk);
 int ti_closure_inc(ti_closure_t * closure, ti_query_t * query, ex_t * e);
 void ti_closure_dec(ti_closure_t * closure, ti_query_t * query);
-int ti_closure_vars_val(
-        ti_closure_t * closure,
-        ti_val_t * val,
-        ex_t * e);
-int ti_closure_vars_nameval(
+void ti_closure_vars_val(ti_closure_t * closure, ti_val_t * val);
+void ti_closure_vars_nameval(
         ti_closure_t * closure,
         ti_val_t * name,
-        ti_val_t * val,
-        ex_t * e);
+        ti_val_t * val);
 int ti_closure_vars_val_idx(ti_closure_t * closure, ti_val_t * v, int64_t i);
 int ti_closure_vars_replace_str(
         ti_closure_t * closure,
@@ -65,28 +61,18 @@ int ti_closure_call_one_arg(
 ti_raw_t * ti_closure_doc(ti_closure_t * closure);
 ti_raw_t * ti_closure_def(ti_closure_t * closure);
 
-static inline int ti_closure_vars_prop(
+static inline void ti_closure_vars_prop(
         ti_closure_t * closure,
-        ti_prop_t * prop,
-        ex_t * e)
+        ti_prop_t * prop)
 {
-    return ti_closure_vars_nameval(
-            closure,
-            (ti_val_t *) prop->name,
-            prop->val,
-            e);
+    ti_closure_vars_nameval(closure, (ti_val_t *) prop->name, prop->val);
 }
 
-static inline int ti_closure_vars_item(
+static inline void ti_closure_vars_item(
         ti_closure_t * closure,
-        ti_item_t * item,
-        ex_t * e)
+        ti_item_t * item)
 {
-    return ti_closure_vars_nameval(
-            closure,
-            (ti_val_t *) item->key,
-            item->val,
-            e);
+    ti_closure_vars_nameval(closure, (ti_val_t *) item->key, item->val);
 }
 
 static inline cleri_node_t * ti_closure_statement(ti_closure_t * closure)

--- a/inc/ti/field.h
+++ b/inc/ti/field.h
@@ -61,6 +61,11 @@ int ti_field_relation_make(
         ti_field_t * field,
         ti_field_t * ofield,
         vec_t * vars);
+int ti_field_vset_pre_assign(
+        ti_field_t * field,
+        imap_t * imap,
+        ti_thing_t * parent,
+        ex_t * e);
 
 static inline ti_field_t * ti_field_by_name(ti_type_t * type, ti_name_t * name)
 {

--- a/inc/ti/field.h
+++ b/inc/ti/field.h
@@ -65,7 +65,8 @@ int ti_field_vset_pre_assign(
         ti_field_t * field,
         imap_t * imap,
         ti_thing_t * parent,
-        ex_t * e);
+        ex_t * e,
+        _Bool do_type_check);
 
 static inline ti_field_t * ti_field_by_name(ti_type_t * type, ti_name_t * name)
 {

--- a/inc/ti/fn/fn.h
+++ b/inc/ti/fn/fn.h
@@ -452,8 +452,7 @@ static int fn_call(ti_query_t * query, cleri_node_t * nd, ex_t * e)
         {
             --n;  // outside `while` so we do not go below zero
 
-            if (ti_do_statement(query, child, e) ||
-                ti_val_make_variable(&query->rval, e))
+            if (ti_do_statement(query, child, e))
                 goto fail1;
 
             VEC_push(args, query->rval);

--- a/inc/ti/fn/fnadd.h
+++ b/inc/ti/fn/fnadd.h
@@ -18,6 +18,7 @@ static int do__f_add(ti_query_t * query, cleri_node_t * nd, ex_t * e)
     }
 
     if (fn_nargs_min("add", DOC_SET_ADD, 1, nargs, e) ||
+        ti_query_test_vset_operation(query, e) ||
         ti_val_try_lock(query->rval, e))
         goto fail0;
 

--- a/inc/ti/fn/fnclear.h
+++ b/inc/ti/fn/fnclear.h
@@ -56,6 +56,7 @@ static int do__f_clear(ti_query_t * query, cleri_node_t * nd, ex_t * e)
 
         if (n && vset->parent && vset->parent->id)
         {
+            /* clear must have a task as this is enforced */
             ti_task_t * task = ti_task_get_task(query->change, vset->parent);
             if (!task || ti_task_add_set_clear(task, ti_vset_key(vset)))
                 ex_set_mem(e);

--- a/inc/ti/fn/fndel.h
+++ b/inc/ti/fn/fndel.h
@@ -75,8 +75,7 @@ static int do__f_del_thing(ti_query_t * query, cleri_node_t * nd, ex_t * e)
     query->rval = item->val;
     ti_incref(query->rval);
 
-    ti_val_attach(query->rval, NULL, NULL);
-    ti_item_destroy(item);
+    ti_item_unassign_destroy(item);
 
     if (thing->id)
     {

--- a/inc/ti/fn/fneach.h
+++ b/inc/ti/fn/fneach.h
@@ -19,8 +19,8 @@ static int each__walk_set(ti_thing_t * t, each__walk_t * w)
 
 static int each__walk_i(ti_item_t * item, each__walk_t * w)
 {
-    if (ti_closure_vars_item(w->closure, item, w->e) ||
-        ti_closure_do_statement(w->closure, w->query, w->e))
+    ti_closure_vars_item(w->closure, item);
+    if (ti_closure_do_statement(w->closure, w->query, w->e))
         return -1;
     ti_val_unsafe_drop(w->query->rval);
     w->query->rval = NULL;
@@ -82,8 +82,8 @@ static int do__f_each(ti_query_t * query, cleri_node_t * nd, ex_t * e)
             {
                 for (vec_each(thing->items.vec, ti_prop_t, p))
                 {
-                    if (ti_closure_vars_prop(closure, p, e) ||
-                        ti_closure_do_statement(closure, query, e))
+                    ti_closure_vars_prop(closure, p);
+                    if (ti_closure_do_statement(closure, query, e))
                         goto fail2;
                     ti_val_unsafe_drop(query->rval);
                     query->rval = NULL;
@@ -96,8 +96,8 @@ static int do__f_each(ti_query_t * query, cleri_node_t * nd, ex_t * e)
             ti_val_t * val;
             for (thing_t_each(thing, name, val))
             {
-                if (ti_closure_vars_nameval(closure, (ti_val_t *) name, val, e) ||
-                    ti_closure_do_statement(closure, query, e))
+                ti_closure_vars_nameval(closure, (ti_val_t *) name, val);
+                if (ti_closure_do_statement(closure, query, e))
                     goto fail2;
                 ti_val_unsafe_drop(query->rval);
                 query->rval = NULL;

--- a/inc/ti/fn/fnextend.h
+++ b/inc/ti/fn/fnextend.h
@@ -10,6 +10,7 @@ static int do__f_extend(ti_query_t * query, cleri_node_t * nd, ex_t * e)
         return fn_call_try("extend", query, nd, e);
 
     if (fn_nargs("extend", DOC_LIST_EXTEND, 1, nargs, e) ||
+        ti_query_test_varr_operation(query, e) ||
         ti_val_try_lock(query->rval, e))
         return e->nr;
 

--- a/inc/ti/fn/fnextendunique.h
+++ b/inc/ti/fn/fnextendunique.h
@@ -10,6 +10,7 @@ static int do__f_extend_unique(ti_query_t * query, cleri_node_t * nd, ex_t * e)
         return fn_call_try("extend_unique", query, nd, e);
 
     if (fn_nargs("extend_unique", DOC_LIST_EXTEND_UNIQUE, 1, nargs, e) ||
+        ti_query_test_varr_operation(query, e) ||
         ti_val_try_lock(query->rval, e))
         return e->nr;
 

--- a/inc/ti/fn/fnfilter.h
+++ b/inc/ti/fn/fnfilter.h
@@ -127,6 +127,7 @@ static int do__f_filter(ti_query_t * query, cleri_node_t * nd, ex_t * e)
 
                 if (ti_val_as_bool(query->rval))
                 {
+                    LOGC("HERE!!!!");
                     if (    ti_val_make_variable(&p->val, e) ||
                             !ti_thing_p_prop_add(thing, p->name, p->val))
                         goto fail2;

--- a/inc/ti/fn/fnfilter.h
+++ b/inc/ti/fn/fnfilter.h
@@ -36,18 +36,13 @@ typedef struct
 
 static int filter__walk_i(ti_item_t * item, filter__walk_i_t * w)
 {
-    if (ti_closure_vars_item(w->closure, item, w->e) ||
-        ti_closure_do_statement(w->closure, w->query, w->e))
+    ti_closure_vars_item(w->closure, item);
+    if (ti_closure_do_statement(w->closure, w->query, w->e))
         return -1;
 
-    if (ti_val_as_bool(w->query->rval))
-    {
-        if (ti_val_make_variable(&item->val, w->e) ||
-            !ti_thing_i_item_add(w->thing, item->key, item->val))
-            return -1;
-        ti_incref(item->key);
-        ti_incref(item->val);
-    }
+    if (ti_val_as_bool(w->query->rval) &&
+        ti_thing_i_item_add_assign(w->thing, item->key, item->val, w->e))
+        return -1;
 
     ti_val_unsafe_drop(w->query->rval);
     w->query->rval = NULL;
@@ -121,18 +116,13 @@ static int do__f_filter(ti_query_t * query, cleri_node_t * nd, ex_t * e)
         {
             for (vec_each(t->items.vec, ti_prop_t, p))
             {
-                if (ti_closure_vars_prop(closure, p, e) ||
-                    ti_closure_do_statement(closure, query, e))
+                ti_closure_vars_prop(closure, p);
+                if (ti_closure_do_statement(closure, query, e))
                     goto fail2;
 
-                if (ti_val_as_bool(query->rval))
-                {
-                    if (    ti_val_make_variable(&p->val, e) ||
-                            !ti_thing_p_prop_add(thing, p->name, p->val))
-                        goto fail2;
-                    ti_incref(p->name);
-                    ti_incref(p->val);
-                }
+                if (ti_val_as_bool(query->rval) &&
+                    ti_thing_p_prop_add_assign(thing, p->name, p->val, e))
+                    goto fail2;
 
                 ti_val_unsafe_drop(query->rval);
                 query->rval = NULL;
@@ -144,18 +134,13 @@ static int do__f_filter(ti_query_t * query, cleri_node_t * nd, ex_t * e)
             ti_val_t * val;
             for (thing_t_each(t, name, val))
             {
-                if (ti_closure_vars_nameval(closure, (ti_val_t *) name, val, e) ||
-                    ti_closure_do_statement(closure, query, e))
+                ti_closure_vars_nameval(closure, (ti_val_t *) name, val);
+                if (ti_closure_do_statement(closure, query, e))
                     goto fail2;
 
-                if (ti_val_as_bool(query->rval))
-                {
-                    if (    ti_val_make_variable(&val, e) ||
-                            !ti_thing_p_prop_add(thing, name, val))
-                        goto fail2;
-                    ti_incref(name);
-                    ti_incref(val);
-                }
+                if (ti_val_as_bool(query->rval) &&
+                    ti_thing_p_prop_add_assign(thing, name, val, e))
+                    goto fail2;
 
                 ti_val_unsafe_drop(query->rval);
                 query->rval = NULL;

--- a/inc/ti/fn/fnfilter.h
+++ b/inc/ti/fn/fnfilter.h
@@ -127,7 +127,6 @@ static int do__f_filter(ti_query_t * query, cleri_node_t * nd, ex_t * e)
 
                 if (ti_val_as_bool(query->rval))
                 {
-                    LOGC("HERE!!!!");
                     if (    ti_val_make_variable(&p->val, e) ||
                             !ti_thing_p_prop_add(thing, p->name, p->val))
                         goto fail2;

--- a/inc/ti/fn/fnmap.h
+++ b/inc/ti/fn/fnmap.h
@@ -20,8 +20,8 @@ static int map__walk_set(ti_thing_t * t, map__walk_t * w)
 
 static int map__walk_i(ti_item_t * item, map__walk_t * w)
 {
-    if (ti_closure_vars_item(w->closure, item, w->e) ||
-        ti_closure_do_statement(w->closure, w->query, w->e) ||
+    ti_closure_vars_item(w->closure, item);
+    if (ti_closure_do_statement(w->closure, w->query, w->e) ||
         ti_val_varr_append(w->varr, &w->query->rval, w->e))
         return -1;
     w->query->rval = NULL;
@@ -93,8 +93,8 @@ static int do__f_map(ti_query_t * query, cleri_node_t * nd, ex_t * e)
             {
                 for (vec_each(thing->items.vec, ti_prop_t, p))
                 {
-                    if (ti_closure_vars_prop(closure, p, e) ||
-                        ti_closure_do_statement(closure, query, e) ||
+                    ti_closure_vars_prop(closure, p);
+                    if (ti_closure_do_statement(closure, query, e) ||
                         ti_val_varr_append(retvarr, &query->rval, e))
                         goto fail2;
                     query->rval = NULL;
@@ -107,8 +107,8 @@ static int do__f_map(ti_query_t * query, cleri_node_t * nd, ex_t * e)
             ti_val_t * val;
             for (thing_t_each(thing, name, val))
             {
-                if (ti_closure_vars_nameval(closure, (ti_val_t *) name, val, e) ||
-                    ti_closure_do_statement(closure, query, e) ||
+                ti_closure_vars_nameval(closure, (ti_val_t *) name, val);
+                if (ti_closure_do_statement(closure, query, e) ||
                     ti_val_varr_append(retvarr, &query->rval, e))
                     goto fail2;
                 query->rval = NULL;

--- a/inc/ti/fn/fnpop.h
+++ b/inc/ti/fn/fnpop.h
@@ -9,6 +9,7 @@ static int do__f_pop(ti_query_t * query, cleri_node_t * nd, ex_t * e)
         return fn_call_try("pop", query, nd, e);
 
     if (fn_nargs("pop", DOC_LIST_POP, 0, nargs, e) ||
+        ti_query_test_varr_operation(query, e) ||
         ti_val_try_lock(query->rval, e))
         return e->nr;
 

--- a/inc/ti/fn/fnpush.h
+++ b/inc/ti/fn/fnpush.h
@@ -11,6 +11,7 @@ static int do__f_push(ti_query_t * query, cleri_node_t * nd, ex_t * e)
         return fn_call_try("push", query, nd, e);
 
     if (fn_nargs_min("push", DOC_LIST_PUSH, 1, nargs, e) ||
+        ti_query_test_varr_operation(query, e) ||
         ti_val_try_lock(query->rval, e))
         return e->nr;
 

--- a/inc/ti/fn/fnreduce.h
+++ b/inc/ti/fn/fnreduce.h
@@ -40,8 +40,6 @@ static int reduce__walk_set(ti_thing_t * t, reduce__walk_t * w)
         prop->val = (ti_val_t *) t;
         /* fall through */
     case 1:
-        if (ti_val_make_variable(&w->query->rval, w->e))
-            return w->e->nr;
         prop = VEC_get(w->closure->vars, 0);
         ti_val_unsafe_drop(prop->val);
         prop->val = w->query->rval;
@@ -134,8 +132,6 @@ static int do__f_reduce(ti_query_t * query, cleri_node_t * nd, ex_t * e)
                 prop->val = v;
                 /* fall through */
             case 1:
-                if (ti_val_make_variable(&query->rval, e))
-                    goto fail2;
                 prop = VEC_get(closure->vars, 0);
                 ti_val_unsafe_drop(prop->val);
                 prop->val = query->rval;

--- a/inc/ti/fn/fnremove.h
+++ b/inc/ti/fn/fnremove.h
@@ -369,8 +369,8 @@ typedef struct
 
 static int remove__walk_i(ti_item_t * item, remove__walk_i_t * w)
 {
-    if (ti_closure_vars_item(w->closure, item, w->e) ||
-        ti_closure_do_statement(w->closure, w->query, w->e))
+    ti_closure_vars_item(w->closure, item);
+    if (ti_closure_do_statement(w->closure, w->query, w->e))
         return -1;
 
     if (ti_val_as_bool(w->query->rval))
@@ -467,8 +467,8 @@ static int do__f_remove_thing(ti_query_t * query, cleri_node_t * nd, ex_t * e)
             if (vec->n == limit)
                 break;
 
-            if (ti_closure_vars_prop(closure, prop, e) ||
-                ti_closure_do_statement(closure, query, e))
+            ti_closure_vars_prop(closure, prop);
+            if (ti_closure_do_statement(closure, query, e))
                 goto fail3;
 
             if (ti_val_as_bool(query->rval))

--- a/inc/ti/fn/fnremove.h
+++ b/inc/ti/fn/fnremove.h
@@ -10,7 +10,6 @@ static int do__f_remove_list(ti_query_t * query, cleri_node_t * nd, ex_t * e)
     vec_t * vec;
 
     if (fn_nargs_range("remove", DOC_LIST_REMOVE, 1, 2, nargs, e) ||
-        ti_query_test_varr_operation(query, e) ||
         ti_val_try_lock(query->rval, e))
         return e->nr;
 
@@ -236,7 +235,6 @@ static int do__f_remove_set(ti_query_t * query, cleri_node_t * nd, ex_t * e)
     ti_vset_t * vset;
 
     if (fn_nargs_min("remove", DOC_SET_REMOVE, 1, nargs, e) ||
-        ti_query_test_vset_operation(query, e) ||
         ti_val_try_lock(query->rval, e))
         return e->nr;
 

--- a/inc/ti/fn/fnremove.h
+++ b/inc/ti/fn/fnremove.h
@@ -10,6 +10,7 @@ static int do__f_remove_list(ti_query_t * query, cleri_node_t * nd, ex_t * e)
     vec_t * vec;
 
     if (fn_nargs_range("remove", DOC_LIST_REMOVE, 1, 2, nargs, e) ||
+        ti_query_test_varr_operation(query, e) ||
         ti_val_try_lock(query->rval, e))
         return e->nr;
 
@@ -235,6 +236,7 @@ static int do__f_remove_set(ti_query_t * query, cleri_node_t * nd, ex_t * e)
     ti_vset_t * vset;
 
     if (fn_nargs_min("remove", DOC_SET_REMOVE, 1, nargs, e) ||
+        ti_query_test_vset_operation(query, e) ||
         ti_val_try_lock(query->rval, e))
         return e->nr;
 

--- a/inc/ti/fn/fnrun.h
+++ b/inc/ti/fn/fnrun.h
@@ -37,8 +37,7 @@ static int do__f_run(ti_query_t * query, cleri_node_t * nd, ex_t * e)
     while (child->next && (child = child->next->next) && n)
     {
         --n;  // outside while so we do not go below zero
-        if (ti_do_statement(query, child, e) ||
-            ti_val_make_variable(&query->rval, e))
+        if (ti_do_statement(query, child, e))
             goto failed;
 
         VEC_push(args, query->rval);

--- a/inc/ti/fn/fnshift.h
+++ b/inc/ti/fn/fnshift.h
@@ -9,6 +9,7 @@ static int do__f_shift(ti_query_t * query, cleri_node_t * nd, ex_t * e)
         return fn_call_try("shift", query, nd, e);
 
     if (fn_nargs("shift", DOC_LIST_SHIFT, 0, nargs, e) ||
+        ti_query_test_varr_operation(query, e) ||
         ti_val_try_lock(query->rval, e))
         return e->nr;
 

--- a/inc/ti/fn/fnsort.h
+++ b/inc/ti/fn/fnsort.h
@@ -120,9 +120,6 @@ static int do__f_sort(ti_query_t * query, cleri_node_t * nd, ex_t * e)
         goto fail0;
     }
 
-    ti_val_unsafe_drop(query->rval);
-    query->rval = NULL;
-
     if (varr->vec->n <= 1)
         goto done;  /* nothing to sort */
 

--- a/inc/ti/fn/fnsort.h
+++ b/inc/ti/fn/fnsort.h
@@ -111,11 +111,13 @@ static int do__f_sort(ti_query_t * query, cleri_node_t * nd, ex_t * e)
         return e->nr;
     }
 
-    varr = ti_varr_cp((ti_varr_t *) query->rval);
-    if (!varr)
+    varr = (ti_varr_t *) query->rval;
+    query->rval = NULL;
+
+    if (ti_varr_to_list(&varr))
     {
         ex_set_mem(e);
-        return e->nr;
+        goto fail0;
     }
 
     ti_val_unsafe_drop(query->rval);

--- a/inc/ti/fn/fnsort.h
+++ b/inc/ti/fn/fnsort.h
@@ -111,14 +111,15 @@ static int do__f_sort(ti_query_t * query, cleri_node_t * nd, ex_t * e)
         return e->nr;
     }
 
-    varr = (ti_varr_t *) query->rval;
-    query->rval = NULL;
-
-    if (ti_varr_to_list(&varr))
+    varr = ti_varr_cp((ti_varr_t *) query->rval);
+    if (!varr)
     {
         ex_set_mem(e);
-        goto fail0;
+        return e->nr;
     }
+
+    ti_val_unsafe_drop(query->rval);
+    query->rval = NULL;
 
     if (varr->vec->n <= 1)
         goto done;  /* nothing to sort */

--- a/inc/ti/fn/fnsplice.h
+++ b/inc/ti/fn/fnsplice.h
@@ -14,6 +14,7 @@ static int do__f_splice(ti_query_t * query, cleri_node_t * nd, ex_t * e)
 
     n = fn_get_nargs(nd);
     if (fn_nargs_min("splice", DOC_LIST_SPLICE, 2, n, e) ||
+        ti_query_test_varr_operation(query, e) ||
         ti_val_try_lock(query->rval, e))
         return e->nr;
 

--- a/inc/ti/fn/fnunshift.h
+++ b/inc/ti/fn/fnunshift.h
@@ -11,6 +11,7 @@ static int do__f_unshift(ti_query_t * query, cleri_node_t * nd, ex_t * e)
         return fn_call_try("unshift", query, nd, e);
 
     if (fn_nargs_min("unshift", DOC_LIST_UNSHIFT, 1, nargs, e) ||
+        ti_query_test_varr_operation(query, e) ||
         ti_val_try_lock(query->rval, e))
         return e->nr;
 

--- a/inc/ti/fn/fnvalue.h
+++ b/inc/ti/fn/fnvalue.h
@@ -15,7 +15,6 @@ static int do__f_value(ti_query_t * query, cleri_node_t * nd, ex_t * e)
     ti_incref(val);
     ti_val_unsafe_drop(query->rval);
     query->rval = val;
-    LOGC("REFS: %u", val->ref);
 
     return 0;
 }

--- a/inc/ti/fn/fnvalue.h
+++ b/inc/ti/fn/fnvalue.h
@@ -15,6 +15,7 @@ static int do__f_value(ti_query_t * query, cleri_node_t * nd, ex_t * e)
     ti_incref(val);
     ti_val_unsafe_drop(query->rval);
     query->rval = val;
+    LOGC("REFS: %u", val->ref);
 
     return 0;
 }

--- a/inc/ti/fn/fnvmap.h
+++ b/inc/ti/fn/fnvmap.h
@@ -10,9 +10,9 @@ typedef struct
 
 static int vmap__walk_i(ti_item_t * item, vmap__walk_i_t * w)
 {
-    if (ti_closure_vars_val(w->closure, item->val, w->e) ||
-        ti_closure_do_statement(w->closure, w->query, w->e) ||
-        ti_val_make_variable(&w->query->rval, w->e) ||
+    ti_closure_vars_val(w->closure, item->val);
+    if (ti_closure_do_statement(w->closure, w->query, w->e) ||
+        ti_val_make_assignable(&w->query->rval, w->thing, item->key, w->e) ||
         !ti_thing_i_item_add(w->thing, item->key, w->query->rval))
         return -1;
 
@@ -77,9 +77,9 @@ static int do__f_vmap(ti_query_t * query, cleri_node_t * nd, ex_t * e)
             /* the original thing is an object */
             for (vec_each(othing->items.vec, ti_prop_t, prop))
             {
-                if (ti_closure_vars_val(closure, prop->val, e) ||
-                    ti_closure_do_statement(closure, query, e) ||
-                    ti_val_make_variable(&query->rval, e) ||
+                ti_closure_vars_val(closure, prop->val);
+                if (ti_closure_do_statement(closure, query, e) ||
+                    ti_val_make_assignable(&query->rval, nthing, prop->name, e) ||
                     !ti_thing_p_prop_add(nthing, prop->name, query->rval))
                     goto fail2;
 
@@ -94,9 +94,9 @@ static int do__f_vmap(ti_query_t * query, cleri_node_t * nd, ex_t * e)
             ti_val_t * val;
             for (thing_t_each(othing, name, val))
             {
-                if (ti_closure_vars_val(closure, val, e) ||
-                    ti_closure_do_statement(closure, query, e) ||
-                    ti_val_make_variable(&query->rval, e) ||
+                ti_closure_vars_val(closure, val);
+                if (ti_closure_do_statement(closure, query, e) ||
+                    ti_val_make_assignable(&query->rval, nthing, name, e) ||
                     !ti_thing_p_prop_add(nthing, name, query->rval))
                     goto fail2;
 

--- a/inc/ti/item.h
+++ b/inc/ti/item.h
@@ -10,7 +10,7 @@
 
 ti_item_t * ti_item_create(ti_raw_t * raw, ti_val_t * val);
 ti_item_t * ti_item_dup(ti_item_t * item);
-void ti_item_destroy(ti_item_t * item);
+void ti_item_unassign_destroy(ti_item_t * item);
 void ti_item_unsafe_vdestroy(ti_item_t * item);
 
 #endif /* TI_ITEM_H_ */

--- a/inc/ti/opr/and.h
+++ b/inc/ti/opr/and.h
@@ -34,6 +34,9 @@ static int opr__and(ti_val_t * a, ti_val_t ** b, ex_t * e, _Bool inplace)
          * available in both `a` and `b`, therefore a "shortcut" can be made
          * if this is an in-place modification or if `a` is not used  anymore.
          */
+        if (ti_val_test_unlocked(a, e))
+            return e->nr;
+
         if (ti_vset_is_unrestricted((ti_vset_t *) a) &&
             (inplace || a->ref == 1))
         {
@@ -52,6 +55,11 @@ static int opr__and(ti_val_t * a, ti_val_t ** b, ex_t * e, _Bool inplace)
                 goto alloc_err;
             ti_val_unsafe_drop(*b);
             *b = (ti_val_t *) vset;
+            if (inplace)
+            {
+                vset->parent = ((ti_vset_t *) a)->parent;
+                vset->key_ = ((ti_vset_t *) a)->key_;
+            }
         }
         return e->nr;
     }

--- a/inc/ti/opr/and.h
+++ b/inc/ti/opr/and.h
@@ -34,7 +34,7 @@ static int opr__and(ti_val_t * a, ti_val_t ** b, ex_t * e, _Bool inplace)
          * available in both `a` and `b`, therefore a "shortcut" can be made
          * if this is an in-place modification or if `a` is not used  anymore.
          */
-        if (ti_val_test_unlocked(a, e))
+        if (inplace && ti_val_test_unlocked(a, e))
             return e->nr;
 
         if (ti_vset_is_unrestricted((ti_vset_t *) a) &&

--- a/inc/ti/opr/and.h
+++ b/inc/ti/opr/and.h
@@ -29,6 +29,9 @@ static int opr__and(ti_val_t * a, ti_val_t ** b, ex_t * e, _Bool inplace)
         break;
 
     case OPR_SET_SET:
+    {
+        ti_field_t * field = ti_vset_field((ti_vset_t *) a);
+        _Bool unrestricted = !field || field->nested_spec == TI_SPEC_ANY;
         /*
          * The resulting set will only contain thing which are already
          * available in both `a` and `b`, therefore a "shortcut" can be made
@@ -37,8 +40,7 @@ static int opr__and(ti_val_t * a, ti_val_t ** b, ex_t * e, _Bool inplace)
         if (inplace && ti_val_test_unlocked(a, e))
             return e->nr;
 
-        if (ti_vset_is_unrestricted((ti_vset_t *) a) &&
-            (inplace || a->ref == 1))
+        if (unrestricted && (inplace || a->ref == 1))
         {
             imap_intersection_inplace(
                     VSET(a),
@@ -50,18 +52,39 @@ static int opr__and(ti_val_t * a, ti_val_t ** b, ex_t * e, _Bool inplace)
         }
         else
         {
-            ti_vset_t * vset = ti_vset_create();
-            if (!vset || imap_intersection_make(vset->imap, VSET(a), VSET(*b)))
+            imap_t * imap = imap_create();
+            if (!imap || imap_intersection_make(imap, VSET(a), VSET(*b)))
                 goto alloc_err;
-            ti_val_unsafe_drop(*b);
-            *b = (ti_val_t *) vset;
+
             if (inplace)
             {
-                vset->parent = ((ti_vset_t *) a)->parent;
-                vset->key_ = ((ti_vset_t *) a)->key_;
+                if (field && ti_field_vset_pre_assign(
+                            field,
+                            imap,
+                            ((ti_vset_t *) a)->parent,
+                            e,
+                            false /* no type check */))
+                {
+                    imap_destroy(imap, (imap_destroy_cb) ti_val_unsafe_drop);
+                    return e->nr;
+                }
+                ti_val_unsafe_drop(*b);
+                imap_destroy(VSET(a), (imap_destroy_cb) ti_val_unsafe_gc_drop);
+                VSET(a) = imap;
+                ti_incref(a);
+                *b = a;
+                return e->nr;
+            }
+            ti_val_unsafe_drop(*b);
+            *b = (ti_val_t *) ti_vset_create_imap(imap);
+            if (!*b)
+            {
+                imap_destroy(imap, (imap_destroy_cb) ti_val_unsafe_drop);
+                goto alloc_err;
             }
         }
         return e->nr;
+    }
     }
     if (ti_val_make_int(b, int_))
         ex_set_mem(e);

--- a/inc/ti/opr/oprinc.h
+++ b/inc/ti/opr/oprinc.h
@@ -4,6 +4,8 @@
 #define CAST_MAX 9223372036854775808.0
 
 #include <assert.h>
+#include <ti/datetime.h>
+#include <ti/field.h>
 #include <ti/opr.h>
 #include <ti/raw.h>
 #include <ti/val.inline.h>
@@ -11,7 +13,6 @@
 #include <ti/vfloat.h>
 #include <ti/vint.h>
 #include <ti/vset.h>
-#include <ti/datetime.h>
 #include <util/logger.h>
 
 #define TI_OPR_PERM(_a, _b) ((_a)->tp<<5|(_b)->tp)

--- a/inc/ti/opr/or.h
+++ b/inc/ti/opr/or.h
@@ -29,6 +29,9 @@ static int opr__or(ti_val_t * a, ti_val_t ** b, ex_t * e, _Bool inplace)
         break;
 
     case OPR_SET_SET:
+    {
+        ti_field_t * field = ti_vset_field((ti_vset_t *) a);
+        _Bool unrestricted = !field || field->nested_spec == TI_SPEC_ANY;
         /*
          * The resulting set might contain items from both `a` and `b`,
          * therefore a "shortcut" can only be made if `b` is not used anymore
@@ -38,9 +41,7 @@ static int opr__or(ti_val_t * a, ti_val_t ** b, ex_t * e, _Bool inplace)
         if (inplace && ti_val_test_unlocked(a, e))
             return e->nr;
 
-        if (ti_vset_is_unrestricted((ti_vset_t *) a) &&
-            (inplace || a->ref == 1) &&
-            (*b)->ref == 1)
+        if (unrestricted && (inplace || a->ref == 1) && (*b)->ref == 1)
         {
             imap_union_move(VSET(a), VSET(*b));
             ti_val_unsafe_drop(*b);
@@ -49,18 +50,39 @@ static int opr__or(ti_val_t * a, ti_val_t ** b, ex_t * e, _Bool inplace)
         }
         else
         {
-            ti_vset_t * vset = ti_vset_create();
-            if (!vset || imap_union_make(vset->imap, VSET(a), VSET(*b)))
+            imap_t * imap = imap_create();
+            if (!imap || imap_union_make(imap, VSET(a), VSET(*b)))
                 goto alloc_err;
-            ti_val_unsafe_drop(*b);
-            *b = (ti_val_t *) vset;
+
             if (inplace)
             {
-                vset->parent = ((ti_vset_t *) a)->parent;
-                vset->key_ = ((ti_vset_t *) a)->key_;
+                if (field && ti_field_vset_pre_assign(
+                            field,
+                            imap,
+                            ((ti_vset_t *) a)->parent,
+                            e,
+                            true /* do type check */))
+                {
+                    imap_destroy(imap, (imap_destroy_cb) ti_val_unsafe_drop);
+                    return e->nr;
+                }
+                ti_val_unsafe_drop(*b);
+                imap_destroy(VSET(a), (imap_destroy_cb) ti_val_unsafe_gc_drop);
+                VSET(a) = imap;
+                ti_incref(a);
+                *b = a;
+                return e->nr;
+            }
+            ti_val_unsafe_drop(*b);
+            *b = (ti_val_t *) ti_vset_create_imap(imap);
+            if (!*b)
+            {
+                imap_destroy(imap, (imap_destroy_cb) ti_val_unsafe_drop);
+                goto alloc_err;
             }
         }
         return e->nr;
+    }
     }
     if (ti_val_make_int(b, int_))
         ex_set_mem(e);

--- a/inc/ti/opr/or.h
+++ b/inc/ti/opr/or.h
@@ -35,6 +35,9 @@ static int opr__or(ti_val_t * a, ti_val_t ** b, ex_t * e, _Bool inplace)
          * and this is an in-place modification of `a`, or `a` is also not
          * used anymore.
          */
+        if (ti_val_test_unlocked(a, e))
+            return e->nr;
+
         if (ti_vset_is_unrestricted((ti_vset_t *) a) &&
             (inplace || a->ref == 1) &&
             (*b)->ref == 1)
@@ -51,6 +54,11 @@ static int opr__or(ti_val_t * a, ti_val_t ** b, ex_t * e, _Bool inplace)
                 goto alloc_err;
             ti_val_unsafe_drop(*b);
             *b = (ti_val_t *) vset;
+            if (inplace)
+            {
+                vset->parent = ((ti_vset_t *) a)->parent;
+                vset->key_ = ((ti_vset_t *) a)->key_;
+            }
         }
         return e->nr;
     }

--- a/inc/ti/opr/or.h
+++ b/inc/ti/opr/or.h
@@ -35,7 +35,7 @@ static int opr__or(ti_val_t * a, ti_val_t ** b, ex_t * e, _Bool inplace)
          * and this is an in-place modification of `a`, or `a` is also not
          * used anymore.
          */
-        if (ti_val_test_unlocked(a, e))
+        if (inplace && ti_val_test_unlocked(a, e))
             return e->nr;
 
         if (ti_vset_is_unrestricted((ti_vset_t *) a) &&

--- a/inc/ti/opr/sub.h
+++ b/inc/ti/opr/sub.h
@@ -63,6 +63,9 @@ static int opr__sub(ti_val_t * a, ti_val_t ** b, ex_t * e, _Bool inplace)
          * in `a`, therefore a "shortcut" can be made if this is an in-place
          * modification or if `a` is not used  anymore.
          */
+        if (ti_val_test_unlocked(a, e))
+            return e->nr;
+
         if (ti_vset_is_unrestricted((ti_vset_t *) a) &&
             (inplace || a->ref == 1))
         {
@@ -78,6 +81,11 @@ static int opr__sub(ti_val_t * a, ti_val_t ** b, ex_t * e, _Bool inplace)
                 goto alloc_err;
             ti_val_unsafe_drop(*b);
             *b = (ti_val_t *) vset;
+            if (inplace)
+            {
+                vset->parent = ((ti_vset_t *) a)->parent;
+                vset->key_ = ((ti_vset_t *) a)->key_;
+            }
         }
         return e->nr;
     }

--- a/inc/ti/opr/sub.h
+++ b/inc/ti/opr/sub.h
@@ -63,7 +63,7 @@ static int opr__sub(ti_val_t * a, ti_val_t ** b, ex_t * e, _Bool inplace)
          * in `a`, therefore a "shortcut" can be made if this is an in-place
          * modification or if `a` is not used  anymore.
          */
-        if (ti_val_test_unlocked(a, e))
+        if (inplace && ti_val_test_unlocked(a, e))
             return e->nr;
 
         if (ti_vset_is_unrestricted((ti_vset_t *) a) &&

--- a/inc/ti/opr/sub.h
+++ b/inc/ti/opr/sub.h
@@ -58,6 +58,9 @@ static int opr__sub(ti_val_t * a, ti_val_t ** b, ex_t * e, _Bool inplace)
         goto type_int;
 
     case OPR_SET_SET:
+    {
+        ti_field_t * field = ti_vset_field((ti_vset_t *) a);
+        _Bool unrestricted = !field || field->nested_spec == TI_SPEC_ANY;
         /*
          * The resulting set will only contain things which already exist
          * in `a`, therefore a "shortcut" can be made if this is an in-place
@@ -66,8 +69,7 @@ static int opr__sub(ti_val_t * a, ti_val_t ** b, ex_t * e, _Bool inplace)
         if (inplace && ti_val_test_unlocked(a, e))
             return e->nr;
 
-        if (ti_vset_is_unrestricted((ti_vset_t *) a) &&
-            (inplace || a->ref == 1))
+        if (unrestricted && (inplace || a->ref == 1))
         {
             imap_difference_inplace(VSET(a), VSET(*b));
             ti_val_unsafe_drop(*b);
@@ -76,18 +78,39 @@ static int opr__sub(ti_val_t * a, ti_val_t ** b, ex_t * e, _Bool inplace)
         }
         else
         {
-            ti_vset_t * vset = ti_vset_create();
-            if (!vset || imap_difference_make(vset->imap, VSET(a), VSET(*b)))
+            imap_t * imap = imap_create();
+            if (!imap || imap_difference_make(imap, VSET(a), VSET(*b)))
                 goto alloc_err;
-            ti_val_unsafe_drop(*b);
-            *b = (ti_val_t *) vset;
+
             if (inplace)
             {
-                vset->parent = ((ti_vset_t *) a)->parent;
-                vset->key_ = ((ti_vset_t *) a)->key_;
+                if (field && ti_field_vset_pre_assign(
+                            field,
+                            imap,
+                            ((ti_vset_t *) a)->parent,
+                            e,
+                            false /* no type check */))
+                {
+                    imap_destroy(imap, (imap_destroy_cb) ti_val_unsafe_drop);
+                    return e->nr;
+                }
+                ti_val_unsafe_drop(*b);
+                imap_destroy(VSET(a), (imap_destroy_cb) ti_val_unsafe_gc_drop);
+                VSET(a) = imap;
+                ti_incref(a);
+                *b = a;
+                return e->nr;
+            }
+            ti_val_unsafe_drop(*b);
+            *b = (ti_val_t *) ti_vset_create_imap(imap);
+            if (!*b)
+            {
+                imap_destroy(imap, (imap_destroy_cb) ti_val_unsafe_drop);
+                goto alloc_err;
             }
         }
         return e->nr;
+    }
     }
     assert (0);
 

--- a/inc/ti/opr/xor.h
+++ b/inc/ti/opr/xor.h
@@ -35,6 +35,9 @@ static int opr__xor(ti_val_t * a, ti_val_t ** b, ex_t * e, _Bool inplace)
          * and this is an in-place modification of `a`, or `a` is also not
          * used anymore.
          */
+        if (ti_val_test_unlocked(a, e))
+            return e->nr;
+
         if (ti_vset_is_unrestricted((ti_vset_t *) a) &&
             (inplace || a->ref == 1) &&
             (*b)->ref == 1)
@@ -54,6 +57,11 @@ static int opr__xor(ti_val_t * a, ti_val_t ** b, ex_t * e, _Bool inplace)
                 goto alloc_err;
             ti_val_unsafe_drop(*b);
             *b = (ti_val_t *) vset;
+            if (inplace)
+            {
+                vset->parent = ((ti_vset_t *) a)->parent;
+                vset->key_ = ((ti_vset_t *) a)->key_;
+            }
         }
         return e->nr;
     }

--- a/inc/ti/opr/xor.h
+++ b/inc/ti/opr/xor.h
@@ -35,7 +35,7 @@ static int opr__xor(ti_val_t * a, ti_val_t ** b, ex_t * e, _Bool inplace)
          * and this is an in-place modification of `a`, or `a` is also not
          * used anymore.
          */
-        if (ti_val_test_unlocked(a, e))
+        if (inplace && ti_val_test_unlocked(a, e))
             return e->nr;
 
         if (ti_vset_is_unrestricted((ti_vset_t *) a) &&

--- a/inc/ti/opr/xor.h
+++ b/inc/ti/opr/xor.h
@@ -2,6 +2,7 @@
 
 static int opr__xor(ti_val_t * a, ti_val_t ** b, ex_t * e, _Bool inplace)
 {
+
     int64_t int_ = 0;       /* set to 0 only to prevent warning */
     ti_opr_perm_t perm = TI_OPR_PERM(a, *b);
     switch(perm)
@@ -29,6 +30,9 @@ static int opr__xor(ti_val_t * a, ti_val_t ** b, ex_t * e, _Bool inplace)
         break;
 
     case OPR_SET_SET:
+    {
+        ti_field_t * field = ti_vset_field((ti_vset_t *) a);
+        _Bool unrestricted = !field || field->nested_spec == TI_SPEC_ANY;
         /*
          * The resulting set might contain items from both `a` and `b`,
          * therefore a "shortcut" can only be made if `b` is not used anymore
@@ -38,9 +42,7 @@ static int opr__xor(ti_val_t * a, ti_val_t ** b, ex_t * e, _Bool inplace)
         if (inplace && ti_val_test_unlocked(a, e))
             return e->nr;
 
-        if (ti_vset_is_unrestricted((ti_vset_t *) a) &&
-            (inplace || a->ref == 1) &&
-            (*b)->ref == 1)
+        if (unrestricted && (inplace || a->ref == 1) && (*b)->ref == 1)
         {
             imap_symmdiff_move(
                     VSET(a),
@@ -52,18 +54,37 @@ static int opr__xor(ti_val_t * a, ti_val_t ** b, ex_t * e, _Bool inplace)
         }
         else
         {
-            ti_vset_t * vset = ti_vset_create();
-            if (!vset || imap_symmdiff_make(vset->imap, VSET(a), VSET(*b)))
+            imap_t * imap = imap_create();
+            if (!imap || imap_symmdiff_make(imap, VSET(a), VSET(*b)))
                 goto alloc_err;
+
             ti_val_unsafe_drop(*b);
-            *b = (ti_val_t *) vset;
             if (inplace)
             {
-                vset->parent = ((ti_vset_t *) a)->parent;
-                vset->key_ = ((ti_vset_t *) a)->key_;
+                ti_incref(a);
+                *b = a;
+                if (field && ti_field_vset_pre_assign(
+                            field,
+                            imap,
+                            ((ti_vset_t *) a)->parent,
+                            e))
+                {
+                    imap_destroy(imap, (imap_destroy_cb) ti_val_unsafe_drop);
+                    return e->nr;
+                }
+                imap_destroy(VSET(a), (imap_destroy_cb) ti_val_unsafe_gc_drop);
+                VSET(a) = imap;
+                return e->nr;
+            }
+            *b = (ti_val_t *) ti_vset_create_imap(imap);
+            if (!*b)
+            {
+                imap_destroy(imap, (imap_destroy_cb) ti_val_unsafe_drop);
+                goto alloc_err;
             }
         }
         return e->nr;
+    }
     }
     if (ti_val_make_int(b, int_))
         ex_set_mem(e);

--- a/inc/ti/opr/xor.h
+++ b/inc/ti/opr/xor.h
@@ -58,24 +58,26 @@ static int opr__xor(ti_val_t * a, ti_val_t ** b, ex_t * e, _Bool inplace)
             if (!imap || imap_symmdiff_make(imap, VSET(a), VSET(*b)))
                 goto alloc_err;
 
-            ti_val_unsafe_drop(*b);
             if (inplace)
             {
-                ti_incref(a);
-                *b = a;
                 if (field && ti_field_vset_pre_assign(
                             field,
                             imap,
                             ((ti_vset_t *) a)->parent,
-                            e))
+                            e,
+                            true /* do type check */))
                 {
                     imap_destroy(imap, (imap_destroy_cb) ti_val_unsafe_drop);
                     return e->nr;
                 }
+                ti_val_unsafe_drop(*b);
                 imap_destroy(VSET(a), (imap_destroy_cb) ti_val_unsafe_gc_drop);
                 VSET(a) = imap;
+                ti_incref(a);
+                *b = a;
                 return e->nr;
             }
+            ti_val_unsafe_drop(*b);
             *b = (ti_val_t *) ti_vset_create_imap(imap);
             if (!*b)
             {

--- a/inc/ti/prop.h
+++ b/inc/ti/prop.h
@@ -11,6 +11,7 @@
 ti_prop_t * ti_prop_create(ti_name_t * name, ti_val_t * val);
 ti_prop_t * ti_prop_dup(ti_prop_t * prop);
 void ti_prop_destroy(ti_prop_t * prop);
+void ti_prop_unassign_destroy(ti_prop_t * prop);
 void ti_prop_unsafe_vdestroy(ti_prop_t * prop);
 
 #endif /* TI_PROP_H_ */

--- a/inc/ti/query.inline.h
+++ b/inc/ti/query.inline.h
@@ -10,6 +10,8 @@
 #include <ti/qcache.h>
 #include <ti/query.h>
 #include <ti/vtask.t.h>
+#include <ti/vset.h>
+#include <ti/varr.inline.h>
 #include <util/vec.h>
 
 static inline vec_t * ti_query_access(ti_query_t * query)
@@ -68,6 +70,24 @@ static inline uint64_t ti_query_scope_id(ti_query_t * query)
             : (query->qbind.flags & TI_QBIND_FLAG_THINGSDB)
             ? TI_SCOPE_THINGSDB
             : TI_SCOPE_NODE;
+}
+
+static inline int ti_query_test_vset_operation(ti_query_t * query, ex_t * e)
+{
+    if (!query->change && ti_vset_is_stored((ti_vset_t *) query->rval))
+        ex_set(e, EX_OPERATION,
+                "operation on a stored set; "
+                "use `wse(...)` to enforce a change");
+    return e->nr;
+}
+
+static inline int ti_query_test_varr_operation(ti_query_t * query, ex_t * e)
+{
+    if (!query->change && ti_varr_is_stored((ti_varr_t *) query->rval))
+        ex_set(e, EX_OPERATION,
+                "operation on a stored list; "
+                "use `wse(...)` to enforce a change");
+    return e->nr;
 }
 
 #endif  /* TI_QUERY_INLINE_H_ */

--- a/inc/ti/thing.h
+++ b/inc/ti/thing.h
@@ -52,10 +52,20 @@ ti_prop_t * ti_thing_p_prop_add(    /* only when property does not exists */
         ti_thing_t * thing,
         ti_name_t * name,
         ti_val_t * val);
+int ti_thing_p_prop_add_assign(
+        ti_thing_t * thing,
+        ti_name_t * name,
+        ti_val_t * val,
+        ex_t * e);
 ti_item_t * ti_thing_i_item_add(
         ti_thing_t * thing,
         ti_raw_t * key,
         ti_val_t * val);
+int ti_thing_i_item_add_assign(
+        ti_thing_t * thing,
+        ti_raw_t * key,
+        ti_val_t * val,
+        ex_t * e);
 ti_prop_t * ti_thing_p_prop_set(
         ti_thing_t * thing,
         ti_name_t * name,

--- a/inc/ti/thing.inline.h
+++ b/inc/ti/thing.inline.h
@@ -111,6 +111,16 @@ static inline ti_val_t * ti_thing_p_val_weak_get(
     return NULL;
 }
 
+static inline ti_val_t ** ti_thing_p_val_addr_get(
+        ti_thing_t * thing,
+        ti_name_t * name)
+{
+    for (vec_each(thing->items.vec, ti_prop_t, prop))
+        if (prop->name == name)
+            return &prop->val;
+    return NULL;
+}
+
 static inline ti_val_t * ti_thing_o_val_weak_get(
         ti_thing_t * thing,
         ti_name_t * name)
@@ -119,6 +129,18 @@ static inline ti_val_t * ti_thing_o_val_weak_get(
     {
         ti_item_t * item = smap_get(thing->items.smap, name->str);
         return item ? item->val : NULL;
+    }
+    return ti_thing_p_val_weak_get(thing, name);
+}
+
+static inline ti_val_t ** ti_thing_o_val_addr_get(
+        ti_thing_t * thing,
+        ti_name_t * name)
+{
+    if (ti_thing_is_dict(thing))
+    {
+        ti_item_t * item = smap_get(thing->items.smap, name->str);
+        return item ? &item->val : NULL;
     }
     return ti_thing_p_val_weak_get(thing, name);
 }
@@ -138,6 +160,15 @@ static inline ti_val_t * ti_thing_t_val_weak_get(
 static inline ti_val_t * ti_thing_val_weak_by_name(
         ti_thing_t * thing,
         ti_name_t * name)
+{
+    return ti_thing_is_object(thing)
+            ? ti_thing_o_val_weak_get(thing, name)
+            : ti_thing_t_val_weak_get(thing, name);
+}
+
+static inline ti_val_t * ti_thing_val_addr_by_key(
+        ti_thing_t * thing,
+        void * key)
 {
     return ti_thing_is_object(thing)
             ? ti_thing_o_val_weak_get(thing, name)

--- a/inc/ti/thing.inline.h
+++ b/inc/ti/thing.inline.h
@@ -111,16 +111,6 @@ static inline ti_val_t * ti_thing_p_val_weak_get(
     return NULL;
 }
 
-static inline ti_val_t ** ti_thing_p_val_addr_get(
-        ti_thing_t * thing,
-        ti_name_t * name)
-{
-    for (vec_each(thing->items.vec, ti_prop_t, prop))
-        if (prop->name == name)
-            return &prop->val;
-    return NULL;
-}
-
 static inline ti_val_t * ti_thing_o_val_weak_get(
         ti_thing_t * thing,
         ti_name_t * name)
@@ -129,18 +119,6 @@ static inline ti_val_t * ti_thing_o_val_weak_get(
     {
         ti_item_t * item = smap_get(thing->items.smap, name->str);
         return item ? item->val : NULL;
-    }
-    return ti_thing_p_val_weak_get(thing, name);
-}
-
-static inline ti_val_t ** ti_thing_o_val_addr_get(
-        ti_thing_t * thing,
-        ti_name_t * name)
-{
-    if (ti_thing_is_dict(thing))
-    {
-        ti_item_t * item = smap_get(thing->items.smap, name->str);
-        return item ? &item->val : NULL;
     }
     return ti_thing_p_val_weak_get(thing, name);
 }
@@ -160,15 +138,6 @@ static inline ti_val_t * ti_thing_t_val_weak_get(
 static inline ti_val_t * ti_thing_val_weak_by_name(
         ti_thing_t * thing,
         ti_name_t * name)
-{
-    return ti_thing_is_object(thing)
-            ? ti_thing_o_val_weak_get(thing, name)
-            : ti_thing_t_val_weak_get(thing, name);
-}
-
-static inline ti_val_t * ti_thing_val_addr_by_key(
-        ti_thing_t * thing,
-        void * key)
 {
     return ti_thing_is_object(thing)
             ? ti_thing_o_val_weak_get(thing, name)

--- a/inc/ti/val.inline.h
+++ b/inc/ti/val.inline.h
@@ -880,6 +880,19 @@ static inline int ti_val_try_lock(ti_val_t * val, ex_t * e)
     return (val->flags |= TI_VFLAG_LOCK) & 0;
 }
 
+
+static inline int ti_val_test_unlocked(ti_val_t * val, ex_t * e)
+{
+    if (val->flags & TI_VFLAG_LOCK)
+    {
+        ex_set(e, EX_OPERATION,
+            "cannot change type `%s` while the value is in use",
+            ti_val_str(val));
+        return -1;
+    }
+    return 0;
+}
+
 /*
  * Returns `lock_was_set`: 0 if already locked, 1 if a new lock is set
  *

--- a/inc/ti/val.inline.h
+++ b/inc/ti/val.inline.h
@@ -523,6 +523,16 @@ static inline void ti_val_unassign_unsafe_drop(ti_val_t * val)
         ti_thing_may_push_gc((ti_thing_t *) val);
 }
 
+static inline void ti_val_replace_drop(ti_val_t * oval, ti_val_t * nval)
+{
+    if (!--oval->ref)
+        ti_val(oval)->destroy(oval);
+    else if (oval != nval && (oval->tp == TI_VAL_SET || oval->tp == TI_VAL_ARR))
+        ((ti_varr_t *) oval)->parent = NULL;
+    else
+        ti_thing_may_push_gc((ti_thing_t *) oval);
+}
+
 static inline void ti_val_unassign_drop(ti_val_t * val)
 {
     if (val)

--- a/inc/ti/val.inline.h
+++ b/inc/ti/val.inline.h
@@ -1019,47 +1019,6 @@ static inline int ti_val_make_assignable(
     return -1;
 }
 
-static inline int ti_val_make_variable(ti_val_t ** val, ex_t * e)
-{
-    switch ((ti_val_enum) (*val)->tp)
-    {
-    case TI_VAL_NIL:
-    case TI_VAL_INT:
-    case TI_VAL_FLOAT:
-    case TI_VAL_BOOL:
-    case TI_VAL_DATETIME:
-    case TI_VAL_MPDATA:
-    case TI_VAL_NAME:
-    case TI_VAL_STR:
-    case TI_VAL_BYTES:
-    case TI_VAL_REGEX:
-    case TI_VAL_THING:
-    case TI_VAL_WRAP:
-    case TI_VAL_ROOM:
-    case TI_VAL_TASK:
-    case TI_VAL_ERROR:
-    case TI_VAL_MEMBER:
-    case TI_VAL_FUTURE:
-        return 0;
-    case TI_VAL_ARR:
-        if (((ti_varr_t *) *val)->parent &&
-            ti_varr_is_list((ti_varr_t *) *val) &&
-            ti_varr_to_list((ti_varr_t **) val))
-            ex_set_mem(e);
-        return e->nr;
-    case TI_VAL_SET:
-        if (((ti_vset_t *) *val)->parent && ti_vset_assign((ti_vset_t **) val))
-            ex_set_mem(e);
-        return e->nr;
-    case TI_VAL_CLOSURE:
-        return ti_closure_unbound((ti_closure_t * ) *val, e);
-    case TI_VAL_TEMPLATE:
-        break;
-    }
-    assert(0);
-    return -1;
-}
-
 static inline int val__str_to_str(ti_val_t ** UNUSED(v), ex_t * UNUSED(e))
 {
     return 0;

--- a/inc/ti/varr.h
+++ b/inc/ti/varr.h
@@ -19,6 +19,7 @@ ti_varr_t * ti_varr_from_slice(
         ssize_t start,
         ssize_t stop,
         ssize_t step);
+ti_varr_t * ti_varr_cp(ti_varr_t * varr);
 void ti_varr_destroy(ti_varr_t * varr);
 int ti_varr_to_list(ti_varr_t ** varr);
 int ti_varr_copy(ti_varr_t ** varr, uint8_t deep);

--- a/inc/ti/varr.inline.h
+++ b/inc/ti/varr.inline.h
@@ -14,8 +14,6 @@
 #include <util/mpack.h>
 #include <util/vec.h>
 
-static inline int ti_val_varr_prepare(ti_val_t ** v, ti_varr_t * to, ex_t * e);
-
 static inline _Bool ti_varr_may_have_things(ti_varr_t * varr)
 {
     return varr->flags & TI_VARR_FLAG_MHT;
@@ -65,6 +63,11 @@ static inline void * ti_varr_key(ti_varr_t * varr)
 static inline void ti_varr_set_may_flags(ti_varr_t * to, ti_varr_t * from)
 {
     to->flags |= from->flags & (TI_VARR_FLAG_MHT|TI_VARR_FLAG_MHR);
+}
+
+static inline _Bool ti_varr_is_stored(ti_varr_t * varr)
+{
+    return varr->parent && varr->parent->id;
 }
 
 #endif  /* TI_RAW_INLINE_H_ */

--- a/inc/ti/version.h
+++ b/inc/ti/version.h
@@ -25,7 +25,7 @@
  *  "-rc0"
  *  ""
  */
-#define TI_VERSION_PRE_RELEASE "-alpha0"
+#define TI_VERSION_PRE_RELEASE "-alpha1"
 
 #define TI_MAINTAINER \
     "Jeroen van der Heijden <jeroen@cesbit.com>"

--- a/inc/ti/version.h
+++ b/inc/ti/version.h
@@ -6,7 +6,7 @@
 
 #define TI_VERSION_MAJOR 1
 #define TI_VERSION_MINOR 3
-#define TI_VERSION_PATCH 3
+#define TI_VERSION_PATCH 4
 
 /* The syntax version is used to test compatibility with functions
  * using the `ti_nodes_check_syntax()` function */
@@ -25,7 +25,7 @@
  *  "-rc0"
  *  ""
  */
-#define TI_VERSION_PRE_RELEASE ""
+#define TI_VERSION_PRE_RELEASE "-alpha0"
 
 #define TI_MAINTAINER \
     "Jeroen van der Heijden <jeroen@cesbit.com>"

--- a/inc/ti/version.h
+++ b/inc/ti/version.h
@@ -25,7 +25,7 @@
  *  "-rc0"
  *  ""
  */
-#define TI_VERSION_PRE_RELEASE "-alpha2"
+#define TI_VERSION_PRE_RELEASE "-alpha3"
 
 #define TI_MAINTAINER \
     "Jeroen van der Heijden <jeroen@cesbit.com>"

--- a/inc/ti/version.h
+++ b/inc/ti/version.h
@@ -5,8 +5,8 @@
 #define TI_VERSION_H_
 
 #define TI_VERSION_MAJOR 1
-#define TI_VERSION_MINOR 3
-#define TI_VERSION_PATCH 4
+#define TI_VERSION_MINOR 4
+#define TI_VERSION_PATCH 0
 
 /* The syntax version is used to test compatibility with functions
  * using the `ti_nodes_check_syntax()` function */
@@ -25,7 +25,7 @@
  *  "-rc0"
  *  ""
  */
-#define TI_VERSION_PRE_RELEASE "-alpha1"
+#define TI_VERSION_PRE_RELEASE "-alpha0"
 
 #define TI_MAINTAINER \
     "Jeroen van der Heijden <jeroen@cesbit.com>"

--- a/inc/ti/version.h
+++ b/inc/ti/version.h
@@ -25,7 +25,7 @@
  *  "-rc0"
  *  ""
  */
-#define TI_VERSION_PRE_RELEASE "-alpha0"
+#define TI_VERSION_PRE_RELEASE "-alpha2"
 
 #define TI_MAINTAINER \
     "Jeroen van der Heijden <jeroen@cesbit.com>"

--- a/inc/ti/vset.h
+++ b/inc/ti/vset.h
@@ -17,6 +17,7 @@ typedef struct ti_vset_s ti_vset_t;
 #include <util/mpack.h>
 
 ti_vset_t * ti_vset_create(void);
+ti_vset_t * ti_vset_create_imap(imap_t * imap);
 void ti_vset_destroy(ti_vset_t * vset);
 int ti_vset_to_client_pk(ti_vset_t * vset, ti_vp_t * vp, int deep, int flags);
 int ti_vset_to_store_pk(ti_vset_t * vset, msgpack_packer * pk);
@@ -109,6 +110,13 @@ static inline _Bool ti_vset_is_unrestricted(ti_vset_t * vset)
 static inline _Bool ti_vset_is_stored(ti_vset_t * vset)
 {
     return vset->parent && vset->parent->id;
+}
+
+static inline void * ti_vset_field(ti_vset_t * vset)
+{
+    return vset->parent && ti_thing_is_instance(vset->parent)
+        ? vset->key_
+        : NULL;
 }
 
 #endif  /* TI_VSET_H_ */

--- a/inc/ti/vset.h
+++ b/inc/ti/vset.h
@@ -23,6 +23,7 @@ int ti_vset_to_store_pk(ti_vset_t * vset, msgpack_packer * pk);
 int ti_vset_to_list(ti_vset_t ** vsetaddr);
 int ti_vset_to_tuple(ti_vset_t ** vsetaddr);
 int ti_vset_to_file(ti_vset_t * vset, FILE * f);
+ti_vset_t * ti_vset_cp(ti_vset_t * vset);
 int ti_vset_assign(ti_vset_t ** vsetaddr);
 int ti_vset_copy(ti_vset_t ** vsetaddr, uint8_t deep);
 int ti_vset_dup(ti_vset_t ** vsetaddr, uint8_t deep);

--- a/inc/ti/vset.h
+++ b/inc/ti/vset.h
@@ -100,13 +100,6 @@ static inline _Bool ti_vset_has_relation(ti_vset_t * vset)
             ((ti_field_t *) vset->key_)->condition.rel;
 }
 
-static inline _Bool ti_vset_is_unrestricted(ti_vset_t * vset)
-{
-    return !vset->parent ||
-           !ti_thing_is_instance(vset->parent) ||
-            ((ti_field_t *) vset->key_)->nested_spec == TI_SPEC_ANY;
-}
-
 static inline _Bool ti_vset_is_stored(ti_vset_t * vset)
 {
     return vset->parent && vset->parent->id;

--- a/inc/ti/vset.h
+++ b/inc/ti/vset.h
@@ -106,4 +106,9 @@ static inline _Bool ti_vset_is_unrestricted(ti_vset_t * vset)
             ((ti_field_t *) vset->key_)->nested_spec == TI_SPEC_ANY;
 }
 
+static inline _Bool ti_vset_is_stored(ti_vset_t * vset)
+{
+    return vset->parent && vset->parent->id;
+}
+
 #endif  /* TI_VSET_H_ */

--- a/itest/test_advanced.py
+++ b/itest/test_advanced.py
@@ -2176,6 +2176,23 @@ new_procedure('multiply', |a, b| a * b);
         """)
         self.assertEqual(res, [1, 2, 3])
 
+    async def test_fast_set_update(self, client):
+        res = await client.query("""//ti
+            .myarr = [
+                {name: 'a'},
+                {name: 'b'},
+                {name: 'c'},
+                {name: 'd'},
+                {name: 'e'}];
+            .myset = set(.myarr[:2]);
+
+            s = .myset;
+            s ^= set(.myarr);
+
+            .myset.len();
+        """)
+        self.assertEqual(res, 3)
+
 
 if __name__ == '__main__':
     run_test(TestAdvanced())

--- a/itest/test_advanced.py
+++ b/itest/test_advanced.py
@@ -1207,14 +1207,14 @@ class TestAdvanced(TestBase):
             run('add', .arr, 3);
             .arr;
         ''')
-        self.assertEqual(res, list(range(3)))
+        self.assertEqual(res, list(range(4)))
 
         res = await client.query('''
             .arr = range(5);
             (|arr, v| arr.push(v)).call(.arr, 5);
             .arr;
         ''')
-        self.assertEqual(res, list(range(5)))
+        self.assertEqual(res, list(range(6)))
 
     async def test_type_mod(self, client):
         await client.query('''
@@ -2165,6 +2165,16 @@ new_procedure('multiply', |a, b| a * b);
             "OK";
         """)
 
+    async def test_filter_assign(self, client):
+        res = await client.query("""//ti
+            a = {
+                arr: [1, 2, 3]
+            };
+            b = a.filter(||true);
+            b.arr.push(4);
+            a.arr;
+        """)
+        self.assertEqual(res, [1, 2, 3])
 
 if __name__ == '__main__':
     run_test(TestAdvanced())

--- a/itest/test_advanced.py
+++ b/itest/test_advanced.py
@@ -1766,7 +1766,7 @@ new_procedure('multiply', |a, b| a * b);
         with self.assertRaisesRegex(
                 TypeError,
                 r"mismatch in type `A` on property `b`; "
-                r"relations must be created using the property on a "
+                r"relations must be created using a property on a "
                 r"stored thing \(a thing with an Id\)"):
             res = await client.query(r"""//ti
                 b = B{name: 'mr B'};

--- a/itest/test_collection_functions.py
+++ b/itest/test_collection_functions.py
@@ -154,6 +154,12 @@ class TestCollectionFunctions(TestBase):
                 'cannot add type `nil` to a set'):
             await client.query(r'.s.add(.a, .b, {}, nil);')
 
+        with self.assertRaisesRegex(
+                OperationError,
+                'operation on a stored set; '
+                r'use `wse\(...\)` to enforce a change'):
+            await client.query('s = .s; s.add({});')
+
     async def test_clear_set(self, client):
         await client.query(r'.s = set(); .a = {}; .b = {}; .c = {};')
         self.assertEqual(
@@ -1001,6 +1007,12 @@ class TestCollectionFunctions(TestBase):
                 OperationError,
                 r'cannot change type `list` while the value is in use'):
             await client.query('.list.map(||.list.extend([4]));')
+
+        with self.assertRaisesRegex(
+                OperationError,
+                'operation on a stored list; '
+                r'use `wse\(...\)` to enforce a change'):
+            await client.query('a = .list; a.extend([123]);')
 
     async def test_filter(self, client):
         await client.query(r'''
@@ -2814,6 +2826,12 @@ class TestCollectionFunctions(TestBase):
             """)
         self.assertEqual(await client.query('.a.arr;'), ['foo', 'bar'])
 
+        with self.assertRaisesRegex(
+                OperationError,
+                'operation on a stored list; '
+                r'use `wse\(...\)` to enforce a change'):
+            await client.query('a = .a.arr; a.extend_unique([123]);')
+
     async def test_pop(self, client):
         await client.query('.list = [1, 2, 3];')
         self.assertEqual(await client.query('.list.pop()'), 3)
@@ -2845,6 +2863,12 @@ class TestCollectionFunctions(TestBase):
                 LookupError,
                 'pop from empty list'):
             await client.query('[].pop();')
+
+        with self.assertRaisesRegex(
+                OperationError,
+                'operation on a stored list; '
+                r'use `wse\(...\)` to enforce a change'):
+            await client.query('a = .a; a.pop();')
 
     async def test_shift(self, client):
         await client.query('.list = [1, 2, 3];')
@@ -2878,6 +2902,12 @@ class TestCollectionFunctions(TestBase):
                 'shift from empty list'):
             await client.query('[].shift();')
 
+        with self.assertRaisesRegex(
+                OperationError,
+                'operation on a stored list; '
+                r'use `wse\(...\)` to enforce a change'):
+            await client.query('a = .a; a.shift();')
+
     async def test_push(self, client):
         await client.query('.list = [];')
         self.assertEqual(await client.query('.list.push("a")'), 1)
@@ -2905,6 +2935,12 @@ class TestCollectionFunctions(TestBase):
                 r'cannot change type `list` while the value is in use'):
             await client.query('.list.map(||.list.push(4));')
 
+        with self.assertRaisesRegex(
+                OperationError,
+                'operation on a stored list; '
+                r'use `wse\(...\)` to enforce a change'):
+            await client.query('a = .a; a.push(123);')
+
     async def test_unshift(self, client):
         await client.query('.list = [];')
         self.assertEqual(await client.query('.list.unshift("c")'), 1)
@@ -2931,6 +2967,12 @@ class TestCollectionFunctions(TestBase):
                 OperationError,
                 r'cannot change type `list` while the value is in use'):
             await client.query('.list.map(||.list.unshift(4));')
+
+        with self.assertRaisesRegex(
+                OperationError,
+                'operation on a stored list; '
+                r'use `wse\(...\)` to enforce a change'):
+            await client.query('a = .a; a.unshift(123);')
 
     async def test_raise(self, client):
         with self.assertRaisesRegex(

--- a/itest/test_nested.py
+++ b/itest/test_nested.py
@@ -52,12 +52,12 @@ class TestNested(TestBase):
         await client0.query(r'''
             .arr = [1, 2];
             .map(|k, v| {
-                v.push(3, 4);  // changes the copy, not the original
+                v.push(3, 4);  // this is a reference
             });
         ''')
         await asyncio.sleep(0.1)
         for client in (client0, client1, client2):
-            self.assertEqual(await client.query('.arr'), [1, 2])
+            self.assertEqual(await client.query('.arr'), [1, 2, 3, 4])
 
     async def test_set_and_push(self, client0, client1, client2):
         await client0.query(r'''
@@ -108,11 +108,11 @@ class TestNested(TestBase):
             arr = .arr;
             arr.push(4);
             .arr;
-        '''), [1, 2, 3])
+        '''), [1, 2, 3, 4])
 
         await asyncio.sleep(0.1)
         for client in (client0, client1, client2):
-            self.assertEqual(await client.query('.arr'), [1, 2, 3])
+            self.assertEqual(await client.query('.arr'), [1, 2, 3, 4])
 
     async def test_assign_pop(self, client0, client1, client2):
         await client0.query(r'''

--- a/itest/test_nested.py
+++ b/itest/test_nested.py
@@ -48,7 +48,7 @@ class TestNested(TestBase):
             client.close()
             await client.wait_closed()
 
-    async def test_push_loop(self, client0, client1, client2):
+    async def _test_push_loop(self, client0, client1, client2):
         await client0.query(r'''
             .arr = [1, 2];
             .map(|k, v| {
@@ -59,7 +59,7 @@ class TestNested(TestBase):
         for client in (client0, client1, client2):
             self.assertEqual(await client.query('.arr'), [1, 2, 3, 4])
 
-    async def test_set_and_push(self, client0, client1, client2):
+    async def _test_set_and_push(self, client0, client1, client2):
         await client0.query(r'''
             .set("arr", []).push(1, 2, 3, 4);
         ''')
@@ -67,7 +67,7 @@ class TestNested(TestBase):
         for client in (client0, client1, client2):
             self.assertEqual(await client.query('.arr'), [1, 2, 3, 4])
 
-    async def test_get_and_push(self, client0, client1, client2):
+    async def _test_get_and_push(self, client0, client1, client2):
         await client0.query(r'''
             .arr = [1, 2];
             .get('arr').push(3, 4);
@@ -76,7 +76,7 @@ class TestNested(TestBase):
         for client in (client0, client1, client2):
             self.assertEqual(await client.query('.arr'), [1, 2, 3, 4])
 
-    async def test_var_assign(self, client0, client1, client2):
+    async def _test_var_assign(self, client0, client1, client2):
         self.assertEqual(await client0.query(r'''
             .a = {};
             tmp = .a;
@@ -88,7 +88,7 @@ class TestNested(TestBase):
         for client in (client0, client1, client2):
             self.assertEqual(await client.query('.a.test'), 'Test')
 
-    async def test_var_assign_del(self, client0, client1, client2):
+    async def _test_var_assign_del(self, client0, client1, client2):
         self.assertEqual(await client0.query(r'''
             .a = {};
             tmp = .a;
@@ -101,7 +101,7 @@ class TestNested(TestBase):
         for client in (client0, client1, client2):
             self.assertEqual(await client.query('.b'), 'Test')
 
-    async def test_tmp_push(self, client0, client1, client2):
+    async def _test_tmp_push(self, client0, client1, client2):
         # Copy is made so the `push` should not create an event
         self.assertEqual(await client0.query(r'''
             .arr = [1, 2, 3];
@@ -114,7 +114,7 @@ class TestNested(TestBase):
         for client in (client0, client1, client2):
             self.assertEqual(await client.query('.arr'), [1, 2, 3, 4])
 
-    async def test_assign_pop(self, client0, client1, client2):
+    async def _test_assign_pop(self, client0, client1, client2):
         await client0.query(r'''
             .arr = [{
                 name: 'Iris'
@@ -128,7 +128,7 @@ class TestNested(TestBase):
         for client in (client0, client1, client2):
             self.assertEqual(await client.query('.arr'), [])
 
-    async def test_ret_val(self, client0, client1, client2):
+    async def _test_ret_val(self, client0, client1, client2):
         await client0.query(r'''
             .arr = [];
             .g = ||.arr;
@@ -142,7 +142,7 @@ class TestNested(TestBase):
             # This should be [123] or at least [] at all nodes
             self.assertEqual(await client.query('.arr'), [123])
 
-    async def test_assign_del(self, client0, client1, client2):
+    async def _test_assign_del(self, client0, client1, client2):
         await client0.query(r"""//ti
             .x = {
                 y: {
@@ -167,7 +167,7 @@ class TestNested(TestBase):
             x = await client.query('.x')
             self.assertEqual(x['test'], 'Test')
 
-    async def test_nested_pop(self, client0, client1, client2):
+    async def _test_nested_pop(self, client0, client1, client2):
         await client0.query(r"""//ti
             .arr = [[{
                 name: 'Iris'
@@ -181,7 +181,7 @@ class TestNested(TestBase):
         for client in (client0, client1, client2):
             self.assertEqual(await client.query('.arr'), [])
 
-    async def test_list_lock_assign(self, client0, client1, client2):
+    async def _test_list_lock_assign(self, client0, client1, client2):
         with self.assertRaisesRegex(
                 OperationError,
                 r'cannot change or remove property `arr` on `#\d+` while '
@@ -194,7 +194,7 @@ class TestNested(TestBase):
                 })
             """)
 
-    async def test_list_lock_del(self, client0, client1, client2):
+    async def _test_list_lock_del(self, client0, client1, client2):
         with self.assertRaisesRegex(
                 OperationError,
                 r'cannot change or remove property `arr` on `#\d+` while '
@@ -207,7 +207,7 @@ class TestNested(TestBase):
                 })
             ''')
 
-    async def test_assign_after_del(self, client0, client1, client2):
+    async def _test_assign_after_del(self, client0, client1, client2):
         await client0.query(r'''
             .a = {name: 'Iris'};
             tmp = .a;
@@ -220,7 +220,7 @@ class TestNested(TestBase):
             iris = await client.query('.b')
             self.assertEqual(iris['name'], 'Iris')
 
-    async def test_assign_after_del_split(self, client0, client1, client2):
+    async def _test_assign_after_del_split(self, client0, client1, client2):
         await client0.query(r'''
             .a = {name: 'Iris'};
             .store = {};
@@ -237,7 +237,7 @@ class TestNested(TestBase):
             iris = await client.query('.store.a')
             self.assertEqual(iris['name'], 'Iris')
 
-    async def test_complex_assign_list(self, client0, client1, client2):
+    async def _test_complex_assign_list(self, client0, client1, client2):
         with self.assertRaisesRegex(
                 OperationError,
                 r'cannot change or remove property `a` on `#\d+` while '
@@ -262,7 +262,7 @@ class TestNested(TestBase):
                 });
             ''')
 
-    async def test_complex_assign_set(self, client0, client1, client2):
+    async def _test_complex_assign_set(self, client0, client1, client2):
         with self.assertRaisesRegex(
                 OperationError,
                 r'cannot change or remove property `a` on `#\d+` while '
@@ -287,7 +287,7 @@ class TestNested(TestBase):
                 });
             ''')
 
-    async def test_nested_closure_query(self, client0, client1, client2):
+    async def _test_nested_closure_query(self, client0, client1, client2):
         usera, userb = await client0.query(r'''
             .channel = {};
             .workspace = {channels: [.channel]};
@@ -328,7 +328,7 @@ class TestNested(TestBase):
             );
         '''), [userb])
 
-    async def test_set_assign_and_rm_props(self, client0, client1, client2):
+    async def _test_set_assign_and_rm_props(self, client0, client1, client2):
         await client0.query(r'''
             x = {n: 0}; y = {n: 1}; z = {n: 2};
             .a = set(x, y);
@@ -363,7 +363,7 @@ class TestNested(TestBase):
             res = await client.query(r'.t1.len() + .t2.len();')
             self.assertEqual(res, 0)
 
-    async def test_ids(self, client0, client1, client2):
+    async def _test_ids(self, client0, client1, client2):
         nones, ids = await client0.query(r'''
             a = {b: {c: {}}};
             a.b.c.d = {};
@@ -401,11 +401,6 @@ class TestNested(TestBase):
         """)
 
         await client0.query(r"""//ti
-            a = .myarr;
-            wse(a.pop());
-        """)
-
-        await client0.query(r"""//ti
             s = .myset;
             wse(s.add(.myarr[0], .myarr[1]));
         """)
@@ -415,18 +410,52 @@ class TestNested(TestBase):
             wse(s ^= set(.myarr));
         """)
 
+        res = await client0.query("""//ti
+            .a1 = [1, 2, 3];
+            .a2 = .a1;
+            .a3 = .a2;
+            a1 = .a1;
+            a2 = .a2;
+            a3 = .a3;
+            .a1 = [2, 3, 4];
+            .assign({a2: [3, 4, 5]})
+            .set('a3', [4, 5, 6])
+
+            a1.push(7);
+            a2.push(8);
+            a3.push(9);
+            [.a1, .a2, .a3];
+        """)
+        self.assertEqual(res, [
+            [2, 3, 4],
+            [3, 4, 5],
+            [4, 5, 6],
+        ])
+
         ids = await client0.query('.myarr.map_id();')
         self.assertEqual(len(ids), 5)
 
         await asyncio.sleep(1.0)
         for client in (client0, client1, client2):
-            size, myset = await client.query('[.myarr.len(), .myset;')
+            size, myset = await client.query('[.myarr.len(), .myset];')
             self.assertEqual(size, 5)
-            self.assertEqual(set(myset), {
+            self.assertEqual(len(myset), 3)
+            self.assertEqual(sorted(myset, key=lambda x: x['name']), [
                 {'#': ids[2], 'name': 'c'},
                 {'#': ids[3], 'name': 'd'},
                 {'#': ids[4], 'name': 'e'},
-            })
+            ])
+            res = await client.query("[.a1, .a2, .a3];")
+            self.assertEqual(res, [
+                [2, 3, 4],
+                [3, 4, 5],
+                [4, 5, 6],
+            ])
+
+        await client0.query(r"""//ti
+            a = .myarr;
+            wse(a.pop());
+        """)
 
 
 if __name__ == '__main__':

--- a/itest/test_relations.py
+++ b/itest/test_relations.py
@@ -1436,10 +1436,7 @@ mod_type('D', 'rel', 'da', 'db');
         ''')
 
         err_msg = (
-            r'failed to create relation; '
-            r'relations between stored and non-stored things must be '
-            r'created using the property on the the stored thing '
-            r'\(the thing with an ID\)')
+            r'xxx')
 
         with self.assertRaisesRegex(TypeError, err_msg):
             await client.query(r'''

--- a/itest/test_relations.py
+++ b/itest/test_relations.py
@@ -215,9 +215,8 @@ class TestRelations(TestBase):
         with self.assertRaisesRegex(
                 TypeError,
                 r'failed to create relation; '
-                r'property `cx` on a `thing` is referring to a second '
-                r'`thing` while property `cy` on that second thing is '
-                r'referring to a third `thing`'):
+                r'relations must be created using the property on a stored '
+                r'thing \(a thing with an Id\)'):
             await client.query(r'''
                 c1 = C{};
                 c2 = C{};
@@ -230,33 +229,16 @@ class TestRelations(TestBase):
         with self.assertRaisesRegex(
                 TypeError,
                 r'failed to create relation; '
-                r'property `cy` on a `thing` is referring to a second '
-                r'`thing` while property `cx` on that second thing is '
-                r'referring to a third `thing`'):
+                r'property `cy` on `#\d+` is referring to `#\d+` '
+                r'while property `cx` on `#\d+` is '
+                r'referring to `#\d+`'):
             await client.query(r'''
-                c1 = C{};
-                c2 = C{};
-                c1.cx = c2;
-                c1.cy = c1;
+                .c1 = C{};
+                .c2 = C{};
+                .c1.cx = .c2;
+                .c1.cy = .c1;
 
                 mod_type('C', 'rel', 'cx', 'cy');
-            ''')
-
-        with self.assertRaisesRegex(
-                TypeError,
-                r'failed to create relation; '
-                r'property `b` on a `thing` is referring to a second '
-                r'`thing` while property `a` on that second thing is '
-                r'referring to a third `thing`'):
-            await client.query(r'''
-                a1 = A{};
-                a2 = A{};
-                b1 = B{};
-
-                a1.b = b1;
-                b1.a = a2;
-
-                mod_type('A', 'rel', 'b', 'a');
             ''')
 
         with self.assertRaisesRegex(
@@ -291,8 +273,8 @@ class TestRelations(TestBase):
 
         with self.assertRaisesRegex(
                 TypeError,
-                r'failed to create relation; at least one thing belongs to '
-                r'at least two different sets; \(property `aa` on type `B`'):
+                r'failed to create relation; relations must be created using '
+                r'the property on a stored thing \(a thing with an Id\)'):
             await client.query(r'''
                 a1 = A{};
                 b1 = B{};
@@ -332,22 +314,6 @@ class TestRelations(TestBase):
                 aa: '{A}'
             });
         ''')
-
-        with self.assertRaisesRegex(
-                TypeError,
-                r'failed to create relation; at least one thing belongs '
-                r'to a set \(`B.aa`\) of a different thing than the thing '
-                r'it is referring to \(`A.b`\)'):
-            await client.query(r'''
-                a1 = A{};
-                b1 = B{};
-                b2 = B{};
-
-                a1.b = b1;
-                b2.aa.add(a1);
-
-                mod_type('A', 'rel', 'b', 'aa');
-            ''')
 
         with self.assertRaisesRegex(
                 TypeError,
@@ -402,33 +368,20 @@ class TestRelations(TestBase):
             .c1.cc.add(.c1);
             .c2.cc.add(.c1);
 
-            a1 = A{};
-            a2 = A{};
-            b1 = B{};
-            b2 = B{};
-            c1 = C{};
-            c2 = C{};
-
-            a1.bb.add(b1, b2);
-            b1.aa.add(a1);
-            b2.aa.add(a2);
-            c1.cc.add(c1);
-            c2.cc.add(c1);
-
             mod_type('A', 'rel', 'bb', 'aa');
             mod_type('C', 'rel', 'cc', 'cc');
 
-            assert(a1.bb.has(b1));
-            assert(a1.bb.has(b2));
+            assert(.a1.bb.has(.b1));
+            assert(.a1.bb.has(.b2));
 
-            assert(!a2.bb.has(b1));
-            assert(a2.bb.has(b2));
+            assert(!.a2.bb.has(.b1));
+            assert(.a2.bb.has(.b2));
 
-            assert(b1.aa.has(a1));
-            assert(!b1.aa.has(a2));
+            assert(.b1.aa.has(.a1));
+            assert(!.b1.aa.has(.a2));
 
-            assert(b2.aa.has(a1));
-            assert(b2.aa.has(a2));
+            assert(.b2.aa.has(.a1));
+            assert(.b2.aa.has(.a2));
 
             'OK';
         '''), 'OK')
@@ -549,41 +502,9 @@ mod_type('D', 'rel', 'da', 'db');
             .d1.dx = .d2;
             .d3.dx = .d3;
 
-            a1 = A{};
-            a2 = A{};
-            a3 = A{};
-            b1 = B{};
-            b2 = B{};
-            c1 = C{};
-            c2 = C{};
-            d1 = D{};
-            d2 = D{};
-            d3 = D{};
-
-            a1.b = b1;
-            a2.b = b2;
-            b2.a = a2;
-            c1.c = c1;
-            d1.dx = d2;
-            d3.dx = d3;
-
             mod_type('A', 'rel', 'b', 'a');
             mod_type('C', 'rel', 'c', 'c');
             mod_type('D', 'rel', 'dx', 'dy');
-
-            assert(a1.b == b1);
-            assert(a2.b == b2);
-            assert(a3.b == nil);
-            assert(b1.a == a1);
-            assert(b2.a == a2);
-            assert(c1.c == c1);
-            assert(c2.c == nil);
-            assert(d1.dx == d2);
-            assert(d1.dy == nil);
-            assert(d2.dx == nil);
-            assert(d2.dy == d1);
-            assert(d3.dx == d3);
-            assert(d3.dy == d3);
 
             'OK';
         '''), 'OK')
@@ -657,56 +578,8 @@ mod_type('D', 'rel', 'da', 'db');
             .c1.cc.add(.c3);
             .c4.cc.add(.c5);
 
-            a1 = A{};
-            a2 = A{};
-            a3 = A{};
-            a4 = A{};
-            b1 = B{};
-            b2 = B{};
-            c1 = C{};
-            c2 = C{};
-            c3 = C{};
-            c4 = C{};
-            c5 = C{};
-
-            a1.b = b1;
-            a2.b = b1;
-            b1.aa.add(a2);
-            b2.aa.add(a3);
-            c1.c = c1;
-            c2.c = c1;
-            c1.cc.add(c2);
-            c1.cc.add(c3);
-            c4.cc.add(c5);
-
             mod_type('A', 'rel', 'b', 'aa');
             mod_type('C', 'rel', 'c', 'cc');
-
-            assert(a1.b == b1);
-            assert(a2.b == b1);
-            assert(a3.b == b2);
-            assert(a4.b == nil);
-            assert(c1.c == c1);
-            assert(c2.c == c1);
-            assert(c3.c == c1);
-            assert(c4.c == nil);
-            assert(c5.c == c4);
-
-            assert(b1.aa.has(a1));
-            assert(b1.aa.has(a2));
-            assert(b1.aa.len() == 2);
-            assert(b2.aa.has(a3));
-            assert(b2.aa.len() == 1);
-
-            assert(c1.cc.has(c1));
-            assert(c1.cc.has(c2));
-            assert(c1.cc.has(c3));
-            assert(c1.cc.len() == 3);
-            assert(c2.cc.len() == 0);
-            assert(c3.cc.len() == 0);
-            assert(c4.cc.has(c5));
-            assert(c4.cc.len() == 1);
-            assert(c5.cc.len() == 0);
 
             assert(types_info().len(), 3);
 
@@ -763,34 +636,34 @@ mod_type('D', 'rel', 'da', 'db');
         ''')
 
         self.assertTrue(await client.query(r'''
-            u = User{};
-            u.space = Space{};
-            u.space.user == u;
+            .u = User{};
+            .u.space = Space{};
+            .u.space.user == .u;
         '''))
 
         self.assertEqual(await client.query(r'''
-            u1 = User{};
+            .u1 = User{};
             s1 = Space{};
-            u1.space = s1;
-            assert (s1.user == u1);
-            assert (u1.space == s1);
+            .u1.space = s1;
+            assert (s1.user == .u1);
+            assert (.u1.space == s1);
 
             u2 = User{};
-            s2 = Space{};
-            s2.user = u2;
-            assert (s2.user == u2);
-            assert (u2.space == s2);
+            .s2 = Space{};
+            .s2.user = u2;
+            assert (.s2.user == u2);
+            assert (u2.space == .s2);
 
-            u = User{};
+            .u = User{};
             s = Space{};
-            u.space = s;
-            assert (s.user == u);
-            assert (u.space == s);
+            .u.space = s;
+            assert (s.user == .u);
+            assert (.u.space == s);
 
-            u.space = s2;
+            .u.space = .s2;
             assert (s.user == nil);
-            assert (u.space == s2);
-            assert (s2.user == u);
+            assert (.u.space == .s2);
+            assert (.s2.user == .u);
             assert (u2.space == nil);
 
             'OK';
@@ -807,34 +680,34 @@ mod_type('D', 'rel', 'da', 'db');
         ''')
 
         self.assertEqual(await client.query(r'''
-            s1 = Self{};
+            .s1 = Self{};
             s2 = Self{};
-            s1.self = s2;
-            assert (s1.self == s2);
-            assert (s2.self == s1);
+            .s1.self = s2;
+            assert (.s1.self == s2);
+            assert (s2.self == .s1);
 
             // a second time shoudl work as well
-            s1.self = s2;
-            assert (s1.self == s2);
-            assert (s2.self == s1);
+            .s1.self = s2;
+            assert (.s1.self == s2);
+            assert (s2.self == .s1);
 
             // remove assignment
-            s1.self = nil;
-            assert(is_nil(s1.self));
+            .s1.self = nil;
+            assert(is_nil(.s1.self));
             assert(is_nil(s2.self));
 
             // Restore assigmment
-            s1.self = s2;
-            assert (s1.self == s2);
-            assert (s2.self == s1);
+            .s1.self = s2;
+            assert (.s1.self == s2);
+            assert (s2.self == .s1);
 
             // Remove relation
             mod_type('Self', 'rel', 'self', nil);
 
             // Check is relation is removed
-            s1.self = nil;
-            assert(is_nil(s1.self));
-            assert(s2.self == s1);
+            .s1.self = nil;
+            assert(is_nil(.s1.self));
+            assert(s2.self == .s1);
 
             'OK';
         '''), 'OK')
@@ -881,30 +754,30 @@ mod_type('D', 'rel', 'da', 'db');
         self.assertEqual(await client.query(r'''
             a1 = A{};
             a2 = A{};
-            b1 = B{};
-            b2 = B{};
+            .b1 = B{};
+            .b2 = B{};
 
-            b1.a = a1;
-            b2.a = a1;
+            .b1.a = a1;
+            .b2.a = a1;
 
-            assert(a1.b.has(b1));
-            assert(a1.b.has(b2));
-            assert(!a2.b.has(b1));
-            assert(!a2.b.has(b2));
+            assert(a1.b.has(.b1));
+            assert(a1.b.has(.b2));
+            assert(!a2.b.has(.b1));
+            assert(!a2.b.has(.b2));
 
-            b2.a = a2;
+            .b2.a = a2;
 
-            assert(a1.b.has(b1));
-            assert(!a1.b.has(b2));
-            assert(!a2.b.has(b1));
-            assert(a2.b.has(b2));
+            assert(a1.b.has(.b1));
+            assert(!a1.b.has(.b2));
+            assert(!a2.b.has(.b1));
+            assert(a2.b.has(.b2));
 
-            a2.b.add(b1);
+            a2.b.add(.b1);
 
-            assert(!a1.b.has(b1));
-            assert(!a1.b.has(b2));
-            assert(a2.b.has(b1));
-            assert(a2.b.has(b2));
+            assert(!a1.b.has(.b1));
+            assert(!a1.b.has(.b2));
+            assert(a2.b.has(.b1));
+            assert(a2.b.has(.b2));
 
             'OK';
         '''), 'OK')
@@ -933,16 +806,16 @@ mod_type('D', 'rel', 'da', 'db');
 
         self.assertEqual(await client.query(r'''
             a = A{};
-            b = B{};
-            b.a.add(a);
+            .b = B{};
+            .b.a.add(a);
 
-            assert(a.b.has(b));
-            assert(b.a.has(a));
+            assert(a.b.has(.b));
+            assert(.b.a.has(a));
 
-            b.a.remove(a);
+            .b.a.remove(a);
 
-            assert(!a.b.has(b));
-            assert(!b.a.has(a));
+            assert(!a.b.has(.b));
+            assert(!.b.a.has(a));
 
             'OK';
         '''), 'OK')

--- a/itest/test_relations.py
+++ b/itest/test_relations.py
@@ -215,7 +215,7 @@ class TestRelations(TestBase):
         with self.assertRaisesRegex(
                 TypeError,
                 r'failed to create relation; '
-                r'relations must be created using the property on a stored '
+                r'relations must be created using a property on a stored '
                 r'thing \(a thing with an Id\)'):
             await client.query(r'''
                 c1 = C{};
@@ -274,7 +274,7 @@ class TestRelations(TestBase):
         with self.assertRaisesRegex(
                 TypeError,
                 r'failed to create relation; relations must be created using '
-                r'the property on a stored thing \(a thing with an Id\)'):
+                r'a property on a stored thing \(a thing with an Id\)'):
             await client.query(r'''
                 a1 = A{};
                 b1 = B{};
@@ -1310,7 +1310,7 @@ mod_type('D', 'rel', 'da', 'db');
 
         err_msg = (
             r'failed to create relation; '
-            r'relations must be created using the property on a stored '
+            r'relations must be created using a property on a stored '
             r'thing \(a thing with an Id\)')
 
         with self.assertRaisesRegex(TypeError, err_msg):

--- a/itest/test_relations.py
+++ b/itest/test_relations.py
@@ -1309,7 +1309,9 @@ mod_type('D', 'rel', 'da', 'db');
         ''')
 
         err_msg = (
-            r'xxx')
+            r'failed to create relation; '
+            r'relations must be created using the property on a stored '
+            r'thing \(a thing with an Id\)')
 
         with self.assertRaisesRegex(TypeError, err_msg):
             await client.query(r'''

--- a/itest/test_relations.py
+++ b/itest/test_relations.py
@@ -1385,9 +1385,10 @@ mod_type('D', 'rel', 'da', 'db');
 
         self.assertEqual(await client.query(r'''
             w = W{};
-            p = P{w: set(w)};
+            .p = P{};
+            .p.w.add(w);
 
-            return [p.w.len(), w.p.len()];
+            return [.p.w.len(), w.p.len()];
         '''), [1, 1])
 
     async def test_iteration_tset(self, client):
@@ -1405,13 +1406,15 @@ mod_type('D', 'rel', 'da', 'db');
 
         self.assertEqual(await client.query(r'''
             w = W{};
-            p = P{w: w};
+            .p = P{};
+            .p.w = w;
             return w.p.len()
         '''), 1)
 
         self.assertEqual(await client.query(r'''
             p = P{};
-            w = W{p: set(p)};
+            .w = W{};
+            .w.p.add(p);
             return p.w.len()
         '''), 1)
 

--- a/itest/test_relations.py
+++ b/itest/test_relations.py
@@ -45,7 +45,7 @@ class TestRelations(TestBase):
         client.close()
         await client.wait_closed()
 
-    async def _test_errors(self, client):
+    async def test_errors(self, client):
         await client.query(r'''
             new_type('A');
             new_type('B');
@@ -192,7 +192,7 @@ class TestRelations(TestBase):
                 mod_type('A', 'rel', 'bstrict', 'a');
             ''')
 
-    async def _test_type_state_error(self, client):
+    async def test_type_state_error(self, client):
         await client.query(r'''
             new_type('A');
             new_type('B');
@@ -257,7 +257,7 @@ class TestRelations(TestBase):
                 mod_type('A', 'rel', 'b', 'a');
             ''')
 
-    async def _test_set_state_error_1(self, client):
+    async def test_set_state_error_1(self, client):
         await client.query(r'''
             new_type('A');
             new_type('B');
@@ -301,7 +301,7 @@ class TestRelations(TestBase):
                 mod_type('A', 'rel', 'b', 'aa');
             ''')
 
-    async def _test_set_state_error_2(self, client):
+    async def test_set_state_error_2(self, client):
         await client.query(r'''
             new_type('A');
             new_type('B');
@@ -330,7 +330,7 @@ class TestRelations(TestBase):
                 mod_type('A', 'rel', 'b', 'aa');
             ''')
 
-    async def _test_set_set_init_state(self, client0):
+    async def test_set_set_init_state(self, client0):
         if not self.with_node1():
             return
         client1 = await get_client(self.node1)
@@ -453,7 +453,7 @@ mod_type('D', 'rel', 'da', 'db');
 'DONE';
 '''.lstrip().replace('  ', '\t'))
 
-    async def _test_type_type_init_state(self, client0):
+    async def test_type_type_init_state(self, client0):
         if not self.with_node1():
             return
         client1 = await get_client(self.node1)
@@ -530,7 +530,7 @@ mod_type('D', 'rel', 'da', 'db');
                 'OK';
             '''), 'OK')
 
-    async def _test_type_set_init_state(self, client0):
+    async def test_type_set_init_state(self, client0):
         if not self.with_node1():
             return
         client1 = await get_client(self.node1)
@@ -619,7 +619,7 @@ mod_type('D', 'rel', 'da', 'db');
                 'OK';
             '''), 'OK')
 
-    async def _test_type_to_type(self, client):
+    async def test_type_to_type(self, client):
         await client.query(r'''
             new_type('User');
             new_type('Space');
@@ -669,7 +669,7 @@ mod_type('D', 'rel', 'da', 'db');
             'OK';
         '''), 'OK')
 
-    async def _test_type_to_self(self, client):
+    async def test_type_to_self(self, client):
         await client.query(r'''
             new_type('Self');
             set_type('Self', {
@@ -728,7 +728,7 @@ mod_type('D', 'rel', 'da', 'db');
             'OK';
         '''), 'OK')
 
-    async def _test_type_to_set(self, client):
+    async def test_type_to_set(self, client):
         await client.query(r'''
             new_type('A');
             new_type('B');
@@ -782,7 +782,7 @@ mod_type('D', 'rel', 'da', 'db');
             'OK';
         '''), 'OK')
 
-    async def _test_set_to_set(self, client):
+    async def test_set_to_set(self, client):
         await client.query(r'''
             new_type('A');
             new_type('B');
@@ -841,7 +841,7 @@ mod_type('D', 'rel', 'da', 'db');
             'OK';
         '''), 'OK')
 
-    async def _test_set_to_set_multi_node(self, client0):
+    async def test_set_to_set_multi_node(self, client0):
         if not self.with_node1():
             return
         client1 = await get_client(self.node1)
@@ -939,7 +939,7 @@ mod_type('D', 'rel', 'da', 'db');
                 'OK';
             '''), 'OK')
 
-    async def _test_mod_type_multi_node(self, client0):
+    async def test_mod_type_multi_node(self, client0):
         if not self.with_node1():
             return
         client1 = await get_client(self.node1)
@@ -1020,7 +1020,7 @@ mod_type('D', 'rel', 'da', 'db');
                 'OK';
             '''), 'OK')
 
-    async def _test_multi_node_replace_val(self, client0):
+    async def test_multi_node_replace_val(self, client0):
         if not self.with_node1():
             return
         client1 = await get_client(self.node1)
@@ -1072,7 +1072,7 @@ mod_type('D', 'rel', 'da', 'db');
                 'OK';
             '''), 'OK')
 
-    async def _test_set_operations(self, client0):
+    async def test_set_operations(self, client0):
         if not self.with_node1():
             return
         client1 = await get_client(self.node1)
@@ -1228,7 +1228,7 @@ mod_type('D', 'rel', 'da', 'db');
                 'OK';
             '''), 'OK')
 
-    async def _test_full_store(self, client0):
+    async def test_full_store(self, client0):
         await client0.query(r'''
             new_type('A');
             new_type('B');
@@ -1289,7 +1289,7 @@ mod_type('D', 'rel', 'da', 'db');
             'OK';
         '''), 'OK')
 
-    async def _test_relation_init_non_id(self, client):
+    async def test_relation_init_non_id(self, client):
         await client.query(r'''
             new_type('P');
             new_type('W');
@@ -1337,7 +1337,7 @@ mod_type('D', 'rel', 'da', 'db');
                 mod_type('S', 'rel', 's', 's');
             ''')
 
-    async def _test_iteration_id(self, client):
+    async def test_iteration_id(self, client):
         await client.query(r'''
             new_type('P');
             new_type('W');
@@ -1391,7 +1391,7 @@ mod_type('D', 'rel', 'da', 'db');
             return [.p.w.len(), w.p.len()];
         '''), [1, 1])
 
-    async def _test_iteration_tset(self, client):
+    async def test_iteration_tset(self, client):
         await client.query(r'''
             new_type('P');
             new_type('W');
@@ -1418,7 +1418,7 @@ mod_type('D', 'rel', 'da', 'db');
             return p.w.len()
         '''), 1)
 
-    async def _test_wse_on_closure(self, client):
+    async def test_wse_on_closure(self, client):
         await client.query("""//ti
             new_type('A');
             new_type('B');
@@ -1497,6 +1497,7 @@ mod_type('D', 'rel', 'da', 'db');
             """)
 
         await client0.query("""//ti
+            .sp = S{};
             .so = S{};
             .so.p |= .S2.p;
             assert (.so.p == .S2.p);
@@ -1507,6 +1508,20 @@ mod_type('D', 'rel', 'da', 'db');
             .ro.f |= set(.RIris, .RCato);
             assert (.RIris.f.has(.ro));
             assert (.RCato.f.has(.ro));
+        """)
+
+        with self.assertRaisesRegex(OperationError, r'enforce a change'):
+            await client0.query("""//ti
+                s = .sp.p;
+                s |= (.S2.p - .S3.p);
+                assert (.sp.p == set(.Iris));
+            """)
+
+        await client0.query("""//ti
+            wse();
+            s = .sp.p;
+            s |= (.S2.p - .S3.p);
+            assert (.sp.p == set(.Iris));
         """)
 
         await client0.query("""//ti
@@ -1526,6 +1541,7 @@ mod_type('D', 'rel', 'da', 'db');
                 assert (.RIris.f.has(.ro));
                 assert (.RCato.f.has(.ro));
                 assert (.ro.f = set(.RIris, .RCato));
+                assert (.sp.p == set(.Iris));
             """)
 
 

--- a/itest/test_relations.py
+++ b/itest/test_relations.py
@@ -45,7 +45,7 @@ class TestRelations(TestBase):
         client.close()
         await client.wait_closed()
 
-    async def test_errors(self, client):
+    async def _test_errors(self, client):
         await client.query(r'''
             new_type('A');
             new_type('B');
@@ -192,7 +192,7 @@ class TestRelations(TestBase):
                 mod_type('A', 'rel', 'bstrict', 'a');
             ''')
 
-    async def test_type_state_error(self, client):
+    async def _test_type_state_error(self, client):
         await client.query(r'''
             new_type('A');
             new_type('B');
@@ -257,7 +257,7 @@ class TestRelations(TestBase):
                 mod_type('A', 'rel', 'b', 'a');
             ''')
 
-    async def test_set_state_error_1(self, client):
+    async def _test_set_state_error_1(self, client):
         await client.query(r'''
             new_type('A');
             new_type('B');
@@ -301,7 +301,7 @@ class TestRelations(TestBase):
                 mod_type('A', 'rel', 'b', 'aa');
             ''')
 
-    async def test_set_state_error_2(self, client):
+    async def _test_set_state_error_2(self, client):
         await client.query(r'''
             new_type('A');
             new_type('B');
@@ -330,7 +330,7 @@ class TestRelations(TestBase):
                 mod_type('A', 'rel', 'b', 'aa');
             ''')
 
-    async def test_set_set_init_state(self, client0):
+    async def _test_set_set_init_state(self, client0):
         if not self.with_node1():
             return
         client1 = await get_client(self.node1)
@@ -453,7 +453,7 @@ mod_type('D', 'rel', 'da', 'db');
 'DONE';
 '''.lstrip().replace('  ', '\t'))
 
-    async def test_type_type_init_state(self, client0):
+    async def _test_type_type_init_state(self, client0):
         if not self.with_node1():
             return
         client1 = await get_client(self.node1)
@@ -530,7 +530,7 @@ mod_type('D', 'rel', 'da', 'db');
                 'OK';
             '''), 'OK')
 
-    async def test_type_set_init_state(self, client0):
+    async def _test_type_set_init_state(self, client0):
         if not self.with_node1():
             return
         client1 = await get_client(self.node1)
@@ -619,7 +619,7 @@ mod_type('D', 'rel', 'da', 'db');
                 'OK';
             '''), 'OK')
 
-    async def test_type_to_type(self, client):
+    async def _test_type_to_type(self, client):
         await client.query(r'''
             new_type('User');
             new_type('Space');
@@ -669,7 +669,7 @@ mod_type('D', 'rel', 'da', 'db');
             'OK';
         '''), 'OK')
 
-    async def test_type_to_self(self, client):
+    async def _test_type_to_self(self, client):
         await client.query(r'''
             new_type('Self');
             set_type('Self', {
@@ -728,7 +728,7 @@ mod_type('D', 'rel', 'da', 'db');
             'OK';
         '''), 'OK')
 
-    async def test_type_to_set(self, client):
+    async def _test_type_to_set(self, client):
         await client.query(r'''
             new_type('A');
             new_type('B');
@@ -782,7 +782,7 @@ mod_type('D', 'rel', 'da', 'db');
             'OK';
         '''), 'OK')
 
-    async def test_set_to_set(self, client):
+    async def _test_set_to_set(self, client):
         await client.query(r'''
             new_type('A');
             new_type('B');
@@ -841,7 +841,7 @@ mod_type('D', 'rel', 'da', 'db');
             'OK';
         '''), 'OK')
 
-    async def test_set_to_set_multi_node(self, client0):
+    async def _test_set_to_set_multi_node(self, client0):
         if not self.with_node1():
             return
         client1 = await get_client(self.node1)
@@ -939,7 +939,7 @@ mod_type('D', 'rel', 'da', 'db');
                 'OK';
             '''), 'OK')
 
-    async def test_mod_type_multi_node(self, client0):
+    async def _test_mod_type_multi_node(self, client0):
         if not self.with_node1():
             return
         client1 = await get_client(self.node1)
@@ -1020,7 +1020,7 @@ mod_type('D', 'rel', 'da', 'db');
                 'OK';
             '''), 'OK')
 
-    async def test_multi_node_replace_val(self, client0):
+    async def _test_multi_node_replace_val(self, client0):
         if not self.with_node1():
             return
         client1 = await get_client(self.node1)
@@ -1072,7 +1072,7 @@ mod_type('D', 'rel', 'da', 'db');
                 'OK';
             '''), 'OK')
 
-    async def test_set_operations(self, client0):
+    async def _test_set_operations(self, client0):
         if not self.with_node1():
             return
         client1 = await get_client(self.node1)
@@ -1228,7 +1228,7 @@ mod_type('D', 'rel', 'da', 'db');
                 'OK';
             '''), 'OK')
 
-    async def test_full_store(self, client0):
+    async def _test_full_store(self, client0):
         await client0.query(r'''
             new_type('A');
             new_type('B');
@@ -1289,7 +1289,7 @@ mod_type('D', 'rel', 'da', 'db');
             'OK';
         '''), 'OK')
 
-    async def test_relation_init_non_id(self, client):
+    async def _test_relation_init_non_id(self, client):
         await client.query(r'''
             new_type('P');
             new_type('W');
@@ -1337,7 +1337,7 @@ mod_type('D', 'rel', 'da', 'db');
                 mod_type('S', 'rel', 's', 's');
             ''')
 
-    async def test_iteration_id(self, client):
+    async def _test_iteration_id(self, client):
         await client.query(r'''
             new_type('P');
             new_type('W');
@@ -1391,7 +1391,7 @@ mod_type('D', 'rel', 'da', 'db');
             return [.p.w.len(), w.p.len()];
         '''), [1, 1])
 
-    async def test_iteration_tset(self, client):
+    async def _test_iteration_tset(self, client):
         await client.query(r'''
             new_type('P');
             new_type('W');
@@ -1418,7 +1418,7 @@ mod_type('D', 'rel', 'da', 'db');
             return p.w.len()
         '''), 1)
 
-    async def test_wse_on_closure(self, client):
+    async def _test_wse_on_closure(self, client):
         await client.query("""//ti
             new_type('A');
             new_type('B');
@@ -1451,6 +1451,81 @@ mod_type('D', 'rel', 'da', 'db');
             res = await client.query("""//ti
                 wse();
                 .check();
+            """)
+
+    async def test_set_operation_complex(self, client0):
+        if not self.with_node1():
+            return
+        client1 = await get_client(self.node1)
+        client1.set_default_scope('//stuff')
+
+        await client0.query("""//ti
+            set_type('P', {name: 'str'});
+            set_type('S', {p: '{P}'});
+            set_type('R', {name: 'str', f:'{R}'});
+            mod_type('R', 'rel', 'f', 'f');
+
+            .iris = {name: 'iris'};
+            .cato = {name: 'cato'};
+            .tess = {name: 'tess'};
+
+            .Iris = P{name: 'Iris'};
+            .Cato = P{name: 'Cato'};
+            .Tess = P{name: 'Tess'};
+
+            .s1 = set(.iris, .tess);
+            .s2 = set(.iris, .cato);
+            .s3 = set(.cato, .tess);
+
+            .S1 = S{p: set(.Iris, .Tess)};
+            .S2 = S{p: set(.Iris, .Cato)};
+            .S3 = S{p: set(.Cato, .Tess)};
+
+            .RIris = R{name: 'Iris', f: set()};
+            .RCato = R{name: 'Cato', f: set()};
+            .RTess = R{name: 'Tess', f: set()};
+        """)
+
+        with self.assertRaisesRegex(TypeError, r'another type'):
+            await client0.query("""//ti
+                .S1.p ^= .s2;
+            """)
+
+        with self.assertRaisesRegex(TypeError, r'a thing with an Id'):
+            await client0.query("""//ti
+                r = R{}; r.f |= set(.RIris);  // thing without an Id
+            """)
+
+        await client0.query("""//ti
+            .so = S{};
+            .so.p |= .S2.p;
+            assert (.so.p == .S2.p);
+        """)
+
+        await client0.query("""//ti
+            .ro = R{name: 'other'};
+            .ro.f |= set(.RIris, .RCato);
+            assert (.RIris.f.has(.ro));
+            assert (.RCato.f.has(.ro));
+        """)
+
+        await client0.query("""//ti
+            s1 = .ro.f & set(.RIris, .RCato, .RTess);
+            s2 = set(.RIris, .RCato, .RTess) | .ro.f;
+            s3 = set(.RIris, .RCato, .RTess) - .ro.f;
+            assert (s1 == set(.RIris, .RCato));
+            assert (s2 == set(.RIris, .RCato, .RTess));
+            assert (s3 == set(.RTess));
+        """)
+
+        await asyncio.sleep(0.2)
+        await self.wait_nodes_ready()
+
+        for client in (client0, client1):
+            await client.query(r"""//ti
+                assert (.RIris.f.has(.ro));
+                assert (.RCato.f.has(.ro));
+                assert (.ro.f = set(.RIris, .RCato));
             """)
 
 

--- a/src/ti/closure.c
+++ b/src/ti/closure.c
@@ -453,10 +453,7 @@ void ti_closure_dec(ti_closure_t * closure, ti_query_t * query)
     }
 }
 
-int ti_closure_vars_val(
-        ti_closure_t * closure,
-        ti_val_t * val,
-        ex_t * e)
+void ti_closure_vars_val(ti_closure_t * closure, ti_val_t * val)
 {
     ti_prop_t * prop;
     switch(closure->vars->n)
@@ -467,23 +464,16 @@ int ti_closure_vars_val(
         ti_incref(val);
         ti_val_unsafe_drop(prop->val);
         prop->val = val;
-        /*
-         * Re-assign variable since we require a copy of lists and sets.
-         */
-        if (ti_val_make_variable(&prop->val, e))
-            return e->nr;
         /* fall through */
     case 0:
         break;
     }
-    return 0;
 }
 
-int ti_closure_vars_nameval(
+void ti_closure_vars_nameval(
         ti_closure_t * closure,
         ti_val_t * name,
-        ti_val_t * val,
-        ex_t * e)
+        ti_val_t * val)
 {
     ti_prop_t * prop;
     switch(closure->vars->n)
@@ -494,11 +484,6 @@ int ti_closure_vars_nameval(
         ti_incref(val);
         ti_val_unsafe_drop(prop->val);
         prop->val = val;
-        /*
-         * Re-assign variable since we require a copy of lists and sets.
-         */
-        if (ti_val_make_variable(&prop->val, e))
-            return e->nr;
         /* fall through */
     case 1:
         prop = VEC_get(closure->vars, 0);
@@ -509,7 +494,6 @@ int ti_closure_vars_nameval(
     case 0:
         break;
     }
-    return 0;
 }
 
 int ti_closure_vars_val_idx(ti_closure_t * closure, ti_val_t * v, int64_t i)

--- a/src/ti/ctask.c
+++ b/src/ti/ctask.c
@@ -114,9 +114,13 @@ static int ctask__thing_clear(ti_thing_t * thing, mp_unp_t * up)
     }
 
     if (ti_thing_is_dict(thing))
-        smap_clear(thing->items.smap, (smap_destroy_cb) ti_item_destroy);
+        smap_clear(
+                thing->items.smap,
+                (smap_destroy_cb) ti_item_unassign_destroy);
     else
-        vec_clear_cb(thing->items.vec, (vec_destroy_cb) ti_prop_destroy);
+        vec_clear_cb(
+                thing->items.vec,
+                (vec_destroy_cb) ti_prop_unassign_destroy);
 
     return 0;
 }

--- a/src/ti/do.c
+++ b/src/ti/do.c
@@ -220,7 +220,7 @@ static inline int do__upd_prop(
             : do__t_upd_prop(wprop, query, thing, name_nd, tokens_nd, e))
         return e->nr;
 
-    ti_val_unassign_unsafe_drop(*wprop->val);
+    ti_val_unsafe_gc_drop(*wprop->val);
     *wprop->val = query->rval;
     ti_incref(query->rval);
 
@@ -1472,6 +1472,7 @@ static int do__var_assign(ti_query_t * query, cleri_node_t * nd, ex_t * e)
                         ti_panic("failed to create task without undo");
                     }
                 }
+                return e->nr;
             }
         }
 

--- a/src/ti/do.c
+++ b/src/ti/do.c
@@ -23,7 +23,6 @@
 #include <ti/template.h>
 #include <ti/thing.inline.h>
 #include <ti/vint.h>
-#include <ti/xprop.t.h>
 #include <util/strx.h>
 
 static inline int do__no_node_scope(ti_query_t * query)

--- a/src/ti/do.c
+++ b/src/ti/do.c
@@ -1439,17 +1439,6 @@ static int do__var_assign(ti_query_t * query, cleri_node_t * nd, ex_t * e)
     }
 
     /*
-     * Must make variable assignable because we require a copy and need to
-     * convert for example a tuple to a list.
-     *
-     * Closures can be ignored here because they are not mutable and will
-     * unbound from the query if the `variable` is assigned or pushed to a list
-     */
-    if (    !ti_val_is_closure(query->rval) &&
-            ti_val_make_variable(&query->rval, e))
-        goto failed;
-
-    /*
      * Try to get the name from cache, else ensure it is set on the cache for
      * the next time the code visits this same point.
      */
@@ -1494,8 +1483,6 @@ alloc_err_with_prop:
 
 alloc_err:
     ex_set_mem(e);
-
-failed:
     ti_name_drop(name);
     return e->nr;
 }

--- a/src/ti/field.c
+++ b/src/ti/field.c
@@ -1135,11 +1135,6 @@ static inline int field__walk_assign(ti_thing_t * thing, ti_field_t * field)
     return thing->type_id != field->nested_spec;
 }
 
-static inline int field__walk_rel_check(ti_thing_t * thing, void * UNUSED(arg))
-{
-    return thing->id != 0;
-}
-
 typedef struct
 {
     ti_field_t * field;
@@ -1220,17 +1215,13 @@ static int field__vset_assign(
 done:
     if (with_relation && !parent->id)
     {
-        if (imap_walk((*vset)->imap, (imap_cb) field__walk_rel_check, NULL))
-        {
-            ex_set(e, EX_TYPE_ERROR,
-                    "mismatch in type `%s` on property `%s`; "
-                    "relations between stored and non-stored things must be "
-                    "created using the property on the the stored thing "
-                    "(the thing with an ID)",
-                    field->type->name,
-                    field->name->str);
-            return e->nr;
-        }
+        ex_set(e, EX_TYPE_ERROR,
+                "mismatch in type `%s` on property `%s`; "
+                "relations must be created using the property "
+                "on a stored thing (a thing with an Id)",
+                field->type->name,
+                field->name->str);
+        return e->nr;
     }
 
     if (ti_val_make_assignable((ti_val_t **) vset, parent, field, e))
@@ -1501,9 +1492,7 @@ int ti_field_make_assignable(
                 ((ti_thing_t *) *val)->type_id != spec))
                 goto type_error;
 
-            if (!parent->id &&
-                ti_val_is_thing(*val) &&
-                ((ti_thing_t *) *val)->id)
+            if (!parent->id && ti_val_is_thing(*val))
                 goto relation_error;
 
             if (relation && relation->tp == TI_VAL_THING)
@@ -1820,9 +1809,8 @@ type_error:
 relation_error:
     ex_set(e, EX_TYPE_ERROR,
             "mismatch in type `%s` on property `%s`; "
-            "relations between stored and non-stored things must be "
-            "created using the property on the the stored thing "
-            "(the thing with an ID)",
+            "relations must be created using the property "
+            "on a stored thing (a thing with an Id)",
             field->type->name,
             field->name->str);
     return e->nr;
@@ -2367,48 +2355,15 @@ static int field__walk_things(
     );
 }
 
-static int field__chk_id(ti_thing_t * thing, void * UNUSED(arg))
-{
-    return thing->id != 0;
-}
-
-static int field__field_id_chk(ti_thing_t * thing, ti_field_t * field)
-{
-    if (field->spec == TI_SPEC_SET)
-    {
-        ti_vset_t * vset = VEC_get(thing->items.vec, field->idx);
-        return imap_walk(vset->imap, (imap_cb) field__chk_id, NULL);
-    }
-    else
-    {
-        ti_thing_t * other = VEC_get(thing->items.vec, field->idx);
-        return (other->tp == TI_VAL_THING && other->id);
-    }
-
-    return 0;
-}
-
 static int field__non_id_chk(ti_thing_t * thing, field__set_rel_chk_t * w)
 {
     if (thing->id)
         return 0;
 
-    if (thing->type_id == w->field->type->type_id &&
-        field__field_id_chk(thing, w->field))
-        goto failed;
-
-    if (thing->type_id == w->ofield->type->type_id &&
-        field__field_id_chk(thing, w->ofield))
-        goto failed;
-
-    return 0;
-
-failed:
     ex_set(w->e, EX_TYPE_ERROR,
             "failed to create relation; "
-            "relations between stored and non-stored things must be "
-            "created using the property on the the stored thing "
-            "(the thing with an ID)");
+            "relations must be created using the property on a stored thing "
+            "(a thing with an Id)");
     return w->e->nr;
 }
 

--- a/src/ti/field.c
+++ b/src/ti/field.c
@@ -1181,6 +1181,66 @@ static int field__walk_tset_cb(ti_thing_t * thing, field__walk_set_t * w)
     return 0;
 }
 
+int ti_field_vset_pre_assign(
+        ti_field_t * field,
+        imap_t * imap,
+        ti_thing_t * parent,
+        ex_t * e)
+{
+    /*
+     * This method may be called when field is either `any` or a `set.
+     * In case of `any`, we have to make sure the specification will be
+     * OBJECT, not ANY.
+     */
+    ti_vset_t * oset;
+    _Bool with_relation = field->condition.rel && parent;
+
+    if (field->nested_spec == TI_SPEC_ANY || imap->n == 0)
+        goto done;
+
+    if (imap_walk(imap, (imap_cb) field__walk_assign, field))
+    {
+        ex_set(e, EX_TYPE_ERROR,
+                "mismatch in type `%s`; "
+                "property `%s` has definition `%.*s` but got a set with "
+                "at least one thing of another type",
+                field->type->name,
+                field->name->str,
+                field->spec_raw->n, (const char *) field->spec_raw->data);
+        return e->nr;
+    }
+
+done:
+    if (with_relation && !parent->id)
+    {
+        ex_set(e, EX_TYPE_ERROR,
+                "mismatch in type `%s` on property `%s`; "
+                "relations must be created using a property "
+                "on a stored thing (a thing with an Id)",
+                field->type->name,
+                field->name->str);
+        return e->nr;
+    }
+
+    if (with_relation)
+    {
+        oset = VEC_get(parent->items.vec, field->idx);
+        field__walk_set_t w = {
+                .field = field->condition.rel->field,
+                .relation = parent,
+                .imap = oset->imap,
+        };
+
+        (void) imap_walk(imap, w.field->spec == TI_SPEC_SET
+                ? (imap_cb) field__walk_set_cb
+                : (imap_cb) field__walk_tset_cb, &w);
+
+        w.imap = imap;
+        (void) imap_walk(oset->imap, (imap_cb) field__walk_unset_cb, &w);
+    }
+    return 0;
+}
+
 static int field__vset_assign(
         ti_field_t * field,
         ti_vset_t ** vset,
@@ -1224,8 +1284,13 @@ done:
         return e->nr;
     }
 
-    if (ti_val_make_assignable((ti_val_t **) vset, parent, field, e))
+    if (ti_vset_assign(vset))
+    {
+        ex_set_mem(e);
         return e->nr;
+    }
+    (*vset)->parent = parent;
+    (*vset)->key_ = field;
 
     if (with_relation)
     {

--- a/src/ti/field.c
+++ b/src/ti/field.c
@@ -1217,7 +1217,7 @@ done:
     {
         ex_set(e, EX_TYPE_ERROR,
                 "mismatch in type `%s` on property `%s`; "
-                "relations must be created using the property "
+                "relations must be created using a property "
                 "on a stored thing (a thing with an Id)",
                 field->type->name,
                 field->name->str);
@@ -1809,7 +1809,7 @@ type_error:
 relation_error:
     ex_set(e, EX_TYPE_ERROR,
             "mismatch in type `%s` on property `%s`; "
-            "relations must be created using the property "
+            "relations must be created using a property "
             "on a stored thing (a thing with an Id)",
             field->type->name,
             field->name->str);
@@ -2362,7 +2362,7 @@ static int field__non_id_chk(ti_thing_t * thing, field__set_rel_chk_t * w)
 
     ex_set(w->e, EX_TYPE_ERROR,
             "failed to create relation; "
-            "relations must be created using the property on a stored thing "
+            "relations must be created using a property on a stored thing "
             "(a thing with an Id)");
     return w->e->nr;
 }

--- a/src/ti/field.c
+++ b/src/ti/field.c
@@ -1185,7 +1185,8 @@ int ti_field_vset_pre_assign(
         ti_field_t * field,
         imap_t * imap,
         ti_thing_t * parent,
-        ex_t * e)
+        ex_t * e,
+        _Bool do_type_check)
 {
     /*
      * This method may be called when field is either `any` or a `set.
@@ -1198,7 +1199,7 @@ int ti_field_vset_pre_assign(
     if (field->nested_spec == TI_SPEC_ANY || imap->n == 0)
         goto done;
 
-    if (imap_walk(imap, (imap_cb) field__walk_assign, field))
+    if (do_type_check && imap_walk(imap, (imap_cb) field__walk_assign, field))
     {
         ex_set(e, EX_TYPE_ERROR,
                 "mismatch in type `%s`; "
@@ -1210,7 +1211,6 @@ int ti_field_vset_pre_assign(
         return e->nr;
     }
 
-done:
     if (with_relation && !parent->id)
     {
         ex_set(e, EX_TYPE_ERROR,
@@ -1222,6 +1222,7 @@ done:
         return e->nr;
     }
 
+done:
     if (with_relation)
     {
         oset = VEC_get(parent->items.vec, field->idx);
@@ -1272,7 +1273,6 @@ static int field__vset_assign(
         return e->nr;
     }
 
-done:
     if (with_relation && !parent->id)
     {
         ex_set(e, EX_TYPE_ERROR,
@@ -1284,6 +1284,7 @@ done:
         return e->nr;
     }
 
+done:
     if (ti_vset_assign(vset))
     {
         ex_set_mem(e);

--- a/src/ti/forloop.c
+++ b/src/ti/forloop.c
@@ -22,7 +22,7 @@ typedef struct
     ex_t * e;
 } forloop__walk_t;
 
-static void forloop__set_prop(
+static inline void forloop__set_prop(
         int nargs,
         cleri_node_t * vars_nd,
         ti_name_t * name,

--- a/src/ti/index.c
+++ b/src/ti/index.c
@@ -508,10 +508,7 @@ static inline int index__t_upd_prop(
         wprop->name = field->name;
         wprop->val = (ti_val_t **) vec_get_addr(thing->items.vec, field->idx);
 
-        return (
-            ti_opr_a_to_b(*wprop->val, tokens_nd, &query->rval, e) ||
-            ti_field_make_assignable(field, &query->rval, thing, e)
-        ) ? e->nr : 0;
+        return ti_opr_a_to_b(*wprop->val, tokens_nd, &query->rval, e);
     }
 
     ti_thing_t_set_not_found(thing, name, rname, e);

--- a/src/ti/item.c
+++ b/src/ti/item.c
@@ -35,7 +35,7 @@ ti_item_t * ti_item_dup(ti_item_t * item)
     return dup;
 }
 
-void ti_item_destroy(ti_item_t * item)
+void ti_item_unassign_destroy(ti_item_t * item)
 {
     if (!item)
         return;
@@ -43,6 +43,7 @@ void ti_item_destroy(ti_item_t * item)
     ti_val_unassign_unsafe_drop(item->val);
     free(item);
 }
+
 
 void ti_item_unsafe_vdestroy(ti_item_t * item)
 {

--- a/src/ti/method.c
+++ b/src/ti/method.c
@@ -95,8 +95,7 @@ int ti_method_call(
         {
             --n;  // outside `while` so we do not go below zero
 
-            if (ti_do_statement(query, child, e) ||
-                ti_val_make_variable(&query->rval, e))
+            if (ti_do_statement(query, child, e))
                 goto fail1;
 
             VEC_push(args, query->rval);

--- a/src/ti/prop.c
+++ b/src/ti/prop.c
@@ -40,6 +40,15 @@ void ti_prop_destroy(ti_prop_t * prop)
     if (!prop)
         return;
     ti_name_unsafe_drop(prop->name);
+    ti_val_unsafe_gc_drop(prop->val);
+    free(prop);
+}
+
+void ti_prop_unassign_destroy(ti_prop_t * prop)
+{
+    if (!prop)
+        return;
+    ti_name_unsafe_drop(prop->name);
     ti_val_unassign_unsafe_drop(prop->val);
     free(prop);
 }

--- a/src/ti/thing.c
+++ b/src/ti/thing.c
@@ -1747,6 +1747,8 @@ int ti_thing_assign(
                  * old value.
                  */
                 val->ref += parent_ref > 1;
+                LOGC("ASSIGN...%u", parent_ref);
+                LOGC("thing id: %u", thing->id);
 
                 if (ti_field_make_assignable(field, &val, thing, e))
                 {
@@ -1756,6 +1758,7 @@ int ti_thing_assign(
                 }
 
                 val->ref += parent_ref == 1;
+                LOGC("val ref : %u", val->ref);
 
                 VEC_push(vec, val);
             }
@@ -1794,6 +1797,7 @@ int ti_thing_assign(
                 ti_val_t * val = VEC_get(tsrc->items.vec, field->idx);
 
                 val->ref += parent_ref > 1;
+                LOGC("thing id: %u", thing->id);
 
                 if (ti_field_make_assignable(field, &val, thing, e))
                 {
@@ -1803,6 +1807,8 @@ int ti_thing_assign(
                 }
 
                 val->ref += parent_ref == 1;
+
+                LOGC("val ref : %u", val->ref);
 
                 ti_thing_t_prop_set(thing, field, val);
                 if (task && ti_task_add_set(

--- a/src/ti/thing.c
+++ b/src/ti/thing.c
@@ -595,7 +595,7 @@ static int thing_p__prop_set_e(
                 return e->nr;
 
             ti_decref(name);
-            ti_val_unsafe_gc_drop(p->val);
+            ti_val_replace_drop(p->val, val);
             p->val = val;
 
             return e->nr;
@@ -631,7 +631,7 @@ static int thing_i__item_set_e(
             return e->nr;
 
         ti_val_unsafe_drop((ti_val_t *) item->key);
-        ti_val_unsafe_gc_drop(item->val);
+        ti_val_replace_drop(item->val, val);
         item->val = val;
         item->key = key;
         return e->nr;
@@ -662,7 +662,7 @@ ti_prop_t * ti_thing_p_prop_set(
         if (p->name == name)
         {
             ti_decref(name);
-            ti_val_unsafe_gc_drop(p->val);
+            ti_val_replace_drop(p->val, val);
             p->val = val;
             return p;
         }
@@ -696,7 +696,7 @@ ti_item_t* ti_thing_i_item_set(
         /* bug #291 */
         ti_val_unsafe_drop((ti_val_t *) key);
 
-        ti_val_unsafe_gc_drop(item->val);
+        ti_val_replace_drop(item->val, val);
         item->val = val;
         return item;
     }
@@ -719,7 +719,7 @@ void ti_thing_t_prop_set(
     ti_val_t ** vaddr = (ti_val_t **) vec_get_addr(
             thing->items.vec,
             field->idx);
-    ti_val_unsafe_gc_drop(*vaddr);
+    ti_val_replace_drop(*vaddr, val);
     *vaddr = val;
 }
 
@@ -865,7 +865,7 @@ int ti_thing_t_set_val_from_strn(
         ti_field_make_assignable(field, val, thing, e))
         return e->nr;
 
-    ti_val_unsafe_gc_drop(*vaddr);
+    ti_val_replace_drop(*vaddr, *val);
     *vaddr = *val;
 
     ti_incref(*val);
@@ -1752,7 +1752,7 @@ static int thing__assign_set_o(
     return e->nr;
 
 failed:
-    ti_val_unsafe_gc_drop(val);
+    ti_val_unassign_unsafe_drop(val);
     if (e->nr == 0)
         ex_set_mem(e);
 

--- a/src/ti/thing.c
+++ b/src/ti/thing.c
@@ -137,6 +137,7 @@ void ti_thing_cancel(ti_thing_t * thing)
 
             if (field->spec == TI_SPEC_SET)
             {
+                /* bug #309, use vec_get instead of VEC_get */
                 ti_field_t * ofield = field->condition.rel->field;
                 ti_vset_t * vset = vec_get(thing->items.vec, field->idx);
                 if (!vset)
@@ -149,6 +150,7 @@ void ti_thing_cancel(ti_thing_t * thing)
             }
             else if ((field->spec & TI_SPEC_MASK_NILLABLE) < TI_SPEC_ANY)
             {
+                /* bug #309, use vec_get instead of VEC_get */
                 ti_field_t * ofield = field->condition.rel->field;
                 ti_thing_t * other = vec_get(thing->items.vec, field->idx);
 
@@ -386,6 +388,84 @@ ti_prop_t * ti_thing_p_prop_add(
 }
 
 /*
+ * Increments the `key` and `val` reference counters on success.
+ * Use only when you are sure the property does not yet exist.
+ */
+int ti_thing_p_prop_add_assign(
+        ti_thing_t * thing,
+        ti_name_t * name,
+        ti_val_t * val,
+        ex_t * e)
+{
+    ti_prop_t * prop;
+
+    switch ((ti_val_enum) val->tp)
+    {
+    case TI_VAL_NIL:
+    case TI_VAL_INT:
+    case TI_VAL_FLOAT:
+    case TI_VAL_BOOL:
+    case TI_VAL_DATETIME:
+    case TI_VAL_MPDATA:
+    case TI_VAL_NAME:
+    case TI_VAL_STR:
+    case TI_VAL_BYTES:
+    case TI_VAL_REGEX:
+    case TI_VAL_THING:
+    case TI_VAL_WRAP:
+    case TI_VAL_ROOM:
+    case TI_VAL_TASK:
+    case TI_VAL_ERROR:
+    case TI_VAL_MEMBER:
+        ti_incref(val);
+        break;
+    case TI_VAL_ARR:
+        val = (ti_val_t *) ti_varr_cp((ti_varr_t *) val);
+        if (!val)
+        {
+            ex_set_mem(e);
+            return e->nr;
+        }
+        ((ti_varr_t *) val)->parent = thing;
+        ((ti_varr_t *) val)->key_ = name;
+        break;
+    case TI_VAL_SET:
+        val = (ti_val_t *) ti_vset_cp((ti_vset_t *) val);
+        if (!val)
+        {
+            ex_set_mem(e);
+            return e->nr;
+        }
+        ((ti_vset_t *) val)->parent = thing;
+        ((ti_vset_t *) val)->key_ = name;
+        break;
+    case TI_VAL_CLOSURE:
+        if (ti_closure_unbound((ti_closure_t *) val, e))
+            return e->nr;
+        ti_incref(val);
+        break;
+    case TI_VAL_FUTURE:
+        val = (ti_val_t *) ti_nil_get();
+        break;
+    case TI_VAL_TEMPLATE:
+        assert (0);
+        break;
+    }
+
+    prop = ti_prop_create(name, val);
+    if (!prop || vec_push(&thing->items.vec, prop))
+    {
+        ti_val_unsafe_drop(val);
+        free(prop);
+        ex_set_mem(e);
+        return e->nr;
+    }
+
+    ti_incref(name);
+    return 0;
+}
+
+/*
  * Does not increment the `key` and `val` reference counters.
  * Use only when you are sure the property does not yet exist.
  */
@@ -407,6 +487,86 @@ ti_item_t * ti_thing_i_item_add(
     return item;
 }
 
+/*
+ * Increments the `key` and `val` reference counters on success.
+ * Use only when you are sure the property does not yet exist.
+ */
+int ti_thing_i_item_add_assign(
+        ti_thing_t * thing,
+        ti_raw_t * key,
+        ti_val_t * val,
+        ex_t * e)
+{
+    ti_item_t * item;
+
+    switch ((ti_val_enum) val->tp)
+    {
+    case TI_VAL_NIL:
+    case TI_VAL_INT:
+    case TI_VAL_FLOAT:
+    case TI_VAL_BOOL:
+    case TI_VAL_DATETIME:
+    case TI_VAL_MPDATA:
+    case TI_VAL_NAME:
+    case TI_VAL_STR:
+    case TI_VAL_BYTES:
+    case TI_VAL_REGEX:
+    case TI_VAL_THING:
+    case TI_VAL_WRAP:
+    case TI_VAL_ROOM:
+    case TI_VAL_TASK:
+    case TI_VAL_ERROR:
+    case TI_VAL_MEMBER:
+        ti_incref(val);
+        break;
+    case TI_VAL_ARR:
+        val = (ti_val_t *) ti_varr_cp((ti_varr_t *) val);
+        if (!val)
+        {
+            ex_set_mem(e);
+            return e->nr;
+        }
+        ((ti_varr_t *) val)->parent = thing;
+        ((ti_varr_t *) val)->key_ = key;
+        break;
+    case TI_VAL_SET:
+        val = (ti_val_t *) ti_vset_cp((ti_vset_t *) val);
+        if (!val)
+        {
+            ex_set_mem(e);
+            return e->nr;
+        }
+        ((ti_vset_t *) val)->parent = thing;
+        ((ti_vset_t *) val)->key_ = key;
+        break;
+    case TI_VAL_CLOSURE:
+        if (ti_closure_unbound((ti_closure_t *) val, e))
+            return e->nr;
+        ti_incref(val);
+        break;
+    case TI_VAL_FUTURE:
+        val = (ti_val_t *) ti_nil_get();
+        break;
+    case TI_VAL_TEMPLATE:
+        assert (0);
+        break;
+    }
+
+    item = ti_item_create(key, val);
+    if (!item || smap_addn(
+            thing->items.smap,
+            (const char *) key->data,
+            key->n,
+            item))
+    {
+        ti_val_unsafe_drop(val);
+        free(item);
+        ex_set_mem(e);
+        return e->nr;
+    }
+    ti_incref(key);
+    return 0;
+}
 
 /*
  * It takes a reference on `name` and `val` when successful
@@ -1564,6 +1724,10 @@ static int thing__assign_set_o(
         ex_t * e)
 {
     assert (ti_val_is_spec(val, thing->via.spec));
+    /* must increase the reference here, even if the value is no longer
+     * required after this function, it might break the parent relation;
+     * bug #309
+     */
     ti_incref(val);
 
     /*
@@ -1729,6 +1893,11 @@ int ti_thing_assign(
                     goto fail;
                 }
 
+                /* must increase the reference here, even if the value is no
+                 * longer required after this function, it might break the
+                 * parent relation;
+                 * bug #309
+                 */
                 ti_incref(val);
                 if (ti_field_make_assignable(field, &val, thing, e))
                 {
@@ -1769,6 +1938,11 @@ int ti_thing_assign(
             {
                 ti_val_t * val = VEC_get(tsrc->items.vec, field->idx);
 
+                /* must increase the reference here, even if the value is no
+                 * longer required after this function, it might break the
+                 * parent relation;
+                 * bug #309
+                 */
                 ti_incref(val);
                 if (ti_field_make_assignable(field, &val, thing, e))
                 {

--- a/src/ti/thing.c
+++ b/src/ti/thing.c
@@ -138,7 +138,7 @@ void ti_thing_cancel(ti_thing_t * thing)
             if (field->spec == TI_SPEC_SET)
             {
                 ti_field_t * ofield = field->condition.rel->field;
-                ti_vset_t * vset = VEC_get(thing->items.vec, field->idx);
+                ti_vset_t * vset = vec_get(thing->items.vec, field->idx);
                 if (!vset)
                     continue;
                 thing__clear_rel_t w = {
@@ -150,7 +150,7 @@ void ti_thing_cancel(ti_thing_t * thing)
             else if ((field->spec & TI_SPEC_MASK_NILLABLE) < TI_SPEC_ANY)
             {
                 ti_field_t * ofield = field->condition.rel->field;
-                ti_thing_t * other = VEC_get(thing->items.vec, field->idx);
+                ti_thing_t * other = vec_get(thing->items.vec, field->idx);
 
                 if (!other || ti_val_is_nil((ti_val_t *) other))
                     continue;
@@ -1561,16 +1561,10 @@ static int thing__assign_set_o(
         ti_raw_t * key,
         ti_val_t * val,
         ti_task_t * task,
-        ex_t * e,
-        uint32_t parent_ref)
+        ex_t * e)
 {
     assert (ti_val_is_spec(val, thing->via.spec));
-
-    /*
-     * Update the reference count based on the parent. The reason we do this
-     * here is that we still require the old value.
-     */
-    val->ref += parent_ref > 1;
+    ti_incref(val);
 
     /*
      * Closures are already unbound so the only possible errors are
@@ -1582,12 +1576,10 @@ static int thing__assign_set_o(
         goto failed;
 
     ti_incref(key);
-    val->ref += parent_ref == 1;
     return e->nr;
 
 failed:
-    if (parent_ref > 1)
-        ti_val_unsafe_gc_drop(val);
+    ti_val_unsafe_gc_drop(val);
     if (e->nr == 0)
         ex_set_mem(e);
 
@@ -1609,8 +1601,7 @@ static int thing__assign_walk_i(ti_item_t * item, thing__assign_walk_i_t * w)
             item->key,
             item->val,
             w->task,
-            w->e,
-            w->tsrc->ref);
+            w->e);
 }
 
 static int thing__assign_restr_i(ti_item_t * item, thing__assign_walk_i_t * w)
@@ -1662,8 +1653,7 @@ int ti_thing_assign(
                             (ti_raw_t *) p->name,
                             p->val,
                             task,
-                            e,
-                            tsrc->ref))
+                            e))
                         return e->nr;
             }
         }
@@ -1683,8 +1673,7 @@ int ti_thing_assign(
                         (ti_raw_t *) name,
                         val,
                         task,
-                        e,
-                        tsrc->ref))
+                        e))
                     return e->nr;
         }
     }
@@ -1692,7 +1681,6 @@ int ti_thing_assign(
     {
         vec_t * vec = NULL;
         ti_type_t * type = thing->via.type;
-        uint32_t parent_ref = tsrc->ref;
 
         if (ti_thing_is_object(tsrc))
         {
@@ -1741,25 +1729,12 @@ int ti_thing_assign(
                     goto fail;
                 }
 
-                /*
-                 * Update the reference count based on the parent.
-                 * The reason we do this here is that we still require the
-                 * old value.
-                 */
-                val->ref += parent_ref > 1;
-                LOGC("ASSIGN...%u", parent_ref);
-                LOGC("thing id: %u", thing->id);
-
+                ti_incref(val);
                 if (ti_field_make_assignable(field, &val, thing, e))
                 {
-                    if (parent_ref > 1)
-                        ti_val_unsafe_gc_drop(val);
+                    ti_val_unsafe_gc_drop(val);
                     goto fail;
                 }
-
-                val->ref += parent_ref == 1;
-                LOGC("val ref : %u", val->ref);
-
                 VEC_push(vec, val);
             }
 
@@ -1778,9 +1753,7 @@ int ti_thing_assign(
         else
         {
             ti_type_t * f_type = tsrc->via.type;
-
             vec = NULL;
-
             if (f_type != type)
             {
                 ex_set(e, EX_TYPE_ERROR,
@@ -1796,20 +1769,12 @@ int ti_thing_assign(
             {
                 ti_val_t * val = VEC_get(tsrc->items.vec, field->idx);
 
-                val->ref += parent_ref > 1;
-                LOGC("thing id: %u", thing->id);
-
+                ti_incref(val);
                 if (ti_field_make_assignable(field, &val, thing, e))
                 {
-                    if (parent_ref > 1)
-                        ti_val_unsafe_gc_drop(val);
+                    ti_val_unsafe_gc_drop(val);
                     return e->nr;
                 }
-
-                val->ref += parent_ref == 1;
-
-                LOGC("val ref : %u", val->ref);
-
                 ti_thing_t_prop_set(thing, field, val);
                 if (task && ti_task_add_set(
                         task,

--- a/src/ti/varr.c
+++ b/src/ti/varr.c
@@ -229,6 +229,30 @@ int ti_varr_nested_spec_err(ti_varr_t * varr, ti_val_t * val, ex_t * e)
     return 0;
 }
 
+ti_varr_t * ti_varr_cp(ti_varr_t * varr)
+{
+    ti_varr_t * list = malloc(sizeof(ti_varr_t));
+    if (!list)
+        return NULL;
+
+    list->ref = 1;
+    list->tp = TI_VAL_ARR;
+    list->flags = ti_varr_may_flags(varr);
+    list->vec = vec_dup(varr->vec);
+    list->parent = NULL;
+
+    if (!list->vec)
+    {
+        free(list);
+        return NULL;
+    }
+
+    for (vec_each(list->vec, ti_val_t, val))
+        ti_incref(val);
+
+    return list;
+}
+
 int ti_varr_to_list(ti_varr_t ** varr)
 {
     ti_varr_t * list = *varr;

--- a/src/ti/vset.c
+++ b/src/ti/vset.c
@@ -32,6 +32,20 @@ ti_vset_t * ti_vset_create(void)
     return vset;
 }
 
+ti_vset_t * ti_vset_create_imap(imap_t * imap)
+{
+    ti_vset_t * vset = malloc(sizeof(ti_vset_t));
+    if (!vset)
+        return NULL;
+
+    vset->ref = 1;
+    vset->tp = TI_VAL_SET;
+    vset->flags = 0;
+    vset->parent = NULL;
+    vset->imap = imap;
+    return vset;
+}
+
 void ti_vset_destroy(ti_vset_t * vset)
 {
     if (!vset)

--- a/src/ti/vset.c
+++ b/src/ti/vset.c
@@ -135,6 +135,17 @@ static int vset__walk_assign(ti_thing_t * t, ti_vset_t * vset)
     return 0;
 }
 
+ti_vset_t * ti_vset_cp(ti_vset_t * vset)
+{
+    ti_vset_t * nvset;
+    if (!(nvset = ti_vset_create()))
+        return NULL;
+
+    return imap_walk(vset->imap, (imap_cb) vset__walk_assign, nvset)
+            ? NULL  /* new set is destroyed if walk has failed */
+            : nvset;
+}
+
 int ti_vset_assign(ti_vset_t ** vsetaddr)
 {
     ti_vset_t * nvset, * ovset = *vsetaddr;

--- a/src/ti/wrap.c
+++ b/src/ti/wrap.c
@@ -537,7 +537,7 @@ int ti_wrap_copy(ti_wrap_t ** wrap, uint8_t deep)
 
             if (!p || ti_val_copy(&p->val, other, p->name, deep))
             {
-                ti_prop_destroy(p);
+                ti_prop_unassign_destroy(p);
                 goto fail;
             }
 
@@ -566,7 +566,7 @@ int ti_wrap_copy(ti_wrap_t ** wrap, uint8_t deep)
 
             if (ti_val_copy(&p->val, other, p->name, deep))
             {
-                ti_prop_destroy(p);
+                ti_prop_unassign_destroy(p);
                 goto fail;
             }
 


### PR DESCRIPTION
## Description

Previous, ThingsDB used a reference when assigning value to value, but a copy was created when assigning to a value. This used to be required as we did not knew the parent to process changes.

## Type of change

- [x] Improve performance (_almost_ non-breaking change which increases performance)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added test to advanced test script

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
