### PR TITLE
Fix incorrect ValueError for user/token not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v1.6.7
+
+* Fix incorrect value error when user or token is not found, pr #390.
+
 # v1.6.6
 
 * Allow `user_info()` in a collection scope, discussion #385.

--- a/inc/ti/fn/fndeltoken.h
+++ b/inc/ti/fn/fndeltoken.h
@@ -28,7 +28,7 @@ static int do__f_del_token(ti_query_t * query, cleri_node_t * nd, ex_t * e)
             ? ti_users_pop_token_by_key((ti_token_key_t *) rkey->data)
             : ti_user_pop_token_by_key(query->user, (ti_token_key_t *) rkey->data);
     if (!token)
-        return ti_raw_err_not_found(rkey, "token", e);
+        return ti_raw_printable_not_found(rkey, "token", e);
 
     ti_token_destroy(token);
 

--- a/inc/ti/fn/fndeluser.h
+++ b/inc/ti/fn/fndeluser.h
@@ -19,7 +19,7 @@ static int do__f_del_user(ti_query_t * query, cleri_node_t * nd, ex_t * e)
     ruser = (ti_raw_t *) query->rval;
     user = ti_users_get_by_namestrn((const char *) ruser->data, ruser->n);
     if (!user)
-        return ti_raw_err_not_found(ruser, "user", e);
+        return ti_raw_printable_not_found(ruser, "user", e);
 
     if (query->user == user)
     {

--- a/inc/ti/fn/fngrant.h
+++ b/inc/ti/fn/fngrant.h
@@ -30,7 +30,7 @@ static int do__f_grant(ti_query_t * query, cleri_node_t * nd, ex_t * e)
     ruser = (ti_raw_t *) query->rval;
     user = ti_users_get_by_namestrn((const char *) ruser->data, ruser->n);
     if (!user)
-        return ti_raw_err_not_found(ruser, "user", e);
+        return ti_raw_printable_not_found(ruser, "user", e);
 
     ti_val_unsafe_drop(query->rval);
     query->rval = NULL;

--- a/inc/ti/fn/fnnewtoken.h
+++ b/inc/ti/fn/fnnewtoken.h
@@ -24,7 +24,7 @@ static int do__f_new_token(ti_query_t * query, cleri_node_t * nd, ex_t * e)
     uname = (ti_raw_t *) query->rval;
     user = ti_users_get_by_namestrn((const char *) uname->data, uname->n);
     if (!user)
-        return ti_raw_err_not_found(uname, "user", e);
+        return ti_raw_printable_not_found(uname, "user", e);
 
     if (user != query->user && ti_access_check_err(
             ti.access_thingsdb,

--- a/inc/ti/fn/fnrenameuser.h
+++ b/inc/ti/fn/fnrenameuser.h
@@ -19,7 +19,7 @@ static int do__f_rename_user(ti_query_t * query, cleri_node_t * nd, ex_t * e)
     rname = (ti_raw_t *) query->rval;
     user = ti_users_get_by_namestrn((const char *) rname->data, rname->n);
     if (!user)
-        return ti_raw_err_not_found(rname, "user", e);
+        return ti_raw_printable_not_found(rname, "user", e);
 
     ti_val_unsafe_drop(query->rval);
     query->rval = NULL;

--- a/inc/ti/fn/fnrevoke.h
+++ b/inc/ti/fn/fnrevoke.h
@@ -30,7 +30,7 @@ static int do__f_revoke(ti_query_t * query, cleri_node_t * nd, ex_t * e)
     uname = (ti_raw_t *) query->rval;
     user = ti_users_get_by_namestrn((const char *) uname->data, uname->n);
     if (!user)
-        return ti_raw_err_not_found(uname, "user", e);
+        return ti_raw_printable_not_found(uname, "user", e);
 
     ti_val_unsafe_drop(query->rval);
     query->rval = NULL;

--- a/inc/ti/fn/fnsetowner.h
+++ b/inc/ti/fn/fnsetowner.h
@@ -30,7 +30,7 @@ static int do__f_set_owner(ti_query_t * query, cleri_node_t * nd, ex_t * e)
     user = ti_users_get_by_namestrn((const char *) ruser->data, ruser->n);
     if (!user)
     {
-        (void) ti_raw_err_not_found(ruser, "user", e);
+        (void) ti_raw_printable_not_found(ruser, "user", e);
         goto fail0;
     }
 

--- a/inc/ti/fn/fnsetpassword.h
+++ b/inc/ti/fn/fnsetpassword.h
@@ -18,7 +18,7 @@ static int do__f_set_password(ti_query_t * query, cleri_node_t * nd, ex_t * e)
     user = ti_users_get_by_namestrn((const char *) uname->data, uname->n);
 
     if (!user)
-        return ti_raw_err_not_found(uname, "user", e);
+        return ti_raw_printable_not_found(uname, "user", e);
 
     if (user != query->user && ti_access_check_err(
             ti.access_thingsdb,

--- a/inc/ti/fn/fnuserinfo.h
+++ b/inc/ti/fn/fnuserinfo.h
@@ -42,7 +42,7 @@ static int do__f_user_info(ti_query_t * query, cleri_node_t * nd, ex_t * e)
         ruser = (ti_raw_t *) query->rval;
         user = ti_users_get_by_namestrn((const char *) ruser->data, ruser->n);
         if (!user)
-            return ti_raw_err_not_found(ruser, "user", e);
+            return ti_raw_printable_not_found(ruser, "user", e);
 
         ti_val_unsafe_drop(query->rval);
     }

--- a/inc/ti/raw.h
+++ b/inc/ti/raw.h
@@ -49,6 +49,7 @@ ti_raw_t * ti_raw_cat_strn_strn(
 _Bool ti_raw_contains(ti_raw_t * a, ti_raw_t * b);
 int ti_raw_check_valid_name(ti_raw_t * raw, const char * s, ex_t * e);
 int ti_raw_err_not_found(ti_raw_t * raw, const char * s, ex_t * e);
+int ti_raw_printable_not_found(ti_raw_t * raw, const char * s, ex_t * e);
 const char * ti_raw_as_printable_str(ti_raw_t * raw);
 static inline _Bool ti_raw_startswith(ti_raw_t * a, ti_raw_t * b);
 static inline _Bool ti_raw_endswith(ti_raw_t * a, ti_raw_t * b);

--- a/inc/ti/version.h
+++ b/inc/ti/version.h
@@ -6,7 +6,7 @@
 
 #define TI_VERSION_MAJOR 1
 #define TI_VERSION_MINOR 6
-#define TI_VERSION_PATCH 6
+#define TI_VERSION_PATCH 7
 
 /* The syntax version is used to test compatibility with functions
  * using the `ti_nodes_check_syntax()` function */
@@ -25,7 +25,7 @@
  *  "-rc0"
  *  ""
  */
-#define TI_VERSION_PRE_RELEASE ""
+#define TI_VERSION_PRE_RELEASE "-alpha0"
 
 #define TI_MAINTAINER \
     "Jeroen van der Heijden <jeroen@cesbit.com>"

--- a/itest/test_thingsdb_functions.py
+++ b/itest/test_thingsdb_functions.py
@@ -180,9 +180,14 @@ class TestThingsDBFunctions(TestBase):
             await client.query('del_user(42);')
 
         with self.assertRaisesRegex(
-                ValueError,
-                'user name must follow the naming rules'):
+                LookupError,
+                'user `` not found'):
             await client.query('del_user("");')
+
+        with self.assertRaisesRegex(
+                LookupError,
+                'user not found'):
+            await client.query(f'del_user("{"x" * 999}");')
 
         with self.assertRaisesRegex(
                 OperationError,

--- a/itest/test_thingsdb_functions.py
+++ b/itest/test_thingsdb_functions.py
@@ -179,11 +179,13 @@ class TestThingsDBFunctions(TestBase):
                 r'but got type `int` instead'):
             await client.query('del_user(42);')
 
+        # pr #390
         with self.assertRaisesRegex(
                 LookupError,
                 'user `` not found'):
             await client.query('del_user("");')
 
+        # pr #390
         with self.assertRaisesRegex(
                 LookupError,
                 'user not found'):

--- a/itest/test_ws.py
+++ b/itest/test_ws.py
@@ -37,6 +37,7 @@ class TestWS(TestBase):
 
         client.close()
         await client.wait_closed()
+        await asyncio.sleep(1)  # sleep is required for nice close
 
     async def test_simple_ws(self, client):
         self.assertTrue(client.is_websocket())

--- a/itest/test_wss.py
+++ b/itest/test_wss.py
@@ -37,6 +37,7 @@ class TestWSS(TestBase):
 
         client.close()
         await client.wait_closed()
+        await asyncio.sleep(1)  # sleep is required for nice close
 
     async def test_simple_wss(self, client):
         self.assertTrue(client.is_websocket())

--- a/src/ti/raw.c
+++ b/src/ti/raw.c
@@ -563,6 +563,20 @@ int ti_raw_err_not_found(ti_raw_t * raw, const char * s, ex_t * e)
     return e->nr;
 }
 
+int ti_raw_printable_not_found(ti_raw_t * raw, const char * s, ex_t * e)
+{
+    /* The length of 99 is just arbitrary for which we think its fine to
+     * include the name in the error message.
+     */
+    if (raw->n <= 99 && strx_is_printablen((const char *) raw->data, raw->n))
+        ex_set(e, EX_LOOKUP_ERROR,
+                "%s `%.*s` not found",
+                s, raw->n, (const char *) raw->data);
+    else
+        ex_set(e, EX_LOOKUP_ERROR, "%s not found", s);
+    return e->nr;
+}
+
 const char * ti_raw_as_printable_str(ti_raw_t * raw)
 {
     const size_t m = RAW__AS_PRINTABLE_BUF_SZ-4;

--- a/src/ti/raw.c
+++ b/src/ti/raw.c
@@ -565,7 +565,7 @@ int ti_raw_err_not_found(ti_raw_t * raw, const char * s, ex_t * e)
 
 int ti_raw_printable_not_found(ti_raw_t * raw, const char * s, ex_t * e)
 {
-    /* The length of 99 is just arbitrary for which we think its fine to
+    /* The length of 99 is just arbitrary for which we decided its fine to
      * include the name in the error message.
      */
     if (raw->n <= 99 && strx_is_printablen((const char *) raw->data, raw->n))


### PR DESCRIPTION
## Description

This pull request fixes an incorrect error when using a function where a user or token is not found. Both a token and user do not honor the naming rules but when not found, the error message is generated by a function which is build for names which must apply to the naming rule.

Example:
```javascript
del_user('123');  // user 123 does not exist
```

The code above returns with a `ValueError` (naming rule) but `123` is valid for a user. 

**Expected:**
A `LookupError` is expected (the same applies for a token not found).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Test thingsdb functions

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
