### PR TITLE
Add `nse(..)` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v1.4.5
 
 * Fixed bug with recursion in computed properties, issue #332.
+* Added `nse(..)` function, pr #.
 
 # v1.4.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # v1.4.5
 
 * Fixed bug with recursion in computed properties, issue #332.
-* Added `nse(..)` function, pr #.
+* Added `nse(..)` function, pr #333.
 
 # v1.4.4
 

--- a/inc/doc.h
+++ b/inc/doc.h
@@ -83,6 +83,7 @@
 #define DOC_NEW                     DOC_SEE("collection-api/new")
 #define DOC_NEW_TYPE                DOC_SEE("collection-api/new_type")
 #define DOC_NOW                     DOC_SEE("collection-api/now")
+#define DOC_NSE                     DOC_SEE("collection-api/nse")
 #define DOC_RAISE                   DOC_SEE("collection-api/raise")
 #define DOC_RAND                    DOC_SEE("collection-api/rand")
 #define DOC_RANDINT                 DOC_SEE("collection-api/randint")

--- a/inc/doc.inline.h
+++ b/inc/doc.inline.h
@@ -161,17 +161,4 @@ static inline const char * doc_dup(ti_val_t * val)
     }
 }
 
-static inline const char * doc_clear(ti_val_t * val)
-{
-    switch ((ti_val_enum) val->tp)
-    {
-    case TI_VAL_THING:          return ti_thing_is_object((ti_thing_t *) val) ?
-                                        DOC_THING_CLEAR : NULL;
-    case TI_VAL_ARR:            return ti_varr_is_list((ti_varr_t *) val) ?
-                                        DOC_LIST_CLEAR : NULL;
-    case TI_VAL_SET:            return DOC_SET_CLEAR;
-    default:                    return NULL;
-    }
-}
-
 #endif  /* DOC_INLINE_H_ */

--- a/inc/ti/fn/fnassign.h
+++ b/inc/ti/fn/fnassign.h
@@ -23,7 +23,8 @@ static int do__f_assign(ti_query_t * query, cleri_node_t * nd, ex_t * e)
      *     tmp.assign({x: 1});
      * }
      */
-    if (ti_val_try_lock(query->rval, e))
+    if (ti_query_test_thing_operation(query, e) ||
+        ti_val_try_lock(query->rval, e))
         return e->nr;
 
     thing = (ti_thing_t *) query->rval;

--- a/inc/ti/fn/fnclear.h
+++ b/inc/ti/fn/fnclear.h
@@ -1,72 +1,102 @@
 #include <ti/fn/fn.h>
 
