### PR TITLE
Allow a default enumerator member in type definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Implement optional _name_ for a room, pr #393.
 * Use MessagePack Extension to internally store names, issue #394.
 * Added whitelist support for both _"procedures"_ and _"rooms"_, pr #395.
+* Added option for a default enumerator member in a type definition, pr #396.
 
 # v1.6.6
 

--- a/inc/ti/condition.h
+++ b/inc/ti/condition.h
@@ -9,6 +9,7 @@
 #include <stdlib.h>
 #include <ti/condition.t.h>
 #include <ti/field.t.h>
+#include <ti/member.t.h>
 
 int ti_condition_field_info_init(
         ti_field_t * field,
@@ -24,6 +25,7 @@ int ti_condition_field_rel_init(
         ti_field_t * field,
         ti_field_t * ofield,
         ex_t * e);
+int ti_condition_init_enum(ti_field_t * field, ti_member_t * member, ex_t * e);
 
 void ti_condition_destroy(ti_condition_via_t condition, uint16_t spec);
 

--- a/inc/ti/enum.h
+++ b/inc/ti/enum.h
@@ -51,6 +51,6 @@ ti_member_t * ti_enum_member_by_val_e(
         ex_t * e);
 ti_val_t * ti_enum_as_mpval(ti_enum_t * enum_);
 int ti_enum_to_pk(ti_enum_t * enum_, ti_vp_t * vp);
-
+int ti_enum_members_check(ti_enum_t * enum_, ex_t * e);
 
 #endif  /* TI_MEMBER_H_ */

--- a/inc/ti/field.t.h
+++ b/inc/ti/field.t.h
@@ -27,7 +27,7 @@ enum
     TI_FIELD_FLAG_DEEP=8,   /* this flag returns deep as-is */
     TI_FIELD_FLAG_ENAME=16, /* return enumerator names instead of value */
 
-    TI_FIELD_FLAG_NO_IDS=TI_FLAGS_NO_IDS,
+    TI_FIELD_FLAG_NO_IDS=TI_FLAGS_NO_IDS,  /* 32 */
 };
 
 #define TI_FIELD_MIN_MAX (TI_FIELD_FLAG_MIN_DEEP|TI_FIELD_FLAG_MAX_DEEP)

--- a/inc/ti/flags.h
+++ b/inc/ti/flags.h
@@ -14,7 +14,8 @@
 /* flags must fit with `TI_QUERY_FLAG` defined in query.t.h */
 enum
 {
-    TI_FLAGS_NO_IDS=1<<5,   /* return no ID's */
+    TI_FLAGS_NO_IDS=1<<5,   /* return no ID's, must be 32 (1<<5)  as it maps
+                             * with TI_FIELD_FLAG_NO_IDS */
 };
 
 int ti_flags_set_from_val(ti_val_t * val, uint8_t * flags, ex_t * e);

