### PR TITLE
Specify platform in ARM build step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -69,6 +69,7 @@ jobs:
       with:
         context: .
         push: true
+        platforms: linux/arm64
         file: docker/arm64.Dockerfile
         tags: ghcr.io/thingsdb/node:arm64-${{ steps.get_version.outputs.VERSION }}
         labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,7 @@ jobs:
       with:
         context: .
         push: true
+        platforms: linux/arm64
         file: docker/arm64.Dockerfile
         tags: ghcr.io/thingsdb/node:arm64-${{ steps.get_version.outputs.VERSION }}
         labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Description

The ARM64 build step in the `deploy` workflow is failing. This is due to GitHub actions trying to build the ARM image in an AMD64 context. Adding the `platforms` parameter should fix this behaviour.

Fixes #376 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Docker build command ran locally and worked.

**Test Configuration**:
- MacOS 14.3.1
- Docker 25.0.3, build 4debf41

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