-static int do__f_clear(ti_query_t * query, cleri_node_t * nd, ex_t * e)
+static int do__f_clear_object(ti_query_t * query, cleri_node_t * nd, ex_t * e)
 {
-    const char * doc;
     const int nargs = fn_get_nargs(nd);
-    ti_val_t * val;
+    ti_thing_t * thing;
     size_t n;
 
-    doc = doc_clear(query->rval);
-    if (!doc)
-        return fn_call_try("clear", query, nd, e);
-
-    if (fn_nargs("clear", doc, 0, nargs, e) ||
+    if (fn_nargs("clear", DOC_THING_CLEAR, 0, nargs, e) ||
+        ti_query_test_thing_operation(query, e) ||
         ti_val_try_lock(query->rval, e))
         return e->nr;
 
-    val = query->rval;
+    thing = (ti_thing_t *) query->rval;
     query->rval = (ti_val_t *) ti_nil_get();
 
-    switch (val->tp)
-    {
-    case TI_VAL_THING:
-    {
-        ti_thing_t * thing = (ti_thing_t *) val;
-        n = ti_thing_n(thing);
-        ti_thing_clear(thing);  /* always an object in this case */
+    n = ti_thing_n(thing);
+    ti_thing_clear(thing);  /* always an object in this case */
 
-        if (n && thing->id)
-        {
-            ti_task_t * task = ti_task_get_task(query->change, thing);
-            if (!task || ti_task_add_thing_clear(task))
-                ti_panic("task clear");
-        }
-        break;
-    }
-    case TI_VAL_ARR:
+    if (n && thing->id)
     {
-        ti_varr_t * varr = (ti_varr_t *) val;
-        n = varr->vec->n;
-        vec_clear_cb(varr->vec, (vec_destroy_cb) ti_val_unsafe_gc_drop);
-        if (n && varr->parent && varr->parent->id)
-        {
-            ti_task_t * task = ti_task_get_task(query->change, varr->parent);
-            if (!task || ti_task_add_arr_clear(task, ti_varr_key(varr)))
-                ti_panic("task clear");
-        }
-        break;
-    }
-    case TI_VAL_SET:
-    {
-        ti_vset_t * vset = (ti_vset_t *) val;
-        n = vset->imap->n;
-
-        ti_vset_clear(vset);
-
-        if (n && vset->parent && vset->parent->id)
-        {
-            /* clear must have a task as this is enforced */
-            ti_task_t * task = ti_task_get_task(query->change, vset->parent);
-            if (!task || ti_task_add_set_clear(task, ti_vset_key(vset)))
-                ti_panic("task clear");
-        }
-        break;
-    }
+        ti_task_t * task = ti_task_get_task(query->change, thing);
+        if (!task || ti_task_add_thing_clear(task))
+            ti_panic("task clear");
     }
 
-    ti_val_unlock(val, true  /* lock was set */);
-    ti_val_unsafe_drop(val);
+    ti_val_unlock((ti_val_t *) thing, true  /* lock was set */);
+    ti_val_unsafe_drop((ti_val_t *) thing);
 
     return e->nr;
+}
+
+static int do__f_clear_list(ti_query_t * query, cleri_node_t * nd, ex_t * e)
+{
+    const int nargs = fn_get_nargs(nd);
+    ti_varr_t * varr;
+    size_t n;
+
+    if (fn_nargs("clear", DOC_LIST_CLEAR, 0, nargs, e) ||
+        ti_query_test_varr_operation(query, e) ||
+        ti_val_try_lock(query->rval, e))
+        return e->nr;
+
+    varr = (ti_varr_t *) query->rval;
+    query->rval = (ti_val_t *) ti_nil_get();
+
+    n = varr->vec->n;
+    vec_clear_cb(varr->vec, (vec_destroy_cb) ti_val_unsafe_gc_drop);
+    if (n && varr->parent && varr->parent->id)
+    {
+        ti_task_t * task = ti_task_get_task(query->change, varr->parent);
+        if (!task || ti_task_add_arr_clear(task, ti_varr_key(varr)))
+            ti_panic("task clear");
+    }
+
+    ti_val_unlock((ti_val_t *) varr, true  /* lock was set */);
+    ti_val_unsafe_drop((ti_val_t *) varr);
+
+    return e->nr;
+}
+
+static int do__f_clear_set(ti_query_t * query, cleri_node_t * nd, ex_t * e)
+{
+    const int nargs = fn_get_nargs(nd);
+    ti_vset_t * vset;
+    size_t n;
+
+    if (fn_nargs("clear", DOC_SET_CLEAR, 0, nargs, e) ||
+        ti_query_test_vset_operation(query, e) ||
+        ti_val_try_lock(query->rval, e))
+        return e->nr;
+
+    vset = (ti_vset_t *) query->rval;
+    query->rval = (ti_val_t *) ti_nil_get();
+
+    n = vset->imap->n;
+    ti_vset_clear(vset);
+    if (n && vset->parent && vset->parent->id)
+    {
+        /* clear must have a task as this is enforced */
+        ti_task_t * task = ti_task_get_task(query->change, vset->parent);
+        if (!task || ti_task_add_set_clear(task, ti_vset_key(vset)))
+            ti_panic("task clear");
+    }
+
+    ti_val_unlock((ti_val_t *) vset, true  /* lock was set */);
+    ti_val_unsafe_drop((ti_val_t *) vset);
+
+    return e->nr;
+}
+
+
+static inline int do__f_clear(ti_query_t * query, cleri_node_t * nd, ex_t * e)
+{
+    return ti_val_is_object(query->rval)
+            ? do__f_clear_object(query, nd, e)
+            : ti_val_is_list(query->rval)
+            ? do__f_clear_list(query, nd, e)
+            : ti_val_is_set(query->rval)
+            ? do__f_clear_set(query, nd, e)
+            : fn_call_try("clear", query, nd, e);
 }

--- a/inc/ti/fn/fndel.h
+++ b/inc/ti/fn/fndel.h
@@ -6,6 +6,17 @@ static int do__f_del_vtask(ti_query_t * query, cleri_node_t * nd, ex_t * e)
     ti_task_t * task;
     ti_vtask_t * vtask;
 
+    if (!query->change)
+    {
+        ex_set(e, EX_OPERATION,
+                "operation on a task; "
+                "%s(...)` to enforce a change",
+                (query->qbind.flags & TI_QBIND_FLAG_NSE)
+                    ? "remove `nse"
+                    : "use `wse");
+        return e->nr;
+    }
+
     vtask = (ti_vtask_t *) query->rval;
     if (ti_vtask_is_locked(vtask, e))
         return e->nr;
@@ -45,6 +56,7 @@ static int do__f_del_thing(ti_query_t * query, cleri_node_t * nd, ex_t * e)
         return fn_call_try("del", query, nd, e);
 
     if (fn_nargs("del", DOC_THING_DEL, 1, nargs, e) ||
+        ti_query_test_thing_operation(query, e) ||
         ti_val_try_lock(query->rval, e))
         return e->nr;
 

--- a/inc/ti/fn/fnnse.h
+++ b/inc/ti/fn/fnnse.h
@@ -7,6 +7,14 @@ static int do__f_nse(ti_query_t * query, cleri_node_t * nd, ex_t * e)
     if (fn_nargs_max("nse", DOC_NSE, 1, nargs, e))
         return e->nr;
 
+    if (query->qbind.flags & TI_QBIND_FLAG_WSE)
+    {
+        ex_set(e, EX_OPERATION,
+                "function `nse` failed; at least one side-effect is enforced"
+                DOC_NSE);
+        return e->nr;
+    }
+
     if (!nargs)
     {
         query->rval = (ti_val_t *) ti_nil_get();

--- a/inc/ti/fn/fnnse.h
+++ b/inc/ti/fn/fnnse.h
@@ -1,0 +1,17 @@
+#include <ti/fn/fn.h>
+
+static int do__f_nse(ti_query_t * query, cleri_node_t * nd, ex_t * e)
+{
+    const int nargs = fn_get_nargs(nd);
+
+    if (fn_nargs_max("nse", DOC_NSE, 1, nargs, e))
+        return e->nr;
+
+    if (!nargs)
+    {
+        query->rval = (ti_val_t *) ti_nil_get();
+        return e->nr;
+    }
+
+    return ti_do_statement(query, nd->children, e);
+}

--- a/inc/ti/fn/fnremove.h
+++ b/inc/ti/fn/fnremove.h
@@ -10,6 +10,7 @@ static int do__f_remove_list(ti_query_t * query, cleri_node_t * nd, ex_t * e)
     vec_t * vec;
 
     if (fn_nargs_range("remove", DOC_LIST_REMOVE, 1, 2, nargs, e) ||
+        ti_query_test_varr_operation(query, e) ||
         ti_val_try_lock(query->rval, e))
         return e->nr;
 
@@ -235,6 +236,7 @@ static int do__f_remove_set(ti_query_t * query, cleri_node_t * nd, ex_t * e)
     ti_vset_t * vset;
 
     if (fn_nargs_min("remove", DOC_SET_REMOVE, 1, nargs, e) ||
+        ti_query_test_vset_operation(query, e) ||
         ti_val_try_lock(query->rval, e))
         return e->nr;
 
@@ -406,6 +408,7 @@ static int do__f_remove_thing(ti_query_t * query, cleri_node_t * nd, ex_t * e)
     size_t alloc_sz = 0;
 
     if (fn_nargs_range("remove", DOC_THING_REMOVE, 1, 2, nargs, e) ||
+        ti_query_test_thing_operation(query, e) ||
         ti_val_try_lock(query->rval, e))
         return e->nr;
 

--- a/inc/ti/fn/fnren.h
+++ b/inc/ti/fn/fnren.h
@@ -11,6 +11,7 @@ static int do__f_ren(ti_query_t * query, cleri_node_t * nd, ex_t * e)
         return fn_call_try("ren", query, nd, e);
 
     if (fn_nargs("ren", DOC_THING_REN, 2, nargs, e) ||
+        ti_query_test_thing_operation(query, e) ||
         ti_val_try_lock(query->rval, e))
         return e->nr;
 

--- a/inc/ti/fn/fnrestrict.h
+++ b/inc/ti/fn/fnrestrict.h
@@ -15,7 +15,8 @@ static int do__f_restrict(ti_query_t * query, cleri_node_t * nd, ex_t * e)
     if (!ti_val_is_object(query->rval))
         return fn_call_try("restrict", query, nd, e);
 
-    if (fn_nargs("restrict", DOC_THING_RESTRICT, 1, nargs, e))
+    if (fn_nargs("restrict", DOC_THING_RESTRICT, 1, nargs, e) ||
+        ti_query_test_thing_operation(query, e))
         return e->nr;
 
     /*

--- a/inc/ti/fn/fnset.h
+++ b/inc/ti/fn/fnset.h
@@ -60,6 +60,7 @@ static int do__f_set_thing(ti_query_t * query, cleri_node_t * nd, ex_t * e)
         return fn_call_try("set", query, nd, e);
 
     if (fn_nargs("set", DOC_THING_SET, 2, nargs, e) ||
+        ti_query_test_thing_operation(query, e) ||
         ti_val_try_lock(query->rval, e))
         return e->nr;
 

--- a/inc/ti/fn/fntothing.h
+++ b/inc/ti/fn/fntothing.h
@@ -13,6 +13,7 @@ static int do__f_to_thing(ti_query_t * query, cleri_node_t * nd, ex_t * e)
 
     if (fn_nargs("to_thing", DOC_TYPED_TO_THING, 0, nargs, e) ||
         ti_type_use(thing->via.type, e) ||
+        ti_query_test_thing_operation(query, e) ||
         ti_val_try_lock(query->rval, e))
         return e->nr;
 

--- a/inc/ti/fn/fntotype.h
+++ b/inc/ti/fn/fntotype.h
@@ -11,7 +11,8 @@ static int do__f_to_type(ti_query_t * query, cleri_node_t * nd, ex_t * e)
     if (!ti_val_is_object(query->rval))
         return fn_call_try("to_type", query, nd, e);
 
-    if (fn_nargs("to_type", DOC_THING_TO_TYPE, 1, nargs, e))
+    if (fn_nargs("to_type", DOC_THING_TO_TYPE, 1, nargs, e) ||
+        ti_query_test_thing_operation(query, e))
         return e->nr;
 
     /*

--- a/inc/ti/qbind.t.h
+++ b/inc/ti/qbind.t.h
@@ -8,7 +8,7 @@ typedef enum
 {
     /* Flag THINGSDB and COLLECTION are exclusive, only one may be set.
      * The order is important since the order is used in function binding */
-    TI_QBIND_BIT_UNUSED,
+    TI_QBIND_BIT_NSE=0,
 
     TI_QBIND_BIT_THINGSDB=1,      /* must be one (see qbind, FN__FLAG_EV_T) */
     TI_QBIND_BIT_COLLECTION=2,    /* must be two (see qbind, FN__FLAG_EV_C) */
@@ -24,7 +24,7 @@ typedef enum
 typedef enum
 {
     /* first three flags are exclusive, only one may be set */
-    TI_QBIND_FLAG_UNUSED        =1<<TI_QBIND_BIT_UNUSED,
+    TI_QBIND_FLAG_NSE           =1<<TI_QBIND_BIT_NSE,
 
     TI_QBIND_FLAG_THINGSDB      =1<<TI_QBIND_BIT_THINGSDB,
     TI_QBIND_FLAG_COLLECTION    =1<<TI_QBIND_BIT_COLLECTION,

--- a/inc/ti/query.inline.h
+++ b/inc/ti/query.inline.h
@@ -90,4 +90,14 @@ static inline int ti_query_test_varr_operation(ti_query_t * query, ex_t * e)
     return e->nr;
 }
 
+static inline int ti_query_test_thing_operation(ti_query_t * query, ex_t * e)
+{
+    if (!query->change && ((ti_thing_t *) query->rval)->id)
+        ex_set(e, EX_OPERATION,
+                "operation on a stored thing; "
+                "use `wse(...)` to enforce a change");
+    return e->nr;
+}
+
+
 #endif  /* TI_QUERY_INLINE_H_ */

--- a/inc/ti/query.inline.h
+++ b/inc/ti/query.inline.h
@@ -77,7 +77,10 @@ static inline int ti_query_test_vset_operation(ti_query_t * query, ex_t * e)
     if (!query->change && ti_vset_is_stored((ti_vset_t *) query->rval))
         ex_set(e, EX_OPERATION,
                 "operation on a stored set; "
-                "use `wse(...)` to enforce a change");
+                "%s(...)` to enforce a change",
+                (query->qbind.flags & TI_QBIND_FLAG_NSE)
+                    ? "remove `nse"
+                    : "use `wse");
     return e->nr;
 }
 