--- a/inc/ti/fn/fnmodenum.h
+++ b/inc/ti/fn/fnmodenum.h
@@ -273,6 +273,13 @@ static void enum__ren(
     {
         if (ti_member_set_name(member, (const char *) rname->data, rname->n, e))
             return;
+
+        if (ti_types_ren_member_spec(query->collection->types, member))
+        {
+            ti_panic("failed to rename enumerator definitions");
+            ex_set_mem(e);
+            return;
+        }
     }
     else if (ti_method_set_name_e(
             method,

--- a/inc/ti/member.h
+++ b/inc/ti/member.h
@@ -18,6 +18,7 @@ ti_member_t * ti_member_create(
         ti_val_t * val,
         ex_t * e);
 ti_member_t * ti_member_placeholder(ti_enum_t * enum_, ex_t * e);
+int ti_member_alloc(ti_enum_t * enum_, ti_name_t * name, ex_t * e);
 void ti_member_destroy(ti_member_t * member);
 void ti_member_drop(ti_member_t * member);
 void ti_member_remove(ti_member_t * member);

--- a/inc/ti/store/storeenums.h
+++ b/inc/ti/store/storeenums.h
@@ -7,7 +7,7 @@
 #include <ti/enums.h>
 
 int ti_store_enums_store(ti_enums_t * enums, const char * fn);
-int ti_store_enums_restore(ti_enums_t * enums, const char * fn);
+int ti_store_enums_restore(ti_enums_t * enums, imap_t * names, const char * fn);
 int ti_store_enums_restore_members(
         ti_enums_t * enums,
         imap_t * names,

--- a/inc/ti/types.h
+++ b/inc/ti/types.h
@@ -7,6 +7,7 @@
 #include <ex.h>
 #include <stdint.h>
 #include <ti/collection.t.h>
+#include <ti/member.t.h>
 #include <ti/raw.t.h>
 #include <ti/type.t.h>
 #include <ti/types.t.h>

--- a/inc/ti/types.h
+++ b/inc/ti/types.h
@@ -17,11 +17,11 @@ ti_types_t * ti_types_create(ti_collection_t * collection);
 void ti_types_destroy(ti_types_t * types);
 int ti_types_add(ti_types_t * types, ti_type_t * type);
 void ti_types_del(ti_types_t * types, ti_type_t * type);
-int ti_types_rename_spec(
+int ti_types_ren_spec(
         ti_types_t * types,
         uint16_t type_or_enum_id,
-        ti_raw_t * oname,
         ti_raw_t * nname);
+int ti_types_ren_member_spec(ti_types_t * types, ti_member_t * member);
 uint16_t ti_types_get_new_id(ti_types_t * types, ti_raw_t * rname, ex_t * e);
 ti_varr_t * ti_types_info(ti_types_t * types, _Bool with_definition);
 int ti_types_to_pk(ti_types_t * types, msgpack_packer * pk);

--- a/inc/ti/version.h
+++ b/inc/ti/version.h
@@ -25,7 +25,7 @@
  *  "-rc0"
  *  ""
  */
-#define TI_VERSION_PRE_RELEASE "-rc0"
+#define TI_VERSION_PRE_RELEASE "-rc1"
 
 #define TI_MAINTAINER \
     "Jeroen van der Heijden <jeroen@cesbit.com>"

--- a/itest/test_enum.py
+++ b/itest/test_enum.py
@@ -996,7 +996,6 @@ class TestEnum(TestBase):
                 T{C1: "a"};
             """)
 
-
         await q("""//ti
             rename_enum('Colors', 'Color');
             mod_enum('Color', 'ren', 'Purple', 'Red');

--- a/itest/test_enum.py
+++ b/itest/test_enum.py
@@ -1016,6 +1016,16 @@ class TestEnum(TestBase):
                 T{C1: "a"};
             """)
 
+
+        await q("""//ti
+            set_type('L', {
+                e: '[Colors]'
+            });
+            set_type('N', {
+                t: 'thing<Colors>'
+            });
+        """)
+
         await q("""//ti
             rename_enum('Colors', 'Color');
             mod_enum('Color', 'ren', 'Purple', 'Red');
@@ -1056,12 +1066,6 @@ class TestEnum(TestBase):
             'C4': 55
         })
 
-        await q("""//ti
-            set_type('L', {
-                e: '[Color]'
-            });
-        """)
-
         with self.assertRaisesRegex(
                 TypeError,
                 r'mismatch in type `L`; property `e` requires an array '
@@ -1075,11 +1079,10 @@ class TestEnum(TestBase):
         """)
         self.assertEqual(res, {'e': [55]})
 
-        await q("""//ti
-            set_type('N', {
-                t: 'thing<Color>'
-            });
+        res = await q("""//ti
+            type_info('L').load().fields;
         """)
+        self.assertEqual(res, [['e', '[Color]']])
 
         with self.assertRaisesRegex(
                 TypeError,
@@ -1093,6 +1096,10 @@ class TestEnum(TestBase):
             return N{t: {a: Color{Blue}}}, 2;
         """)
         self.assertEqual(res, {'t': {'a': 55}})
+        res = await q("""//ti
+            type_info('N').load().fields;
+        """)
+        self.assertEqual(res, [['t', 'thing<Color>']])
 
 
 if __name__ == '__main__':

--- a/itest/test_enum.py
+++ b/itest/test_enum.py
@@ -953,6 +953,16 @@ class TestEnum(TestBase):
 
         with self.assertRaisesRegex(
                 TypeError,
+                r'invalid declaration for `e` on type `A`; type `list` '
+                r'cannot contain enum type `Colors` with a default value;'):
+            await q("""//ti
+                set_type('A', {
+                    e: '[Colors{Blue}]'
+                });
+            """)
+
+        with self.assertRaisesRegex(
+                TypeError,
                 r'invalid declaration for `e` on type `A`; unknown '
                 r'type `CPurple\}` in declaration;'):
             await q("""//ti
@@ -1035,6 +1045,25 @@ class TestEnum(TestBase):
             'C3': 55,
             'C4': 55
         })
+
+        await q("""//ti
+            set_type('L', {
+                e: '[Color]'
+            });
+        """)
+
+        with self.assertRaisesRegex(
+                TypeError,
+                r'mismatch in type `L`; property `e` requires an array '
+                r'with items that matches definition `\[Color\]`'):
+            await q("""//ti
+                L{e: [0]};
+            """)
+
+        res = await q("""//ti
+            L{e: [Color{Blue}]};
+        """)
+        self.assertEqual(res, {'e': [55]})
 
 
 if __name__ == '__main__':

--- a/itest/test_enum.py
+++ b/itest/test_enum.py
@@ -1016,7 +1016,6 @@ class TestEnum(TestBase):
                 T{C1: "a"};
             """)
 
-
         await q("""//ti
             set_type('L', {
                 e: '[Colors]'

--- a/itest/test_enum.py
+++ b/itest/test_enum.py
@@ -943,6 +943,16 @@ class TestEnum(TestBase):
 
         with self.assertRaisesRegex(
                 TypeError,
+                r'invalid declaration for `t` on type `N`; type `thing` '
+                r'cannot contain enum type `Colors` with a default value;'):
+            await q("""//ti
+                set_type('N', {
+                    t: 'thing<Colors{Blue}>'
+                });
+            """)
+
+        with self.assertRaisesRegex(
+                TypeError,
                 r'invalid declaration for `e` on type `A`; unknown '
                 r'type `COLORS` in declaration;'):
             await q("""//ti
@@ -1065,15 +1075,24 @@ class TestEnum(TestBase):
         """)
         self.assertEqual(res, {'e': [55]})
 
+        await q("""//ti
+            set_type('N', {
+                t: 'thing<Color>'
+            });
+        """)
+
         with self.assertRaisesRegex(
                 TypeError,
-                r'xxx'):
+                r'mismatch in type `N`; property `t` requires a thing '
+                r'with values that matches definition `thing\<Color\>`'):
             await q("""//ti
-                set_type('N', {
-                    't': 'thing<Color{Blue}>'
-                });
+                N{t: {a: 0}};
             """)
 
+        res = await q("""//ti
+            return N{t: {a: Color{Blue}}}, 2;
+        """)
+        self.assertEqual(res, {'t': {'a': 55}})
 
 
 if __name__ == '__main__':

--- a/itest/test_enum.py
+++ b/itest/test_enum.py
@@ -1065,6 +1065,16 @@ class TestEnum(TestBase):
         """)
         self.assertEqual(res, {'e': [55]})
 
+        with self.assertRaisesRegex(
+                TypeError,
+                r'xxx'):
+            await q("""//ti
+                set_type('N', {
+                    't': 'thing<Color{Blue}>'
+                });
+            """)
+
+
 
 if __name__ == '__main__':
     run_test(TestEnum())

--- a/itest/test_enum.py
+++ b/itest/test_enum.py
@@ -909,6 +909,134 @@ class TestEnum(TestBase):
 
         self.assertEqual(await client.query('Color{Blue}.nVar(1, 2, 3);'), 21)
 
+    async def test_def_enum_definition(self, client):
+        # Added this test for default enumerator members which are allowed
+        # since version 1.7.0. See issue #387 and pr #396,
+        q = client.query
+        await q("""//ti
+            set_enum('Colors', {
+                Blue: 55,
+                Purple: 66,
+                Yellow: 77,
+            });
+        """)
+
+        await q("""//ti
+            set_type('T', {
+                C1: 'Colors{Purple}',
+                C2: 'Colors{Yellow}?',
+                C3: 'Colors',
+                C4: 'Colors?',
+            })
+        """)
+
+        with self.assertRaisesRegex(
+                TypeError,
+                r'invalid declaration for `e` on type `A`; if you want '
+                r'the default enum member, remove the curly brackets `\{\}` '
+                r'from the definition;'):
+            await q("""//ti
+                set_type('A', {
+                    e: 'Colors{}'
+                });
+            """)
+
+        with self.assertRaisesRegex(
+                TypeError,
+                r'invalid declaration for `e` on type `A`; unknown '
+                r'type `COLORS` in declaration;'):
+            await q("""//ti
+                set_type('A', {
+                    e: 'COLORS{X}'
+                });
+            """)
+
+        with self.assertRaisesRegex(
+                TypeError,
+                r'invalid declaration for `e` on type `A`; unknown '
+                r'type `CPurple\}` in declaration;'):
+            await q("""//ti
+                set_type('A', {
+                    e: 'CPurple}'
+                });
+            """)
+
+        with self.assertRaisesRegex(
+                LookupError,
+                r'invalid declaration for `e` on type `A`; cannot find '
+                r'member `Magenta` on enum type `Colors`;'):
+            await q("""//ti
+                set_type('A', {
+                    e: 'Colors{Magenta}'
+                });
+            """)
+
+        with self.assertRaisesRegex(
+                OperationError,
+                r'enum member `Colors\{Yellow\}` is still in use'):
+            await q("""//ti
+                mod_enum('Colors', 'del', 'Yellow');
+            """)
+
+        with self.assertRaisesRegex(
+                TypeError,
+                r'invalid declaration for `e` on type `A`; type `set` cannot '
+                r'contain enum type `Colors`;'):
+            await q("""//ti
+                set_type('A', {
+                    e: '{Colors{Purple}}'
+                });
+            """)
+
+        with self.assertRaisesRegex(
+                TypeError,
+                r'mismatch in type `T`; type `str` is invalid for '
+                r'property `C1` with definition `Colors\{Purple\}`'):
+            await q("""//ti
+                T{C1: "a"};
+            """)
+
+
+        await q("""//ti
+            rename_enum('Colors', 'Color');
+            mod_enum('Color', 'ren', 'Purple', 'Red');
+            mod_enum('Color', 'ren', 'Yellow', 'Orange');
+        """)
+        await self.node0.shutdown()
+        await self.node0.run()
+        res = await q("""//ti
+            type_info('T').load().fields;
+        """)
+        self.assertEqual(res, [
+            ['C1', 'Color{Red}'],
+            ['C2', 'Color{Orange}?'],
+            ['C3', 'Color'],
+            ['C4', 'Color?'],
+        ])
+
+        res = await q("T{};")
+        self.assertEqual(res, {
+            'C1': 66,
+            'C2': 77,
+            'C3': 55,
+            'C4': None
+        })
+
+        res = await q("""//ti
+            T{
+                C1: Color{Blue},
+                C2: Color{Blue},
+                C3: Color{Blue},
+                C4: Color{Blue},
+            };
+        """)
+        self.assertEqual(res, {
+            'C1': 55,
+            'C2': 55,
+            'C3': 55,
+            'C4': 55
+        })
+
 
 if __name__ == '__main__':
     run_test(TestEnum())

--- a/itest/test_relations.py
+++ b/itest/test_relations.py
@@ -1624,6 +1624,30 @@ mod_type('D', 'rel', 'da', 'db');
             assert(c.many.has(c));
         """)
 
+        # Test rename type with relation
+
+        await client.query("""//ti
+            rename_type('A', 'AA');
+            rename_type('B', 'BB');
+            rename_type('C', 'CC');
+        """)
+
+        await self.node0.shutdown()
+        await self.node0.run()
+
+        res = await client.query("""//ti
+            type_info("AA").load().fields;
+        """)
+        self.assertEqual(res, [['one', 'AA?']])
+        res = await client.query("""//ti
+            type_info("BB").load().fields;
+        """)
+        self.assertEqual(res, [['one', 'BB?'], ['many', '{BB}']])
+        res = await client.query("""//ti
+            type_info("CC").load().fields;
+        """)
+        self.assertEqual(res, [['many', '{CC}']])
+
 
 if __name__ == '__main__':
     run_test(TestRelations())

--- a/itest/test_simple.py
+++ b/itest/test_simple.py
@@ -37,6 +37,25 @@ class TestSimple(TestBase):
     async def test_hello_world(self, client):
         await client.query('"Hello world!"')
 
+    async def test_def_enum_definition(self, client):
+        q = client.query
+        await q("""//ti
+            set_enum('Colors', {
+                Blue: 0,
+                Purple: 1,
+                Yellow: 2
+            });
+        """)
+
+        await q("""//ti
+            set_type('T', {
+                C1: 'Colors{Purple}',
+                C2: 'Colors{Yellow}?',
+                C3: 'Colors',
+            })
+        """)
+
+
 
 if __name__ == '__main__':
     run_test(TestSimple())

--- a/itest/test_simple.py
+++ b/itest/test_simple.py
@@ -37,25 +37,6 @@ class TestSimple(TestBase):
     async def test_hello_world(self, client):
         await client.query('"Hello world!"')
 
-    async def test_def_enum_definition(self, client):
-        q = client.query
-        await q("""//ti
-            set_enum('Colors', {
-                Blue: 0,
-                Purple: 1,
-                Yellow: 2
-            });
-        """)
-
-        await q("""//ti
-            set_type('T', {
-                C1: 'Colors{Purple}',
-                C2: 'Colors{Yellow}?',
-                C3: 'Colors',
-            })
-        """)
-
-
 
 if __name__ == '__main__':
     run_test(TestSimple())

--- a/itest/test_whitelist.py
+++ b/itest/test_whitelist.py
@@ -342,5 +342,6 @@ class TestWhitelist(TestBase):
         await self.node0.shutdown()
         await self.node0.run()
 
+
 if __name__ == '__main__':
     run_test(TestWhitelist())

--- a/src/ti/condition.c
+++ b/src/ti/condition.c
@@ -21,7 +21,6 @@ static ti_val_t * condition__dval_cb(ti_field_t * field)
     return dval;
 }
 
-
 int ti_condition_field_info_init(
         ti_field_t * field,
         const char * str,
@@ -413,7 +412,6 @@ int ti_condition_field_info_init(
         goto failed;
     }
 
-
 invalid:
     ex_set(e, EX_VALUE_ERROR,
             "invalid declaration for `%s` on type `%s`; "
@@ -566,6 +564,20 @@ fail0:
     return e->nr;
 }
 
+int ti_condition_init_enum(ti_field_t * field, ti_member_t * member, ex_t * e)
+{
+    field->condition.none = malloc(sizeof(ti_condition_t));
+    if (!field->condition.none)
+    {
+        ex_set_mem(e);
+        return e->nr;
+    }
+    field->condition.none->dval = (ti_val_t *) member;
+    field->dval_cb = condition__dval_cb;
+    ti_incref(member);
+    return 0;
+}
+
 static void condition__del_type_cb(
         ti_field_t * field,
         ti_thing_t * thing,
@@ -710,6 +722,8 @@ void ti_condition_destroy(ti_condition_via_t condition, uint16_t spec)
         ti_val_drop(condition.none->dval);
         /* fall through */
     default:
+        if (spec >= 0x6000)  /* in case of enum default */
+            ti_val_drop(condition.none->dval);
         free(condition.none);
         return;
     }

--- a/src/ti/ctask.c
+++ b/src/ti/ctask.c
@@ -1318,13 +1318,20 @@ set_member:
             mp_to.via.str.n,
             &e);
 
+    if (ti_types_ren_member_spec(collection->types, member))
+    {
+        ti_panic("failed to rename enumerator definitions");
+        ex_set_mem(e);
+    }
+
 done:
     if (e.nr)
         log_critical(e.msg);
     else
+    {
         /* update modified time-stamp */
         enum_->modified_at = mp_modified.via.u64;
-
+    }
     return e.nr;
 }
 

--- a/src/ti/ctask.c
+++ b/src/ti/ctask.c
@@ -1312,16 +1312,16 @@ static int ctask__mod_enum_ren(ti_thing_t * thing, mp_unp_t * up)
     }
 
 set_member:
