### PR TITLE
Implement improved dup() and copy()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v1.4.16
+
+* Improve `dup()` and `copy()` with self references, pr #355.
+
 # v1.4.15
 
 * Added support for methods on an _enumerator_ type, pr #352.

--- a/inc/ti/thing.t.h
+++ b/inc/ti/thing.t.h
@@ -56,6 +56,7 @@ enum
                                            the `id`.*/
     TI_THING_FLAG_DICT      =1<<2,      /* thing is an object and items are
                                            stored in the smap_t. */
+    TI_THING_FLAG_DEEP      =1<<3,      /* used for deep copy/duplication */
 };
 
 union ti_thing_via_items

--- a/inc/ti/version.h
+++ b/inc/ti/version.h
@@ -6,7 +6,7 @@
 
 #define TI_VERSION_MAJOR 1
 #define TI_VERSION_MINOR 4
-#define TI_VERSION_PATCH 15
+#define TI_VERSION_PATCH 16
 
 /* The syntax version is used to test compatibility with functions
  * using the `ti_nodes_check_syntax()` function */
@@ -25,7 +25,7 @@
  *  "-rc0"
  *  ""
  */
-#define TI_VERSION_PRE_RELEASE ""
+#define TI_VERSION_PRE_RELEASE "-alpha0"
 
 #define TI_MAINTAINER \
     "Jeroen van der Heijden <jeroen@cesbit.com>"

--- a/itest/test_advanced.py
+++ b/itest/test_advanced.py
@@ -2422,6 +2422,56 @@ new_procedure('multiply', |a, b| a * b);
                 A{TEST};
             """, scope='/thingsdb')
 
+    async def test_deep_copy_and_dup(self, client):
+        # pr #355
+        res = await client.query(r"""//ti
+            a = {};
+            a.a = a;
+            b = a.dup(10);
+            b == b.a.a.a;
+        """)
+        self.assertIs(res, True)
+        res = await client.query(r"""//ti
+            a = {};
+            a.a = a;
+            b = a.copy(10);
+            b == b.a.a.a;
+        """)
+        self.assertIs(res, True)
+        res = await client.query(r"""//ti
+            a = {};
+            a['for item thing'] = 1;
+            a.a = a;
+            b = a.copy(10);
+            b == b.a.a.a;
+        """)
+        self.assertIs(res, True)
+        res = await client.query(r"""//ti
+            a = {};
+            a['for item thing'] = 1;
+            a.a = a;
+            b = a.dup(10);
+            b == b.a.a.a;
+        """)
+        self.assertIs(res, True)
+        res = await client.query(r"""//ti
+            new_type('T');
+            set_type('T', {
+                a: 'T?'
+            });
+            a = T{};
+            a.a = a;
+            b = a.dup(10);
+            b == b.a.a.a;
+        """)
+        self.assertIs(res, True)
+        res = await client.query(r"""//ti
+            a = T{};
+            a.a = a;
+            b = a.copy(10);
+            b == b.a.a.a;
+        """)
+        self.assertIs(res, True)
 
 if __name__ == '__main__':
     run_test(TestAdvanced())


### PR DESCRIPTION
## Description

When creating a duplicate or copy with a large deep value, potentially many things will be created when a thing contains a self reference. This pull request improves duplicates or copies by using a single copy for the same thing if found by recursion. This can drastically improve the performance and is usually what you want as a user. 

## Type of change

- [x] Improvement of existing functionality. While we do not expect existing code depends on the _old_ behavior, the _new_ behavior is different so you might want to check where `copy()` or `dup()` is used with a deep level greater or equal to two. For example `my_thing.dup(2)` might yield a different result. 
 
## How Has This Been Tested?

- [x] Update test code

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