@@ -86,7 +89,10 @@ static inline int ti_query_test_varr_operation(ti_query_t * query, ex_t * e)
     if (!query->change && ti_varr_is_stored((ti_varr_t *) query->rval))
         ex_set(e, EX_OPERATION,
                 "operation on a stored list; "
-                "use `wse(...)` to enforce a change");
+                "%s(...)` to enforce a change",
+                (query->qbind.flags & TI_QBIND_FLAG_NSE)
+                    ? "remove `nse"
+                    : "use `wse");
     return e->nr;
 }
 
@@ -95,7 +101,10 @@ static inline int ti_query_test_thing_operation(ti_query_t * query, ex_t * e)
     if (!query->change && ((ti_thing_t *) query->rval)->id)
         ex_set(e, EX_OPERATION,
                 "operation on a stored thing; "
-                "use `wse(...)` to enforce a change");
+                "%s(...)` to enforce a change",
+                (query->qbind.flags & TI_QBIND_FLAG_NSE)
+                    ? "remove `nse"
+                    : "use `wse");
     return e->nr;
 }
 

--- a/inc/ti/version.h
+++ b/inc/ti/version.h
@@ -25,7 +25,7 @@
  *  "-rc0"
  *  ""
  */
-#define TI_VERSION_PRE_RELEASE "-alpha0"
+#define TI_VERSION_PRE_RELEASE "-alpha1"
 
 #define TI_MAINTAINER \
     "Jeroen van der Heijden <jeroen@cesbit.com>"