-    (void) ti_member_set_name(
+    ti_member_set_name(
             member,
             mp_to.via.str.data,
             mp_to.via.str.n,
             &e);
 
-    if (ti_types_ren_member_spec(collection->types, member))
+    if (e.nr == 0 && ti_types_ren_member_spec(collection->types, member))
     {
         ti_panic("failed to rename enumerator definitions");
-        ex_set_mem(e);
+        ex_set_mem(&e);
     }
 
 done:

--- a/src/ti/enums.c
+++ b/src/ti/enums.c
@@ -64,7 +64,7 @@ int ti_enums_rename(ti_enums_t * enums, ti_enum_t * enum_, ti_raw_t * nname)
 
     (void) smap_pop(enums->smap, enum_->name);
 
-    if (ti_types_rename_spec(
+    if (ti_types_ren_spec(
             enums->collection->types,
             enum_->enum_id | TI_ENUM_ID_FLAG,
             enum_->rname,

--- a/src/ti/enums.c
+++ b/src/ti/enums.c
@@ -67,7 +67,6 @@ int ti_enums_rename(ti_enums_t * enums, ti_enum_t * enum_, ti_raw_t * nname)
     if (ti_types_ren_spec(
             enums->collection->types,
             enum_->enum_id | TI_ENUM_ID_FLAG,
-            enum_->rname,
             nname))
     {
         ti_panic("failed to rename enumerator definitions");

--- a/src/ti/field.c
+++ b/src/ti/field.c
@@ -677,6 +677,17 @@ skip_nesting:
                         return e->nr;
                     }
 
+                    if ((field->spec & TI_SPEC_MASK_NILLABLE) == TI_SPEC_OBJECT)
+                    {
+                        ex_set(e, EX_TYPE_ERROR,
+                            "invalid declaration for `%s` on type `%s`; "
+                            "type `"TI_VAL_THING_S"` cannot contain "
+                            "enum type `%s` with a default value"DOC_T_TYPE,
+                            field->name->str, field->type->name,
+                            enum_->name);
+                        return e->nr;
+                    }
+
                     if (m == n-1)
                     {
                         ex_set(e, EX_TYPE_ERROR,

--- a/src/ti/field.c
+++ b/src/ti/field.c
@@ -655,6 +655,17 @@ skip_nesting:
                         return e->nr;
                     }
 
+                    if ((field->spec & TI_SPEC_MASK_NILLABLE) == TI_SPEC_ARR)
+                    {
+                        ex_set(e, EX_TYPE_ERROR,
+                            "invalid declaration for `%s` on type `%s`; "
+                            "type `"TI_VAL_LIST_S"` cannot contain "
+                            "enum type `%s` with a default value"DOC_T_TYPE,
+                            field->name->str, field->type->name,
+                            enum_->name);
+                        return e->nr;
+                    }
+
                     if ((field->spec & TI_SPEC_MASK_NILLABLE) == TI_SPEC_SET)
                     {
                         ex_set(e, EX_TYPE_ERROR,

--- a/src/ti/field.c
+++ b/src/ti/field.c
@@ -637,6 +637,8 @@ skip_nesting:
                     str,
                     m);
 
+                m++;
+
                 if (enum_)
                 {
                     ti_member_t * member;
@@ -675,7 +677,7 @@ skip_nesting:
                         return e->nr;
                     }
 
-                    member = ti_enum_member_by_strn(enum_, str[m], n-m-1);
+                    member = ti_enum_member_by_strn(enum_, str+m, n-m-1);
                     if (!member)
                     {
                         if (field__spec_is_ascii(field, str, n, e))
@@ -684,7 +686,7 @@ skip_nesting:
                                 "cannot find member `%.*s on "
                                 "enum type `%s`"DOC_T_TYPE,
                                 field->name->str, field->type->name,
-                                n-m-1, str[m],
+                                n-m-1, str+m,
                                 enum_->name);
                         return e->nr;
                     }

--- a/src/ti/field.c
+++ b/src/ti/field.c
@@ -628,7 +628,7 @@ skip_nesting:
     {
         /* possible enum with default */
         size_t m = 0;
-        for (; m < n-1; m++)
+        for (; m < n; m++)
         {
             if (str[m] == '{')
             {
@@ -666,7 +666,7 @@ skip_nesting:
                         return e->nr;
                     }
 
-                    if (m == n-2)
+                    if (m == n-1)
                     {
                         ex_set(e, EX_TYPE_ERROR,
                             "invalid declaration for `%s` on type `%s`; "
@@ -683,7 +683,7 @@ skip_nesting:
                         if (field__spec_is_ascii(field, str, n, e))
                             ex_set(e, EX_LOOKUP_ERROR,
                                 "invalid declaration for `%s` on type `%s`; "
-                                "cannot find member `%.*s on "
+                                "cannot find member `%.*s` on "
                                 "enum type `%s`"DOC_T_TYPE,
                                 field->name->str, field->type->name,
                                 n-m-1, str+m,
@@ -705,15 +705,16 @@ skip_nesting:
                     ++enum_->refcount;
                     goto found;
                 }
+                m--;
+                break;
             }
         }
-
-        if (field__spec_is_ascii(field, str, n, e))
+        if (field__spec_is_ascii(field, str, m, e))
             ex_set(e, EX_TYPE_ERROR,
                     "invalid declaration for `%s` on type `%s`; "
                     "unknown type `%.*s` in declaration"DOC_T_TYPE,
                     field->name->str, field->type->name,
-                    n, str);
+                    m, str);
         return e->nr;
     }
 

--- a/src/ti/member.c
+++ b/src/ti/member.c
@@ -103,6 +103,31 @@ failed:
     return NULL;
 }
 
+int ti_member_alloc(ti_enum_t * enum_, ti_name_t * name, ex_t * e)
+{
+    ti_member_t * member = malloc(sizeof(ti_member_t));
+    if (!member)
+        goto alloc_error;
+
+    member->ref = 1;
+    member->tp = TI_VAL_MEMBER;
+    member->name = name;
+    member->enum_ = enum_;
+    member->val = NULL;
+    ti_incref(name);
+
+    if (ti_enum_add_member(enum_, member, e))
+        goto failed;
+
+    return e->nr;
+
+alloc_error:
+    ex_set_mem(e);
+failed:
+    ti_member_destroy(member);
+    return e->nr;
+}
+
 void ti_member_destroy(ti_member_t * member)
 {
     if (!member)

--- a/src/ti/store.c
+++ b/src/ti/store.c
@@ -381,6 +381,7 @@ int ti_store_restore(void)
         rc = (  -(!store_collection) ||
                 ti_store_enums_restore(
                         collection->enums,
+                        namesmap,
                         store_collection->enums_fn) ||
                 ti_store_types_restore(
                         collection->types,

--- a/src/ti/store/storeenums.c
+++ b/src/ti/store/storeenums.c
@@ -5,6 +5,7 @@
 #include <ti.h>
 #include <ti/enum.h>
 #include <ti/enums.inline.h>
+#include <ti/enum.inline.h>
 #include <ti/field.h>
 #include <ti/member.h>
 #include <ti/prop.h>
@@ -18,27 +19,30 @@
 static int mkenum_cb(ti_enum_t * enum_, msgpack_packer * pk)
 {
     uintptr_t p;
-    if (msgpack_pack_array(pk, 5) ||
+    if (msgpack_pack_array(pk, 6) ||
         msgpack_pack_uint16(pk, enum_->enum_id) ||
         msgpack_pack_uint64(pk, enum_->created_at) ||
         msgpack_pack_uint64(pk, enum_->modified_at) ||
         mp_pack_strn(pk, enum_->rname->data, enum_->rname->n) ||
-        msgpack_pack_map(pk, enum_->members->n + enum_->methods->n)
+        msgpack_pack_map(pk, enum_->methods->n)
     ) return -1;
-
-    for (vec_each(enum_->members, ti_member_t, member))
-    {
-        p = (uintptr_t) member->name;
-        if (msgpack_pack_uint64(pk, p) ||
-            ti_val_to_store_pk(member->val, pk)
-        ) return -1;
-    }
 
     for (vec_each(enum_->methods, ti_method_t, method))
     {
         p = (uintptr_t) method->name;
         if (msgpack_pack_uint64(pk, p) ||
             ti_val_to_store_pk((ti_val_t *) method->closure, pk)
+        ) return -1;
+    }
+
+    if (msgpack_pack_map(pk, enum_->members->n))
+        return -1;
+
+    for (vec_each(enum_->members, ti_member_t, member))
+    {
+        p = (uintptr_t) member->name;
+        if (msgpack_pack_uint64(pk, p) ||
+            ti_val_to_store_pk(member->val, pk)
         ) return -1;
     }
 
@@ -81,13 +85,14 @@ done:
 /*
  * Restore enums without values so they can be referenced to by types
  */
-int ti_store_enums_restore(ti_enums_t * enums, const char * fn)
+int ti_store_enums_restore(ti_enums_t * enums, imap_t * names, const char * fn)
 {
     int rc = -1;
     fx_mmap_t fmap;
-    size_t i;
+    size_t i, ii;
     mp_obj_t obj, mp_id, mp_name, mp_created, mp_modified;
     mp_unp_t up;
+    ex_t e = {0};
 
     if (!fx_file_exist(fn))
     {
@@ -120,7 +125,8 @@ int ti_store_enums_restore(ti_enums_t * enums, const char * fn)
     {
         ti_enum_t * enum_;
 
-        if (mp_next(&up, &obj) != MP_ARR || obj.via.sz != 5 ||
+        if (mp_next(&up, &obj) != MP_ARR ||
+                (obj.via.sz != 5 && obj.via.sz != 6) ||
             mp_next(&up, &mp_id) != MP_U64 ||
             mp_next(&up, &mp_created) != MP_U64 ||
             mp_next(&up, &mp_modified) != MP_U64 ||
@@ -147,6 +153,26 @@ int ti_store_enums_restore(ti_enums_t * enums, const char * fn)
             ti_enum_destroy(enum_);
             goto fail1;
         }
+
+        if (obj.via.sz == 6)
+        {
+            ti_name_t * name;
+
+            if (mp_next(&up, &obj) != MP_MAP)
+                goto fail1;
+
+            for (ii = obj.via.sz; ii--;)
+            {
+                if (mp_next(&up, &mp_id) != MP_U64)
+                    goto fail1;
+
+                name = imap_get(names, mp_id.via.u64);
+                if (!name ||
+                    mp_skip(&up) <= 0 || /* skip value */
+                    ti_member_alloc(enum_, name, &e))
+                    goto fail1;
+            }
+        }
     }
 
     rc = 0;
@@ -156,8 +182,12 @@ fail1:
         rc = -1;
 fail0:
     if (rc)
-        log_critical("failed to restore enums from file: `%s`", fn);
-
+    {
+        if (e.nr)
+            log_critical("failed to restore enums from file: `%s` (%s)", fn, e.msg);
+        else
+            log_critical("failed to restore enums from file: `%s`", fn);
+    }
     return rc;
 }
 
@@ -174,6 +204,7 @@ int ti_store_enums_restore_members(
     ex_t e = {0};
     ti_name_t * name;
     ti_enum_t * enum_;
+    ti_member_t * member;
     ti_val_t * val;
     size_t i, ii;
     mp_obj_t obj, mp_id;
@@ -200,51 +231,105 @@ int ti_store_enums_restore_members(
 
     for (i = enums->imap->n; i--;)
     {
-        if (mp_next(&up, &obj) != MP_ARR || obj.via.sz != 5 ||
+        if (mp_next(&up, &obj) != MP_ARR ||
+                (obj.via.sz != 5 && obj.via.sz != 6) ||
             mp_next(&up, &mp_id) != MP_U64 ||
             mp_skip(&up) != MP_U64 ||  /* created */
             mp_skip(&up) != MP_U64 ||  /* modified */
-            mp_skip(&up) != MP_STR ||  /* name */
-            mp_next(&up, &obj) != MP_MAP
+            mp_skip(&up) != MP_STR
         ) goto fail1;
 
         enum_ = ti_enums_by_id(enums, mp_id.via.u64);
         assert(enum_);
 
-        /* this might allocate too much for the methods but never too little */
-        if (ti_enum_prealloc(enum_, obj.via.sz, &e))
+        /* TODO (COMPAT); For comptibility with < 1.7.0 */
+        if (obj.via.sz == 5)
         {
-            log_critical(e.msg);
-            goto fail1;
-        }
-
-        for (ii = obj.via.sz; ii--;)
-        {
-            if (mp_next(&up, &mp_id) != MP_U64)
+            if (mp_next(&up, &obj) != MP_MAP)
                 goto fail1;
 
-            name = imap_get(names, mp_id.via.u64);
-            if (!name)
-                goto fail1;
-
-            val = ti_val_from_vup(&vup);
-            if (!val)
-                goto fail1;
-
-            if (ti_val_is_closure(val))
-               (void) ti_enum_add_method(enum_, name, (ti_closure_t *) val, &e);
-            else
-                (void) ti_member_create(enum_, name, val, &e);
-
-            if (e.nr)
+            for (ii = obj.via.sz; ii--;)
             {
-                ti_val_unsafe_drop(val);
-                log_critical(e.msg);
-                goto fail1;
-            }
+                if (mp_next(&up, &mp_id) != MP_U64)
+                    goto fail1;
 
-            ti_decref(val);  /* we do not need the reference anymore */
+                name = imap_get(names, mp_id.via.u64);
+                if (!name)
+                    goto fail1;
+
+                val = ti_val_from_vup(&vup);
+                if (!val)
+                    goto fail1;
+
+                if (ti_val_is_closure(val))
+                    (void) ti_enum_add_method(
+                        enum_, name, (ti_closure_t *) val, &e);
+                else
+                    (void) ti_member_create(enum_, name, val, &e);
+
+                if (e.nr)
+                {
+                    ti_val_unsafe_drop(val);
+                    goto fail1;
+                }
+                ti_decref(val);  /* we do not need the reference anymore */
+            }
         }
+        else
+        {
+            if (mp_next(&up, &obj) != MP_MAP)
+                goto fail1;
+
+            for (ii = obj.via.sz; ii--;)
+            {
+                if (mp_next(&up, &mp_id) != MP_U64)
+                    goto fail1;
+
+                name = imap_get(names, mp_id.via.u64);
+                if (!name)
+                    goto fail1;
+
+                val = ti_val_from_vup(&vup);
+                if (!val || !ti_val_is_closure(val))
+                    goto fail1;
+
+                if (ti_enum_add_method(enum_, name, (ti_closure_t *) val, &e))
+                {
+                    ti_val_unsafe_drop(val);
+                    goto fail1;
+                }
+
+                ti_decref(val);  /* we do not need the reference anymore */
+            }
+            if (mp_next(&up, &obj) != MP_MAP || obj.via.sz == 0)
+                goto fail1;
+
+            for (ii = obj.via.sz; ii--;)
+            {
+                if (mp_next(&up, &mp_id) != MP_U64)
+                    goto fail1;
+
+                name = imap_get(names, mp_id.via.u64);
+                if (!name)
+                    goto fail1;
+
+                member = ti_enum_member_by_raw(enum_, (ti_raw_t *) name);
+                if (!member || member->val)
+                    goto fail1;
+
+                val = ti_val_from_vup(&vup);
+                if (!val)
+                    goto fail1;
+
+                member->val = val;
+            }
+            if (ti_enum_set_enum_tp(enum_, val, &e))
+                goto fail1;
+        }
+
+        /* perform a sanity check for the members */
+        if (ti_enum_members_check(enum_, &e))
+            goto fail1;
     }
 
     rc = 0;
@@ -254,7 +339,11 @@ fail1:
         rc = -1;
 fail0:
     if (rc)
-        log_critical("failed to restore members from file: `%s`", fn);
-
+    {
+        if (e.nr)
+            log_critical("failed to restore members from file: `%s` (%s)", fn, e.msg);
+        else
+            log_critical("failed to restore members from file: `%s`", fn);
+    }
     return rc;
 }

--- a/src/ti/type.c
+++ b/src/ti/type.c
@@ -196,7 +196,7 @@ int ti_type_rename(ti_type_t * type, ti_raw_t * nname)
         return -1;
     }
 
-    if (ti_types_rename_spec(type->types, type->type_id, type->rname, nname))
+    if (ti_types_ren_spec(type->types, type->type_id, type->rname, nname))
     {
         ti_panic("failed to rename all type");
         return -1;

--- a/src/ti/type.c
+++ b/src/ti/type.c
@@ -196,7 +196,7 @@ int ti_type_rename(ti_type_t * type, ti_raw_t * nname)
         return -1;
     }
 
-    if (ti_types_ren_spec(type->types, type->type_id, type->rname, nname))
+    if (ti_types_ren_spec(type->types, type->type_id, nname))
     {
         ti_panic("failed to rename all type");
         return -1;

--- a/src/ti/types.c
+++ b/src/ti/types.c
@@ -92,18 +92,18 @@ static int types__ren_member_cb(ti_type_t * type, ti_member_t * member)
 {
     for (vec_each(type->fields, ti_field_t, field))
     {
-        if (field->condition.none && field->condition.none->dval == member)
+        if (field->condition.none &&
+                field->condition.none->dval == (ti_val_t *) member)
         {
             /* enum with default value rename */
+            int flags_pos = types__spec_flags_pos(field->spec_raw->data);
             ti_member_t * member = \
                 (ti_member_t *) field->condition.none->dval;
             ti_raw_t * spec_raw = ti_str_from_fmt(
-                    "%.*s%.*s{%.*s}%s",
+                    "%.*s%s{%s}%s",
                     flags_pos,
                     (const char *) field->spec_raw->data,
-                    w->nname->n,
-                    (const char *) w->nname->data,
-                    member->name->n,
+                    member->enum_->name,
                     member->name->str,
                     (field->spec & TI_SPEC_NILLABLE) ? "?": "");
             if (!spec_raw)

--- a/src/ti/types.c
+++ b/src/ti/types.c
@@ -73,9 +73,8 @@ void ti_types_del(ti_types_t * types, ti_type_t * type)
 typedef struct
 {
     uint16_t id;
-    ti_raw_t * oname;
     ti_raw_t * nname;
-} types__rename_t;
+} types__ren_t;
 
 int types__spec_flags_pos(const unsigned char * x)
 {
@@ -89,14 +88,61 @@ int types__spec_flags_pos(const unsigned char * x)
     return i;
 }
 
-static int types__rename_cb(ti_type_t * type, types__rename_t * w)
+static int types__ren_member_cb(ti_type_t * type, ti_member_t * member)
+{
+    for (vec_each(type->fields, ti_field_t, field))
+    {
+        if (field->condition.none && field->condition.none->dval == member)
+        {
+            /* enum with default value rename */
+            ti_member_t * member = \
+                (ti_member_t *) field->condition.none->dval;
+            ti_raw_t * spec_raw = ti_str_from_fmt(
+                    "%.*s%.*s{%.*s}%s",
+                    flags_pos,
+                    (const char *) field->spec_raw->data,
+                    w->nname->n,
+                    (const char *) w->nname->data,
+                    member->name->n,
+                    member->name->str,
+                    (field->spec & TI_SPEC_NILLABLE) ? "?": "");
+            if (!spec_raw)
+                return -1;
+
+            ti_val_unsafe_drop((ti_val_t *) field->spec_raw);
+            field->spec_raw = spec_raw;
+        }
+    }
+    return 0;
+}
+
+static int types__ren_cb(ti_type_t * type, types__ren_t * w)
 {
     for (vec_each(type->fields, ti_field_t, field))
     {
         if ((field->spec & TI_SPEC_MASK_NILLABLE) == w->id)
         {
             int flags_pos = types__spec_flags_pos(field->spec_raw->data);
-            if (field->spec == w->id && !flags_pos)
+            if (field->condition.none)
+            {
+                /* enum with default value rename */
+                ti_member_t * member = \
+                    (ti_member_t *) field->condition.none->dval;
+                ti_raw_t * spec_raw = ti_str_from_fmt(
+                        "%.*s%.*s{%.*s}%s",
+                        flags_pos,
+                        (const char *) field->spec_raw->data,
+                        w->nname->n,
+                        (const char *) w->nname->data,
+                        member->name->n, member->name->str,
+                        (field->spec & TI_SPEC_NILLABLE) ? "?": "");
+                if (!spec_raw)
+                    return -1;
+
+                ti_val_unsafe_drop((ti_val_t *) field->spec_raw);
+                field->spec_raw = spec_raw;
+            }
+            else if (field->spec == w->id && !flags_pos)
             {
                 ti_val_unsafe_drop((ti_val_t *) field->spec_raw);
                 field->spec_raw = w->nname;
@@ -164,19 +210,22 @@ static int types__rename_cb(ti_type_t * type, types__rename_t * w)
     return 0;
 }
 
-int ti_types_rename_spec(
+int ti_types_ren_spec(
         ti_types_t * types,
         uint16_t type_or_enum_id,
-        ti_raw_t * oname,
         ti_raw_t * nname)
 {
-    types__rename_t w = {
+    types__ren_t w = {
         .id = type_or_enum_id,
-        .oname = oname,
         .nname = nname,
     };
 
-    return imap_walk(types->imap, (imap_cb) types__rename_cb, &w);
+    return imap_walk(types->imap, (imap_cb) types__ren_cb, &w);
+}
+
+int ti_types_ren_member_spec(ti_types_t * types, ti_member_t * member)
+{
+    return imap_walk(types->imap, (imap_cb) types__ren_member_cb, member);
 }
 
 uint16_t ti_types_get_new_id(ti_types_t * types, ti_raw_t * rname, ex_t * e)

--- a/src/ti/types.c
+++ b/src/ti/types.c
@@ -3,6 +3,7 @@
  */
 #include <assert.h>
 #include <stdlib.h>
+#include <ti/spec.inline.h>
 #include <ti/type.h>
 #include <ti/types.h>
 #include <ti/types.inline.h>
@@ -123,7 +124,7 @@ static int types__ren_cb(ti_type_t * type, types__ren_t * w)
         if ((field->spec & TI_SPEC_MASK_NILLABLE) == w->id)
         {
             int flags_pos = types__spec_flags_pos(field->spec_raw->data);
-            if (field->condition.none)
+            if (ti_spec_is_enum(field->spec) && field->condition.none)
             {
                 /* enum with default value rename */
                 ti_member_t * member = \


### PR DESCRIPTION
## Description

Allow a type definition to set a default enumerator value.

For example:

```javascript
set_type('T', {
  e: 'E{M}`,
});
```

Where `T` is a new type, `E` the enumerator and `M` a member which we want as the default when not provided.

Implements issue #387.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Added enumerator tests

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
