### PR TITLE
Added subset and superset operations for sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * libcleri is now integrated into the core ThingsDB codebase, eliminating the need for separate installation.
 * The `new_backup()` and `new_token()` functions no longer accept `int`, `float` or `str` as time.
   _(This was marked as deprecated since v0.10.1)_
+* Added set operators `<`, `<=`, `>`, `>=` for subset, proper subset, superset and proper superset checking.
 
 # v1.4.16
 

--- a/inc/ti/opr/ge.h
+++ b/inc/ti/opr/ge.h
@@ -64,6 +64,9 @@ static int opr__ge(ti_val_t * a, ti_val_t ** b, ex_t * e)
     case OPR_BYTES_BYTES:
         bool_ = ti_raw_cmp((ti_raw_t *) a, (ti_raw_t *) *b) >= 0;
         break;
+    case OPR_SET_SET:
+        bool_ = ti_vset_ge((ti_vset_t*) a, (ti_vset_t *) *b);
+        break;
     }
 
     ti_val_unsafe_drop(*b);

--- a/inc/ti/opr/gt.h
+++ b/inc/ti/opr/gt.h
@@ -64,6 +64,9 @@ static int opr__gt(ti_val_t * a, ti_val_t ** b, ex_t * e)
     case OPR_BYTES_BYTES:
         bool_ = ti_raw_cmp((ti_raw_t *) a, (ti_raw_t *) *b) > 0;
         break;
+    case OPR_SET_SET:
+        bool_ = ti_vset_gt((ti_vset_t*) a, (ti_vset_t *) *b);
+        break;
     }
 
     ti_val_unsafe_drop(*b);

--- a/inc/ti/opr/le.h
+++ b/inc/ti/opr/le.h
@@ -64,6 +64,9 @@ static int opr__le(ti_val_t * a, ti_val_t ** b, ex_t * e)
     case OPR_BYTES_BYTES:
         bool_ = ti_raw_cmp((ti_raw_t *) a, (ti_raw_t *) *b) <= 0;
         break;
+    case OPR_SET_SET:
+        bool_ = ti_vset_le((ti_vset_t*) a, (ti_vset_t *) *b);
+        break;
     }
 
     ti_val_unsafe_drop(*b);

--- a/inc/ti/opr/lt.h
+++ b/inc/ti/opr/lt.h
@@ -64,6 +64,9 @@ static int opr__lt(ti_val_t * a, ti_val_t ** b, ex_t * e)
     case OPR_BYTES_BYTES:
         bool_ = ti_raw_cmp((ti_raw_t *) a, (ti_raw_t *) *b) < 0;
         break;
+    case OPR_SET_SET:
+        bool_ = ti_vset_lt((ti_vset_t*) a, (ti_vset_t *) *b);
+        break;
     }
 
     ti_val_unsafe_drop(*b);

--- a/inc/ti/version.h
+++ b/inc/ti/version.h
@@ -25,7 +25,7 @@
  *  "-rc0"
  *  ""
  */
-#define TI_VERSION_PRE_RELEASE "-alpha8"
+#define TI_VERSION_PRE_RELEASE "-alpha9"
 
 #define TI_MAINTAINER \
     "Jeroen van der Heijden <jeroen@cesbit.com>"

--- a/inc/ti/vset.h
+++ b/inc/ti/vset.h
@@ -72,6 +72,26 @@ static inline _Bool ti_vset_eq(ti_vset_t * va, ti_vset_t * vb)
     return imap_eq(va->imap, vb->imap);
 }
 
