### PR TITLE
Add Docker file with TLS/SSL support and arguments as environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v1.5.3
+
+ * Listen to `THINGSDB_INIT`, `THINGSDB_SECRET` and `THINGSDB_DEPLOY` environment variable.
+ * Added `tls.Dockerfile` for TLS/SSL support in docker container.
+
 # v1.5.2
 
 * Restrict future arguments for `then()` or `else()` to objects without an Id.

--- a/docker/tls.Dockerfile
+++ b/docker/tls.Dockerfile
@@ -1,0 +1,44 @@
+FROM amd64/alpine:3.19
+COPY ./ /tmp/thingsdb/
+RUN apk update && \
+    apk upgrade && \
+    apk add gcc make libuv-dev musl-dev pcre2-dev yajl-dev curl-dev util-linux-dev linux-headers && \
+    cd /tmp/thingsdb/Release && \
+    make clean && \
+    make
+
+FROM ghcr.io/cesbit/tlsproxy:v0.1.1
+
+FROM amd64/alpine:latest
+RUN apk update && \
+    apk add pcre2 libuv yajl curl tzdata && \
+    mkdir -p /var/lib/thingsdb
+COPY --from=0 /tmp/thingsdb/Release/thingsdb /usr/local/bin/
+COPY --from=1 /tlsproxy /usr/local/bin/
+
+# Volume mounts
+VOLUME ["/data"]
+VOLUME ["/modules"]
+VOLUME ["/certificates"]
+
+# Client (Socket TLS/SSL) connections
+EXPOSE 9443
+# Client (HTTPS) connections
+EXPOSE 443
+# Status (HTTP) connections
+EXPOSE 8080
+
+ENV TLSPROXY_TARGET=127.0.0.1
+ENV TLSPROXY_PORTS=9443:9200,443:9210
+ENV TLSPROXY_CERT_FILE=certificates/server.crt
+ENV TLSPROXY_KEY_FILE=certificates/server.key
+
+ENV THINGSDB_BIND_CLIENT_ADDR=0.0.0.0
+ENV THINGSDB_BIND_NODE_ADDR=0.0.0.0
+ENV THINGSDB_LISTEN_CLIENT_PORT=9200
+ENV THINGSDB_HTTP_API_PORT=9210
+ENV THINGSDB_HTTP_STATUS_PORT=8080
+ENV THINGSDB_MODULES_PATH=/modules
+ENV THINGSDB_STORAGE_PATH=/data
+
+ENTRYPOINT ["sh", "-c", "/usr/local/bin/tlsproxy & /usr/local/bin/thingsdb"]

--- a/inc/ti/evars.h
+++ b/inc/ti/evars.h
@@ -4,6 +4,7 @@
 #ifndef TI_EVARS_H_
 #define TI_EVARS_H_
 
-void ti_evars_parse(void);
+void ti_evars_arg_parse(void);
+void ti_evars_cfg_parse(void);
 
 #endif  /* TI_EVARS_H_ */

--- a/inc/ti/version.h
+++ b/inc/ti/version.h
@@ -6,7 +6,7 @@
 
 #define TI_VERSION_MAJOR 1
 #define TI_VERSION_MINOR 5
-#define TI_VERSION_PATCH 2
+#define TI_VERSION_PATCH 3
 
 /* The syntax version is used to test compatibility with functions
  * using the `ti_nodes_check_syntax()` function */
@@ -25,7 +25,7 @@
  *  "-rc0"
  *  ""
  */
-#define TI_VERSION_PRE_RELEASE ""
+#define TI_VERSION_PRE_RELEASE "-alpha0"
 
 #define TI_MAINTAINER \
     "Jeroen van der Heijden <jeroen@cesbit.com>"

--- a/main.c
+++ b/main.c
@@ -96,6 +96,8 @@ int main(int argc, char * argv[])
     if (rc)
         goto stop;
 
+    ti_evars_arg_parse();
+
     /* parse arguments */
     rc = ti_args_parse(argc, argv);
     if (rc)
@@ -127,7 +129,7 @@ int main(int argc, char * argv[])
             goto stop;
     }
 
-    ti_evars_parse();
+    ti_evars_cfg_parse();
 
     rc = ti_cfg_ensure_storage_path();
     if (rc)

--- a/src/ti/evars.c
+++ b/src/ti/evars.c
@@ -61,13 +61,44 @@ static void evars__str(const char * evar, char ** straddr)
     *straddr = str;
 }
 
+static void evars__bool_arg(const char * evar, int32_t * b)
+{
+    char * u8str = getenv(evar);
+    if (!u8str)
+        return;
+
+    *b = ((int32_t) strtoul(u8str, NULL, 10)) != 0;
+}
+
+static void evars__str_arg(const char * evar, char * strarg)
+{
+    char * str = getenv(evar);
+    if (!str || strlen(str) >= ARGPARSE_MAX_LEN_ARG)
+        return;
+    (void) strcpy(strarg, str);
+}
+
 static void evars__ip_support(const char * evar, int * ip_support)
 {
     char * str = getenv(evar);
     (void) ti_tcp_ip_support_int(str, ip_support);
 }
 
-void ti_evars_parse(void)
+void ti_evars_arg_parse(void)
+{
+
+    evars__bool_arg(
+            "THINGSDB_INIT",
+            &ti.args->init);
+    evars__bool_arg(
+            "THINGSDB_DEPLOY",
+            &ti.args->deploy);
+    evars__str_arg(
+            "THINGSDB_SECRET",
+            ti.args->secret);
+}
+
+void ti_evars_cfg_parse(void)
 {
     evars__u16(
             "THINGSDB_LISTEN_CLIENT_PORT",


### PR DESCRIPTION
## Description

Some cases do not support the option to add arguments like `--init`. Add environment variable as fallback. (arguments win from env vars).
- `THINGSDB_INIT` (example: `THINGSDB_INIT=1`)
- `THINGSDB_DEPLOY` (example: `THINGSDB_DEPLOY=1`)
- `THINGSDB_INIT` (example: `THINGSDB_SECRET=pass`)

Also add a Docker file with TLS/SSL support. This file is currently just added as an example. If no problems are found, this can be improved and included as a Docker build package.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
