### PR TITLE
use fragments for websocket writes

### DIFF
--- a/inc/ti/version.h
+++ b/inc/ti/version.h
@@ -25,7 +25,7 @@
  *  "-rc0"
  *  ""
  */
-#define TI_VERSION_PRE_RELEASE "-alpha0"
+#define TI_VERSION_PRE_RELEASE "-alpha1"
 
 #define TI_MAINTAINER \
     "Jeroen van der Heijden <jeroen@cesbit.com>"

--- a/inc/ti/ws.t.h
+++ b/inc/ti/ws.t.h
@@ -15,8 +15,6 @@ struct ti_ws_s
     queue_t * queue;          /* ti_write_t */
     ti_stream_t * stream;
     struct lws * wsi;
-    unsigned char * wbuf;
-    size_t wbuf_sz;
 };
 
 #endif  /* TI_WS_T_H_ */

--- a/itest/test_ws.py
+++ b/itest/test_ws.py
@@ -45,6 +45,11 @@ class TestWS(TestBase):
         self.assertIsInstance(info, str)
         res = await client.query('6 * 7;')
         self.assertEqual(res, 42)
+        n = 10000
+        res = await client.query("""//ti
+            range(n).map(|i| `item {i}`);
+        """, n=n)
+        self.assertEqual(res, [f'item {i}' for i in range(n)])
 
 
 if __name__ == '__main__':

--- a/itest/ws/index.html
+++ b/itest/ws/index.html
@@ -12,7 +12,8 @@
         const thingsdb = new ThingsDB('ws://localhost:9270');
         thingsdb.connect().then(() => {
             thingsdb.auth().then(() => {
-                thingsdb.query('@:stuff', '"Hello World!";').then(response => {
+                thingsdb.query('@thingsdb', '"Hello World!";').then(response => {
+                    console.log('Query done!');
                     console.log(response);  // will be "Hello World!"
                 });
             });

--- a/src/ti/stream.c
+++ b/src/ti/stream.c
@@ -279,7 +279,7 @@ const char * ti_stream_name(ti_stream_t * stream)
         return stream->name_ ? stream->name_ : "<client> "STREAM__UNRESOLVED;
     case TI_STREAM_WS_IN_CLIENT:
         if (stream->via.user)
-            sprintf(prefix, "<client:%"PRIu64"> ", stream->via.user->id);
+            sprintf(prefix, "<ws:%"PRIu64"> ", stream->via.user->id);
         else
             sprintf(prefix, "<ws:not authorized> ");
         stream->name_ = ti_ws_name(prefix, (ti_ws_t *) stream->with.ws);


### PR DESCRIPTION
## Description

Honor MTU size when writing WebSocket fragments. (issue reported by @ivomans)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Test ws

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
