### PR TITLE
Modprocedure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # v1.4.13
 
-* Added function `mod_procedure(..)`, pr .
+* Added function `mod_procedure(..)`, pr #348.
 
 # v1.4.12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v1.4.13
+
+* Added function `mod_procedure(..)`, pr .
+
 # v1.4.12
 
 * Added `timeit(..)` function, issue #345.

--- a/inc/doc.h
+++ b/inc/doc.h
@@ -170,6 +170,7 @@
 /* Procedures API */
 #define DOC_DEL_PROCEDURE           DOC_SEE("procedures-api/del_procedure")
 #define DOC_HAS_PROCEDURE           DOC_SEE("procedures-api/has_procedure")
+#define DOC_MOD_PROCEDURE           DOC_SEE("procedures-api/mod_procedure")
 #define DOC_NEW_PROCEDURE           DOC_SEE("procedures-api/new_procedure")
 #define DOC_PROCEDURE_DOC           DOC_SEE("procedures-api/procedure_doc")
 #define DOC_PROCEDURE_INFO          DOC_SEE("procedures-api/procedure_info")

--- a/inc/ti/fn/fnmodprocedure.h
+++ b/inc/ti/fn/fnmodprocedure.h
@@ -1,0 +1,50 @@
+#include <ti/fn/fn.h>
+
+static int do__f_mod_procedure(ti_query_t * query, cleri_node_t * nd, ex_t * e)
+{
+    const int nargs = fn_get_nargs(nd);
+    ti_task_t * task;
+    ti_raw_t * raw;
+    ti_procedure_t * procedure;
+    ti_closure_t * closure;
+    smap_t * procedures = ti_query_procedures(query);
+
+    if (fn_not_thingsdb_or_collection_scope("mod_procedure", query, e) ||
+        fn_nargs("mod_procedure", DOC_MOD_PROCEDURE, 2, nargs, e) ||
+        ti_do_statement(query, nd->children, e) ||
+        fn_arg_str("mod_procedure", DOC_MOD_PROCEDURE, 1, query->rval, e))
+        return e->nr;
+
+    procedure = ti_procedures_by_name(procedures, (ti_raw_t *) query->rval);
+    if (!procedure)
+        return ti_raw_err_not_found((ti_raw_t *) query->rval, "procedure", e);
+
+    raw = (ti_raw_t *) query->rval;
+    query->rval = NULL;
+
+    if (ti_do_statement(query, nd->children->next->next, e) ||
+        fn_arg_closure("mod_procedure", DOC_MOD_PROCEDURE, 2, query->rval, e))
+        goto fail1;
+
+    closure = (ti_closure_t *) query->rval;
+    if (ti_closure_unbound(closure, e))
+        goto fail1;
+
+    ti_procedure_mod(procedure, closure, util_now_usec());
+
+    query->rval = (ti_val_t *) raw;
+
+    task = ti_task_get_task(
+            query->change,
+            query->collection ? query->collection->root : ti.thing0);
+    if (!task || ti_task_add_mod_procedure(task, procedure))
+    {
+        ti_panic("failed to create mod_procedure task");
+        ex_set_mem(e);
+    }
+    return e->nr;
+
+fail1:
+    ti_val_unsafe_drop((ti_val_t *) raw);
+    return e->nr;
+}

--- a/inc/ti/procedure.h
+++ b/inc/ti/procedure.h
@@ -21,6 +21,10 @@ ti_procedure_t * ti_procedure_create(
         size_t name_n,
         ti_closure_t * closure,
         uint64_t created_at);
+void ti_procedure_mod(
+        ti_procedure_t * procedure,
+        ti_closure_t * closure,
+        uint64_t created_at);
 void ti_procedure_destroy(ti_procedure_t * procedure);
 int ti_procedure_info_to_pk(
         ti_procedure_t * procedure,

--- a/inc/ti/task.h
+++ b/inc/ti/task.h
@@ -65,6 +65,7 @@ int ti_task_add_new_module(
         ti_raw_t * source);
 int ti_task_add_new_node(ti_task_t * task, ti_node_t * node);
 int ti_task_add_new_procedure(ti_task_t * task, ti_procedure_t * procedure);
+int ti_task_add_mod_procedure(ti_task_t * task, ti_procedure_t * procedure);
 int ti_task_add_vtask_new(ti_task_t * task, ti_vtask_t * vtask);
 int ti_task_add_vtask_del(ti_task_t * task, ti_vtask_t * vtask);
 int ti_task_add_vtask_cancel(ti_task_t * task, ti_vtask_t * vtask);

--- a/inc/ti/task.t.h
+++ b/inc/ti/task.t.h
@@ -84,6 +84,7 @@ typedef enum
     TI_TASK_MOD_TYPE_HID,                   /* 71  */
     TI_TASK_REN,                            /* 72  */
     TI_TASK_FILL,                           /* 73  */
+    TI_TASK_MOD_PROCEDURE,                  /* 74  */
 } ti_task_enum;
 
 typedef struct ti_task_s ti_task_t;