+static inline _Bool ti_vset_le(ti_vset_t * va, ti_vset_t * vb)
+{
+    return imap_le(va->imap, vb->imap);
+}
+
+static inline _Bool ti_vset_lt(ti_vset_t * va, ti_vset_t * vb)
+{
+    return imap_lt(va->imap, vb->imap);
+}
+
+static inline _Bool ti_vset_ge(ti_vset_t * va, ti_vset_t * vb)
+{
+    return imap_le(vb->imap, va->imap);
+}
+
+static inline _Bool ti_vset_gt(ti_vset_t * va, ti_vset_t * vb)
+{
+    return imap_lt(vb->imap, va->imap);
+}
+
 static inline void * ti_vset_key(ti_vset_t * vset)
 {
     return ti_thing_is_object(vset->parent)

--- a/inc/util/imap.h
+++ b/inc/util/imap.h
@@ -41,6 +41,7 @@ int imap_walk_cp(
         imap_destroy_cb destroy_cb);
 void imap_walkn(imap_t * imap, size_t * n, imap_cb cb, void * arg);
 _Bool imap__eq_(imap_t * a, imap_t * b);
+_Bool imap__le_(imap_t * a, imap_t * b);
 static inline _Bool imap_eq(imap_t * a, imap_t * b);
 vec_t * imap_vec(imap_t * imap);
 vec_t * imap_vec_ref(imap_t * imap);
@@ -81,6 +82,16 @@ struct imap_s
 static inline _Bool imap_eq(imap_t * a, imap_t * b)
 {
     return a == b || (a->n == b->n && (!a->n || imap__eq_(a, b)));
+}
+
+static inline _Bool imap_le(imap_t * a, imap_t * b)
+{
+    return a == b || !a->n || (a->n <= b->n && imap__le_(a, b));
+}
+
+static inline _Bool imap_lt(imap_t * a, imap_t * b)
+{
+    return (!a->n && b->n) || (a != b && a->n < b->n && imap__le_(a, b));
 }
 
 #endif /* IMAP_H_ */

--- a/itest/test_advanced.py
+++ b/itest/test_advanced.py
@@ -2025,18 +2025,6 @@ new_procedure('multiply', |a, b| a * b);
                 'name `union` is reserved'):
             await client.query('new_type("union");')
 
-    async def test_reserved_enum_union(self, client):
-        # bug #294
-        with self.assertRaisesRegex(
-                ValueError,
-                'name `enum` is reserved'):
-            await client.query('new_type("enum");')
-
-        with self.assertRaisesRegex(
-                ValueError,
-                'name `union` is reserved'):
-            await client.query('new_type("union");')
-
     async def test_loop_set_relation_error(self, client):
         # bug 302
         with self.assertRaises(AssertionError):

--- a/itest/test_operators.py
+++ b/itest/test_operators.py
@@ -237,6 +237,35 @@ class TestOperators(TestBase):
         ''')
         self.assertEqual(set(res), {10, 20, 30, 41, 42, 50})
 
+        res = await client.query(r"""//ti
+            [
+                set() < set(),
+                set() <= set(),
+                set() < set(.x10),
+                set(.x10, .x40, .x41) < set(.x10, .x40, .x41),
+                set(.x10, .x40, .x41) <= set(.x10, .x40, .x41),
+                set(.x10, .x40, .x41) > set(.x10, .x40, .x41),
+                set(.x10, .x40, .x41) >= set(.x10, .x40, .x41),
+                set(.x10) <= set(),
+                set(.x10) < set(),
+                set(.x10, .x40, .x41) < set(.x10, .x41, .x42, .x43),
+                set(.x10, .x41) <= set(.x10, .x11, .x41, .x42, .x43),
+            ];
+        """)
+        self.assertEqual(res, [
+            False,
+            True,
+            True,
+            False,
+            True,
+            False,
+            True,
+            False,
+            False,
+            False,
+            True,
+        ])
+
     async def test_preopr(self, client):
         self.assertIs(await client.query(r'''
             !true;


### PR DESCRIPTION
## Description

Added support for the following set operations:

Operation | Description
-------------- | -----------------
`<=` (is subset) | Determines if a is a subset of b.
`< `(is proper subset) | Determines if a is a proper subset of b (subset, but not equal).
`>=` (is superset) |	Determines if a is a superset of b.
`>` (is proper superset) | Determines if a is a proper superset of b (superset, but not equal).


## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Update operations tetsting

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