--- a/src/ti/do.c
+++ b/src/ti/do.c
@@ -260,7 +260,8 @@ static int do__name_assign(ti_query_t * query, cleri_node_t * nd, ex_t * e)
         return e->nr;
     }
 
-    if (ti_val_try_lock(query->rval, e))
+    if (ti_query_test_thing_operation(query, e) ||
+        ti_val_try_lock(query->rval, e))
         return e->nr;
 
     thing = (ti_thing_t *) query->rval;

--- a/src/ti/index.c
+++ b/src/ti/index.c
@@ -215,7 +215,8 @@ static int index__slice_ass(ti_query_t * query, cleri_node_t * inode, ex_t * e)
         return e->nr;
     }
 
-    if (ti_val_try_lock(query->rval, e))
+    if (ti_query_test_varr_operation(query, e) ||
+        ti_val_try_lock(query->rval, e))
         return e->nr;
 
     query->rval = NULL;
@@ -546,7 +547,8 @@ static int index__set(ti_query_t * query, cleri_node_t * inode, ex_t * e)
     ti_thing_t * thing;
     ti_raw_t * rname;
 
-    if (ti_val_try_lock(query->rval, e))
+    if (ti_query_test_thing_operation(query, e) ||
+        ti_val_try_lock(query->rval, e))
         return e->nr;
 
     thing = (ti_thing_t *) query->rval;

--- a/src/ti/index.c
+++ b/src/ti/index.c
@@ -11,6 +11,7 @@
 #include <ti/nil.h>
 #include <ti/opr/oprinc.h>
 #include <ti/prop.h>
+#include <ti/query.inline.h>
 #include <ti/task.h>
 #include <ti/thing.inline.h>
 #include <ti/val.inline.h>

--- a/src/ti/index.c
+++ b/src/ti/index.c
@@ -408,7 +408,8 @@ static int index__array_ass(ti_query_t * query, cleri_node_t * inode, ex_t * e)
     ti_varr_t * varr;
     size_t idx = 0;  /* only set to prevent warning */
 
-    if (ti_val_try_lock(query->rval, e))
+    if (ti_query_test_varr_operation(query, e) ||
+        ti_val_try_lock(query->rval, e))
         return e->nr;
 
     varr = (ti_varr_t *) query->rval;

--- a/src/ti/qbind.c
+++ b/src/ti/qbind.c
@@ -256,8 +256,8 @@ static void qbind__statement(ti_qbind_t * qbind, cleri_node_t * nd);
 
 
 /*
- * Used to convert the TI_QBIND_FLAG_ON_VAR to FN__FLAG_EXCL_VAR. Therefore
- * the FN__FLAG_EXCL_VAR must be `1`.
+ * Used to convert the TI_QBIND_FLAG_ON_VAR to FN__FLAG_XVAR. Therefore
+ * the FN__FLAG_XVAR must be `1`.
  */
 #define qbind__is_onvar(__flag) (((__flag) & TI_QBIND_FLAG_ON_VAR) && 1)
 