--- a/inc/ti/version.h
+++ b/inc/ti/version.h
@@ -6,7 +6,7 @@
 
 #define TI_VERSION_MAJOR 1
 #define TI_VERSION_MINOR 4
-#define TI_VERSION_PATCH 12
+#define TI_VERSION_PATCH 13
 
 /* The syntax version is used to test compatibility with functions
  * using the `ti_nodes_check_syntax()` function */
@@ -25,7 +25,7 @@
  *  "-rc0"
  *  ""
  */
-#define TI_VERSION_PRE_RELEASE ""
+#define TI_VERSION_PRE_RELEASE "-alpha0"
 
 #define TI_MAINTAINER \
     "Jeroen van der Heijden <jeroen@cesbit.com>"

--- a/itest/test_procedures.py
+++ b/itest/test_procedures.py
@@ -255,10 +255,23 @@ class TestProcedures(TestBase):
             del_procedure('missing_wse');
         '''), None)
 
-        await asyncio.sleep(0.2)
+        await client.query("""//ti
+            mod_procedure('upd_list', |i| {
+                "Modified";
+                wse({
+                    .upd_list.call(i);
+                });
+                nil;  // Return nil
+            });
+        """)
+
+        await asyncio.sleep(1.0)
         for client in (client0, client1, client2, client3, client4):
+            self.assertEqual(
+                await client.query('procedure_doc("upd_list");'), "Modified")
+
             self.assertTrue(await client.query(
-                '(procedures_info().len() == 5);'))
+                'procedures_info().len() == 5;'))
 
         # run tests
         await self.run_tests(client0)

--- a/src/ti/procedure.c
+++ b/src/ti/procedure.c
@@ -57,6 +57,8 @@ void ti_procedure_mod(
     ti_val_unsafe_drop((ti_val_t *) procedure->closure);
     ti_val_drop((ti_val_t *) procedure->doc);
     ti_val_drop((ti_val_t *) procedure->def);
+    procedure->doc = NULL;
+    procedure->def = NULL;
     procedure->closure = closure;
     procedure->created_at = created_at;
 }

--- a/src/ti/procedure.c
+++ b/src/ti/procedure.c
@@ -49,6 +49,18 @@ ti_procedure_t * ti_procedure_create(
     return procedure;
 }
 
+void ti_procedure_mod(
+        ti_procedure_t * procedure,
+        ti_closure_t * closure,
+        uint64_t created_at)
+{
+    ti_val_unsafe_drop((ti_val_t *) procedure->closure);
+    ti_val_drop((ti_val_t *) procedure->doc);
+    ti_val_drop((ti_val_t *) procedure->def);
+    procedure->closure = closure;
+    procedure->created_at = created_at;
+}
+
 void ti_procedure_destroy(ti_procedure_t * procedure)
 {
     if (!procedure)

--- a/src/ti/qbind.c
+++ b/src/ti/qbind.c
@@ -138,6 +138,7 @@
 #include <ti/fn/fnmaptype.h>
 #include <ti/fn/fnmapwrap.h>
 #include <ti/fn/fnmodenum.h>
+#include <ti/fn/fnmodprocedure.h>
 #include <ti/fn/fnmodtype.h>
 #include <ti/fn/fnmoduleinfo.h>
 #include <ti/fn/fnmodulesinfo.h>
@@ -276,11 +277,11 @@ static void qbind__statement(ti_qbind_t * qbind, cleri_node_t * nd);
  */
 enum
 {
-    TOTAL_KEYWORDS = 251,
+    TOTAL_KEYWORDS = 252,
     MIN_WORD_LENGTH = 2,
     MAX_WORD_LENGTH = 17,
-    MIN_HASH_VALUE = 23,
-    MAX_HASH_VALUE = 651
+    MIN_HASH_VALUE = 6,
+    MAX_HASH_VALUE = 645
 };
 
 /*
@@ -292,32 +293,32 @@ static inline unsigned int qbind__hash(
 {
     static unsigned short asso_values[] =
     {
-        652, 652, 652, 652, 652, 652, 652, 652, 652, 652,
-        652, 652, 652, 652, 652, 652, 652, 652, 652, 652,
-        652, 652, 652, 652, 652, 652, 652, 652, 652, 652,
-        652, 652, 652, 652, 652, 652, 652, 652, 652, 652,
-        652, 652, 652, 652, 652, 652, 652, 652, 652, 652,
-        652, 652,  12, 652,  12, 652,  11, 652, 652, 652,
-        652, 652, 652, 652, 652, 652, 652, 652, 652, 652,
-        652, 652, 652, 652, 652, 652, 652, 652, 652, 652,
-        652, 652, 652, 652, 652, 652, 652, 652, 652, 652,
-        652, 652, 652, 652, 652,  10, 652,  11,  21,  47,
-         35,  11,  70, 236, 179,  10,  11, 174,  15,  21,
-         13,  50,  96,  22,  12,  10,  10,  30, 223, 163,
-        126, 182,  40, 652, 652, 652, 652, 652, 652, 652,
-        652, 652, 652, 652, 652, 652, 652, 652, 652, 652,
-        652, 652, 652, 652, 652, 652, 652, 652, 652, 652,
-        652, 652, 652, 652, 652, 652, 652, 652, 652, 652,
-        652, 652, 652, 652, 652, 652, 652, 652, 652, 652,
-        652, 652, 652, 652, 652, 652, 652, 652, 652, 652,
-        652, 652, 652, 652, 652, 652, 652, 652, 652, 652,
-        652, 652, 652, 652, 652, 652, 652, 652, 652, 652,
-        652, 652, 652, 652, 652, 652, 652, 652, 652, 652,
-        652, 652, 652, 652, 652, 652, 652, 652, 652, 652,
-        652, 652, 652, 652, 652, 652, 652, 652, 652, 652,
-        652, 652, 652, 652, 652, 652, 652, 652, 652, 652,
-        652, 652, 652, 652, 652, 652, 652, 652, 652, 652,
-        652, 652, 652, 652, 652, 652
+        646, 646, 646, 646, 646, 646, 646, 646, 646, 646,
+        646, 646, 646, 646, 646, 646, 646, 646, 646, 646,
+        646, 646, 646, 646, 646, 646, 646, 646, 646, 646,
+        646, 646, 646, 646, 646, 646, 646, 646, 646, 646,
+        646, 646, 646, 646, 646, 646, 646, 646, 646, 646,
+        646, 646,   1, 646,   1, 646,   1, 646, 646, 646,
+        646, 646, 646, 646, 646, 646, 646, 646, 646, 646,
+        646, 646, 646, 646, 646, 646, 646, 646, 646, 646,
+        646, 646, 646, 646, 646, 646, 646, 646, 646, 646,
+        646, 646, 646, 646, 646,   0, 646,  15,  57,  51,
+         17,   4, 118, 298, 153,   0,   0, 121,  19,  54,
+          8,  33, 133,  32,   3,   0,   0,  11,  97, 235,
+         21, 115,  65, 646, 646, 646, 646, 646, 646, 646,
+        646, 646, 646, 646, 646, 646, 646, 646, 646, 646,
+        646, 646, 646, 646, 646, 646, 646, 646, 646, 646,
+        646, 646, 646, 646, 646, 646, 646, 646, 646, 646,
+        646, 646, 646, 646, 646, 646, 646, 646, 646, 646,
+        646, 646, 646, 646, 646, 646, 646, 646, 646, 646,
+        646, 646, 646, 646, 646, 646, 646, 646, 646, 646,
+        646, 646, 646, 646, 646, 646, 646, 646, 646, 646,
+        646, 646, 646, 646, 646, 646, 646, 646, 646, 646,
+        646, 646, 646, 646, 646, 646, 646, 646, 646, 646,
+        646, 646, 646, 646, 646, 646, 646, 646, 646, 646,
+        646, 646, 646, 646, 646, 646, 646, 646, 646, 646,
+        646, 646, 646, 646, 646, 646, 646, 646, 646, 646,
+        646, 646, 646, 646, 646, 646
     };
 
     register unsigned int hval = n;
@@ -588,12 +589,13 @@ qbind__fmap_t qbind__fn_mapping[TOTAL_KEYWORDS] = {
     {.name="log",               .fn=do__f_log,                  ROOT_NE},
     {.name="lookup_err",        .fn=do__f_lookup_err,           ROOT_NE},
     {.name="lower",             .fn=do__f_lower,                CHAIN_NE},
-    {.name="map",               .fn=do__f_map,                  CHAIN_NE},
     {.name="map_id",            .fn=do__f_map_id,               CHAIN_NE},
     {.name="map_type",          .fn=do__f_map_type,             CHAIN_NE},
     {.name="map_wrap",          .fn=do__f_map_wrap,             CHAIN_NE},
+    {.name="map",               .fn=do__f_map,                  CHAIN_NE},
     {.name="max_quota_err",     .fn=do__f_max_quota_err,        ROOT_NE},
     {.name="mod_enum",          .fn=do__f_mod_enum,             ROOT_CE},
+    {.name="mod_procedure",     .fn=do__f_mod_procedure,        ROOT_BE},
     {.name="mod_type",          .fn=do__f_mod_type,             ROOT_CE},
     {.name="module_info",       .fn=do__f_module_info,          ROOT_NE},
     {.name="modules_info",      .fn=do__f_modules_info,         ROOT_NE},
@@ -609,11 +611,11 @@ qbind__fmap_t qbind__fn_mapping[TOTAL_KEYWORDS] = {
     {.name="new_type",          .fn=do__f_new_type,             ROOT_CE},
     {.name="new_user",          .fn=do__f_new_user,             ROOT_TE},
     {.name="new",               .fn=do__f_new,                  ROOT_NE},
-    {.name="nse",               .fn=do__f_nse,                  XROOT_NSE},
     {.name="node_err",          .fn=do__f_node_err,             ROOT_NE},
     {.name="node_info",         .fn=do__f_node_info,            ROOT_NE},
     {.name="nodes_info",        .fn=do__f_nodes_info,           ROOT_NE},
     {.name="now",               .fn=do__f_now,                  ROOT_NE},
+    {.name="nse",               .fn=do__f_nse,                  XROOT_NSE},
     {.name="num_arguments_err", .fn=do__f_num_arguments_err,    ROOT_NE},
     {.name="one",               .fn=do__f_one,                  CHAIN_NE},
     {.name="operation_err",     .fn=do__f_operation_err,        ROOT_NE},

--- a/src/ti/task.c
+++ b/src/ti/task.c
@@ -1134,6 +1134,50 @@ fail_pack:
     return -1;
 }
 
+int ti_task_add_mod_procedure(ti_task_t * task, ti_procedure_t * procedure)
+{
+    size_t alloc = procedure->closure->node->len + procedure->name_n + 64;
+    ti_data_t * data;
+    msgpack_packer pk;
+    msgpack_sbuffer buffer;
+
+    if (mp_sbuffer_alloc_init(&buffer, alloc, sizeof(ti_data_t)))
+        return -1;
+    msgpack_packer_init(&pk, &buffer, msgpack_sbuffer_write);
+
+    msgpack_pack_array(&pk, 2);
+
+    msgpack_pack_uint8(&pk, TI_TASK_MOD_PROCEDURE);
+    msgpack_pack_map(&pk, 3);
+
+    mp_pack_str(&pk, "name");
+    mp_pack_strn(&pk, procedure->name, procedure->name_n);
+
+    mp_pack_str(&pk, "created_at");
+    msgpack_pack_uint64(&pk, procedure->created_at);
+
+    mp_pack_str(&pk, "closure");
+    if (ti_closure_to_store_pk(procedure->closure, &pk))
+        goto fail_pack;
+
+    data = (ti_data_t *) buffer.data;
+    ti_data_init(data, buffer.size);
+
+    if (vec_push(&task->list, data))
+        goto fail_data;
+
+    task__upd_approx_sz(task, data);
+    return 0;
+
+fail_data:
+    free(data);
+    return -1;
+
+fail_pack:
+    msgpack_sbuffer_destroy(&buffer);
+    return -1;
+}
+
 int ti_task_add_vtask_new(ti_task_t * task, ti_vtask_t * vtask)
 {
     size_t alloc = 1024;


### PR DESCRIPTION
## Description

Adds a function `mod_procedure(..)` which allows you to change the closure for a procedure.

This is basically a shortcut for running `del_procedure(..)` and `new_procedure(..)`. 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Update test_procedures 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