@@ -271,11 +271,11 @@ static void qbind__statement(ti_qbind_t * qbind, cleri_node_t * nd);
  */
 enum
 {
-    TOTAL_KEYWORDS = 245,
+    TOTAL_KEYWORDS = 246,
     MIN_WORD_LENGTH = 2,
     MAX_WORD_LENGTH = 17,
-    MIN_HASH_VALUE = 28,
-    MAX_HASH_VALUE = 619
+    MIN_HASH_VALUE = 7,
+    MAX_HASH_VALUE = 602
 };
 
 /*
@@ -287,32 +287,32 @@ static inline unsigned int qbind__hash(
 {
     static unsigned short asso_values[] =
     {
-        620, 620, 620, 620, 620, 620, 620, 620, 620, 620,
-        620, 620, 620, 620, 620, 620, 620, 620, 620, 620,
-        620, 620, 620, 620, 620, 620, 620, 620, 620, 620,
-        620, 620, 620, 620, 620, 620, 620, 620, 620, 620,
-        620, 620, 620, 620, 620, 620, 620, 620, 620, 620,
-        620, 620,  25, 620,  24, 620,  13, 620, 620, 620,
-        620, 620, 620, 620, 620, 620, 620, 620, 620, 620,
-        620, 620, 620, 620, 620, 620, 620, 620, 620, 620,
-        620, 620, 620, 620, 620, 620, 620, 620, 620, 620,
-        620, 620, 620, 620, 620,  12, 620,  13,  20,  36,
-         14,  13,  85, 252, 138,  12,  19, 139,  19,  22,
-         17,  21, 146,  37,  12,  12,  15,  43,  27, 170,
-        154,  48,  51, 620, 620, 620, 620, 620, 620, 620,
-        620, 620, 620, 620, 620, 620, 620, 620, 620, 620,
-        620, 620, 620, 620, 620, 620, 620, 620, 620, 620,
-        620, 620, 620, 620, 620, 620, 620, 620, 620, 620,
-        620, 620, 620, 620, 620, 620, 620, 620, 620, 620,
-        620, 620, 620, 620, 620, 620, 620, 620, 620, 620,
-        620, 620, 620, 620, 620, 620, 620, 620, 620, 620,
-        620, 620, 620, 620, 620, 620, 620, 620, 620, 620,
-        620, 620, 620, 620, 620, 620, 620, 620, 620, 620,
-        620, 620, 620, 620, 620, 620, 620, 620, 620, 620,
-        620, 620, 620, 620, 620, 620, 620, 620, 620, 620,
-        620, 620, 620, 620, 620, 620, 620, 620, 620, 620,
-        620, 620, 620, 620, 620, 620, 620, 620, 620, 620,
-        620, 620, 620, 620, 620, 620
+        603, 603, 603, 603, 603, 603, 603, 603, 603, 603,
+        603, 603, 603, 603, 603, 603, 603, 603, 603, 603,
+        603, 603, 603, 603, 603, 603, 603, 603, 603, 603,
+        603, 603, 603, 603, 603, 603, 603, 603, 603, 603,
+        603, 603, 603, 603, 603, 603, 603, 603, 603, 603,
+        603, 603,   1, 603,   1, 603,   2, 603, 603, 603,
+        603, 603, 603, 603, 603, 603, 603, 603, 603, 603,
+        603, 603, 603, 603, 603, 603, 603, 603, 603, 603,
+        603, 603, 603, 603, 603, 603, 603, 603, 603, 603,
+        603, 603, 603, 603, 603,   0, 603,  10,   8,  41,
+         21,   2, 117, 232, 120,   0,  11, 241,  14,  36,
+         11,  30, 111,   1,   1,   0,   7,  21, 243,  83,
+        199, 165,  31, 603, 603, 603, 603, 603, 603, 603,
+        603, 603, 603, 603, 603, 603, 603, 603, 603, 603,
+        603, 603, 603, 603, 603, 603, 603, 603, 603, 603,
+        603, 603, 603, 603, 603, 603, 603, 603, 603, 603,
+        603, 603, 603, 603, 603, 603, 603, 603, 603, 603,
+        603, 603, 603, 603, 603, 603, 603, 603, 603, 603,
+        603, 603, 603, 603, 603, 603, 603, 603, 603, 603,
+        603, 603, 603, 603, 603, 603, 603, 603, 603, 603,
+        603, 603, 603, 603, 603, 603, 603, 603, 603, 603,
+        603, 603, 603, 603, 603, 603, 603, 603, 603, 603,
+        603, 603, 603, 603, 603, 603, 603, 603, 603, 603,
+        603, 603, 603, 603, 603, 603, 603, 603, 603, 603,
+        603, 603, 603, 603, 603, 603, 603, 603, 603, 603,
+        603, 603, 603, 603, 603, 603
     };
 
     register unsigned int hval = n;
@@ -376,7 +376,7 @@ static inline unsigned int qbind__hash(
 
 typedef enum
 {
-    FN__FLAG_EXCL_VAR   = 1<<0, /* must be 1, see qbind__is_onvar() */
+    FN__FLAG_XVAR   = 1<<0, /* must be 1, see qbind__is_onvar() */
     FN__FLAG_EV_T       = 1<<1, /* must be 2, maps to ti_qbind_bit_t */
     FN__FLAG_EV_C       = 1<<2, /* must be 4, maps to ti_qbind_bit_t */
     FN__FLAG_ROOT       = 1<<3,
@@ -392,7 +392,8 @@ typedef enum
                                    variable as well. */
     FN__FLAG_FUT        = 1<<7, /* must check for closure and do not set wse
                                    by itself */
-    FN__FLAG_SOFT       = 1<<8, /* no change for some */
+    FN__FLAG_NSE        = 1<<8, /* set the nse flag */
+    FN__FLAG_XNSE       = 1<<9, /* no change when nse flag is set*/
 } qbind__fn_flag_t;
 
 typedef struct
@@ -428,48 +429,40 @@ typedef struct
         .flags=FN__FLAG_ROOT|FN__FLAG_EV_T|FN__FLAG_AS_ON_VAR
 #define CHAIN_NE \
         .flags=FN__FLAG_CHAIN|FN__FLAG_AS_ON_VAR
-#define CHAIN_CE \
-        .flags=FN__FLAG_CHAIN|FN__FLAG_EV_C|FN__FLAG_AS_ON_VAR
+#define CHAIN_CE_X \
+        .flags=FN__FLAG_CHAIN|FN__FLAG_EV_C|FN__FLAG_XNSE|FN__FLAG_AS_ON_VAR
 #define CHAIN_BE \
         .flags=FN__FLAG_CHAIN|FN__FLAG_EV_C|FN__FLAG_EV_T|FN__FLAG_AS_ON_VAR
-#define CHAIN_CE_XVAR \
-        .flags=FN__FLAG_CHAIN|FN__FLAG_EXCL_VAR|FN__FLAG_EV_C|FN__FLAG_AS_ON_VAR
+#define CHAIN_BE_X \
+        .flags=FN__FLAG_CHAIN|FN__FLAG_EV_C|FN__FLAG_EV_T|FN__FLAG_XNSE|FN__FLAG_AS_ON_VAR
+#define CHAIN_CE_XX \
+        .flags=FN__FLAG_CHAIN|FN__FLAG_XVAR|FN__FLAG_XNSE|FN__FLAG_EV_C|FN__FLAG_AS_ON_VAR
 #define CHAIN_FUT \
         .flags=FN__FLAG_CHAIN|FN__FLAG_AS_ON_VAR|FN__FLAG_FUT
 #define ROOT_FUT \
         .flags=FN__FLAG_ROOT|FN__FLAG_FUT
 #define BOTH_NE \
         .flags=FN__FLAG_ROOT|FN__FLAG_CHAIN|FN__FLAG_AS_ON_VAR
-#define BOTH_CE_XROOT \
-        .flags=FN__FLAG_ROOT|FN__FLAG_CHAIN|FN__FLAG_EV_C|FN__FLAG_XROOT|FN__FLAG_AS_ON_VAR
+#define BOTH_CE_XXROOT \
+        .flags=FN__FLAG_ROOT|FN__FLAG_CHAIN|FN__FLAG_EV_C|FN__FLAG_XROOT|FN__FLAG_XNSE|FN__FLAG_AS_ON_VAR
 #define XROOT_NE \
         .flags=FN__FLAG_ROOT
 #define XROOT_BE \
         .flags=FN__FLAG_ROOT|FN__FLAG_EV_C|FN__FLAG_EV_T
-#define XROOT_CE \
-        .flags=FN__FLAG_ROOT|FN__FLAG_EV_C
-#define XROOT_TE \
-        .flags=FN__FLAG_ROOT|FN__FLAG_EV_T
 #define XCHAIN_NE \
         .flags=FN__FLAG_CHAIN
-#define XCHAIN_CE \
-        .flags=FN__FLAG_CHAIN|FN__FLAG_EV_C
-#define XCHAIN_CE_XVAR \
-        .flags=FN__FLAG_CHAIN|FN__FLAG_EXCL_VAR|FN__FLAG_EV_C
-#define XBOTH_CE_XROOT \
-        .flags=FN__FLAG_ROOT|FN__FLAG_CHAIN|FN__FLAG_EV_C|FN__FLAG_XROOT
-#define ROOO_NSE \
-        .flags=FN__FLAG_ROOT|FN__FLAG_SOFT
+#define XROOT_NSE \
+        .flags=FN__FLAG_ROOT|FN__FLAG_NSE
 
 qbind__fmap_t qbind__fn_mapping[TOTAL_KEYWORDS] = {
-    {.name="add",               .fn=do__f_add,                  CHAIN_CE_XVAR},
+    {.name="add",               .fn=do__f_add,                  CHAIN_CE_XX},
     {.name="again_at",          .fn=do__f_again_at,             CHAIN_BE},
     {.name="again_in",          .fn=do__f_again_in,             CHAIN_BE},
     {.name="alt_raise",         .fn=do__f_alt_raise,            ROOT_NE},
     {.name="args",              .fn=do__f_args,                 CHAIN_NE},
     {.name="assert_err",        .fn=do__f_assert_err,           ROOT_NE},
     {.name="assert",            .fn=do__f_assert,               ROOT_NE},
-    {.name="assign",            .fn=do__f_assign,               CHAIN_CE},
+    {.name="assign",            .fn=do__f_assign,               CHAIN_CE_X},
     {.name="at",                .fn=do__f_at,                   CHAIN_NE},
     {.name="auth_err",          .fn=do__f_auth_err,             ROOT_NE},
     {.name="backup_info",       .fn=do__f_backup_info,          ROOT_NE},
@@ -484,7 +477,7 @@ qbind__fmap_t qbind__fn_mapping[TOTAL_KEYWORDS] = {
     {.name="cancelled_err",     .fn=do__f_cancelled_err,        ROOT_NE},
     {.name="change_id",         .fn=do__f_change_id,            ROOT_NE},
     {.name="choice",            .fn=do__f_choice,               CHAIN_NE},
-    {.name="clear",             .fn=do__f_clear,                CHAIN_CE},
+    {.name="clear",             .fn=do__f_clear,                CHAIN_CE_X},
     {.name="closure",           .fn=do__f_closure,              BOTH_NE},
     {.name="code",              .fn=do__f_code,                 CHAIN_NE},
     {.name="collection_info",   .fn=do__f_collection_info,      ROOT_NE},
@@ -504,7 +497,7 @@ qbind__fmap_t qbind__fn_mapping[TOTAL_KEYWORDS] = {
     {.name="del_token",         .fn=do__f_del_token,            ROOT_TE},
     {.name="del_type",          .fn=do__f_del_type,             ROOT_CE},
     {.name="del_user",          .fn=do__f_del_user,             ROOT_TE},
-    {.name="del",               .fn=do__f_del,                  CHAIN_BE},
+    {.name="del",               .fn=do__f_del,                  CHAIN_BE_X},
     {.name="deploy_module",     .fn=do__f_deploy_module,        ROOT_TE},
     {.name="doc",               .fn=do__f_doc,                  CHAIN_NE},
     {.name="dup",               .fn=do__f_dup,                  CHAIN_NE},
@@ -520,10 +513,10 @@ qbind__fmap_t qbind__fn_mapping[TOTAL_KEYWORDS] = {
     {.name="err",               .fn=do__f_err,                  BOTH_NE},
     {.name="every",             .fn=do__f_every,                CHAIN_NE},
     {.name="export",            .fn=do__f_export,               ROOT_NE},
-    {.name="extend_unique",     .fn=do__f_extend_unique,        CHAIN_CE_XVAR},
-    {.name="extend",            .fn=do__f_extend,               CHAIN_CE_XVAR},
+    {.name="extend_unique",     .fn=do__f_extend_unique,        CHAIN_CE_XX},
+    {.name="extend",            .fn=do__f_extend,               CHAIN_CE_XX},
     {.name="extract",           .fn=do__f_extract,              CHAIN_NE},
-    {.name="fill",              .fn=do__f_fill,                 CHAIN_CE_XVAR},
+    {.name="fill",              .fn=do__f_fill,                 CHAIN_CE_XX},
     {.name="filter",            .fn=do__f_filter,               CHAIN_NE},
     {.name="find_index",        .fn=do__f_find_index,           CHAIN_NE},
     {.name="find",              .fn=do__f_find,                 XCHAIN_NE},
@@ -607,7 +600,7 @@ qbind__fmap_t qbind__fn_mapping[TOTAL_KEYWORDS] = {
     {.name="new_type",          .fn=do__f_new_type,             ROOT_CE},
     {.name="new_user",          .fn=do__f_new_user,             ROOT_TE},
     {.name="new",               .fn=do__f_new,                  ROOT_NE},
-    {.name="nse",               .fn=do__f_nse,                  ROOO_NSE},
+    {.name="nse",               .fn=do__f_nse,                  XROOT_NSE},
     {.name="node_err",          .fn=do__f_node_err,             ROOT_NE},
     {.name="node_info",         .fn=do__f_node_info,            ROOT_NE},
     {.name="nodes_info",        .fn=do__f_nodes_info,           ROOT_NE},
@@ -617,11 +610,11 @@ qbind__fmap_t qbind__fn_mapping[TOTAL_KEYWORDS] = {
     {.name="operation_err",     .fn=do__f_operation_err,        ROOT_NE},
     {.name="overflow_err",      .fn=do__f_overflow_err,         ROOT_NE},
     {.name="owner",             .fn=do__f_owner,                CHAIN_NE},
-    {.name="pop",               .fn=do__f_pop,                  CHAIN_CE_XVAR},
+    {.name="pop",               .fn=do__f_pop,                  CHAIN_CE_XX},
     {.name="procedure_doc",     .fn=do__f_procedure_doc,        ROOT_NE},
     {.name="procedure_info",    .fn=do__f_procedure_info,       ROOT_NE},
     {.name="procedures_info",   .fn=do__f_procedures_info,      ROOT_NE},
-    {.name="push",              .fn=do__f_push,                 CHAIN_CE_XVAR},
+    {.name="push",              .fn=do__f_push,                 CHAIN_CE_XX},
     {.name="raise",             .fn=do__f_raise,                ROOT_NE},
     {.name="rand",              .fn=do__f_rand,                 ROOT_NE},
     {.name="randint",           .fn=do__f_randint,              ROOT_NE},
@@ -631,8 +624,8 @@ qbind__fmap_t qbind__fn_mapping[TOTAL_KEYWORDS] = {
     {.name="refresh_module",    .fn=do__f_refresh_module,       ROOT_TE},
     {.name="refs",              .fn=do__f_refs,                 ROOT_NE},
     {.name="regex",             .fn=do__f_regex,                ROOT_NE},
-    {.name="remove",            .fn=do__f_remove,               CHAIN_CE},
-    {.name="ren",               .fn=do__f_ren,                  CHAIN_CE},
+    {.name="remove",            .fn=do__f_remove,               CHAIN_CE_X},
+    {.name="ren",               .fn=do__f_ren,                  CHAIN_CE_X},
     {.name="rename_collection", .fn=do__f_rename_collection,    ROOT_TE},
     {.name="rename_enum",       .fn=do__f_rename_enum,          ROOT_CE},
     {.name="rename_module",     .fn=do__f_rename_module,        ROOT_TE},
@@ -643,7 +636,7 @@ qbind__fmap_t qbind__fn_mapping[TOTAL_KEYWORDS] = {
     {.name="reset_counters",    .fn=do__f_reset_counters,       ROOT_NE},
     {.name="restart_module",    .fn=do__f_restart_module,       ROOT_NE},
     {.name="restore",           .fn=do__f_restore,              ROOT_TE},
-    {.name="restrict",          .fn=do__f_restrict,             CHAIN_CE},
+    {.name="restrict",          .fn=do__f_restrict,             CHAIN_CE_X},
     {.name="restriction",       .fn=do__f_restriction,          CHAIN_NE},
     {.name="reverse",           .fn=do__f_reverse,              CHAIN_NE},
     {.name="revoke",            .fn=do__f_revoke,               ROOT_TE},
@@ -661,12 +654,12 @@ qbind__fmap_t qbind__fn_mapping[TOTAL_KEYWORDS] = {
     {.name="set_password",      .fn=do__f_set_password,         ROOT_TE},
     {.name="set_time_zone",     .fn=do__f_set_time_zone,        ROOT_TE},
     {.name="set_type",          .fn=do__f_set_type,             ROOT_CE},
-    {.name="set",               .fn=do__f_set,                  BOTH_CE_XROOT},
-    {.name="shift",             .fn=do__f_shift,                CHAIN_CE_XVAR},
+    {.name="set",               .fn=do__f_set,                  BOTH_CE_XXROOT},
+    {.name="shift",             .fn=do__f_shift,                CHAIN_CE_XX},
     {.name="shutdown",          .fn=do__f_shutdown,             ROOT_NE},
     {.name="some",              .fn=do__f_some,                 CHAIN_NE},
     {.name="sort",              .fn=do__f_sort,                 CHAIN_NE},
-    {.name="splice",            .fn=do__f_splice,               CHAIN_CE_XVAR},
+    {.name="splice",            .fn=do__f_splice,               CHAIN_CE_XX},
     {.name="split",             .fn=do__f_split,                CHAIN_NE},
     {.name="starts_with",       .fn=do__f_starts_with,          CHAIN_NE},
     {.name="str",               .fn=do__f_str,                  ROOT_NE},
@@ -678,8 +671,8 @@ qbind__fmap_t qbind__fn_mapping[TOTAL_KEYWORDS] = {
     {.name="thing",             .fn=do__f_thing,                ROOT_NE},
     {.name="time_zones_info",   .fn=do__f_time_zones_info,      ROOT_NE},
     {.name="timeval",           .fn=do__f_timeval,              ROOT_NE},
-    {.name="to_thing",          .fn=do__f_to_thing,             CHAIN_CE},
-    {.name="to_type",           .fn=do__f_to_type,              CHAIN_CE},
+    {.name="to_thing",          .fn=do__f_to_thing,             CHAIN_CE_X},
+    {.name="to_type",           .fn=do__f_to_type,              CHAIN_CE_X},
     {.name="to",                .fn=do__f_to,                   CHAIN_NE},
     {.name="trim_left",         .fn=do__f_trim_left,            CHAIN_NE},
     {.name="trim_right",        .fn=do__f_trim_right,           CHAIN_NE},
@@ -692,7 +685,7 @@ qbind__fmap_t qbind__fn_mapping[TOTAL_KEYWORDS] = {
     {.name="type",              .fn=do__f_type,                 ROOT_NE},
     {.name="types_info",        .fn=do__f_types_info,           ROOT_NE},
     {.name="unique",            .fn=do__f_unique,               CHAIN_NE},
-    {.name="unshift",           .fn=do__f_unshift,              CHAIN_CE_XVAR},
+    {.name="unshift",           .fn=do__f_unshift,              CHAIN_CE_XX},
     {.name="unwrap",            .fn=do__f_unwrap,               CHAIN_NE},
     {.name="upper",             .fn=do__f_upper,                CHAIN_NE},
     {.name="user_info",         .fn=do__f_user_info,            ROOT_NE},
@@ -911,9 +904,9 @@ static void qbind__function(
     /* may set wse flag */
     q->flags |= (
         ((FN__FLAG_EV_T|FN__FLAG_EV_C) & q->flags & fmflags) &&
-        ((~fmflags & FN__FLAG_EXCL_VAR) || (~flags & FN__FLAG_EXCL_VAR)) &&
+        ((~fmflags & FN__FLAG_XVAR) || (~flags & FN__FLAG_XVAR)) &&
         ((~fmflags & FN__FLAG_XROOT) || (~flags & FN__FLAG_ROOT)) &&
-        ((~fmflags & FN__FLAG_SOFT) || (~flags & FN__FLAG_SOFT))
+        ((~fmflags & FN__FLAG_XNSE) || (~q->flags & TI_QBIND_FLAG_NSE))
     ) << TI_QBIND_BIT_WSE;
 
     /* update the value cache if no build-in function is found */
@@ -924,6 +917,9 @@ static void qbind__function(
 
     /* list (arguments) */
     nd = nd->children->next->children->next;
+
+    if (fmflags & FN__FLAG_NSE)
+        q->flags |= TI_QBIND_FLAG_NSE;
 
     if (fmflags & FN__FLAG_FUT)
     {

--- a/src/ti/qbind.c
+++ b/src/ti/qbind.c
@@ -376,7 +376,7 @@ static inline unsigned int qbind__hash(
 
 typedef enum
 {
-    FN__FLAG_XVAR   = 1<<0, /* must be 1, see qbind__is_onvar() */
+    FN__FLAG_XVAR       = 1<<0, /* must be 1, see qbind__is_onvar() */
     FN__FLAG_EV_T       = 1<<1, /* must be 2, maps to ti_qbind_bit_t */
     FN__FLAG_EV_C       = 1<<2, /* must be 4, maps to ti_qbind_bit_t */
     FN__FLAG_ROOT       = 1<<3,


### PR DESCRIPTION
## Description

Sometimes ThingsDB will generate a change while you _know_ it is not required.
A common example is the following:
```javascript
response = {};
response.test = "message";  // this will create a change as ThingsDB doesn't know that response is not stored
response;
```

We know that ThingsDB does not require a change, however one will be created.
With the new function _nse()_ we could _promise_ ThingsDB that no change is required.
The function _nse()_ will only work for _chained_ function calls and assignments. Therefore calling _wse()_ will create a change and will make a call to _nse()_ obsolete. The _nse()_ function should raise an error in the latter case as the usage is not legit.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

- [x] Test Collection functions

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
