### PR TITLE
Allow return statement without arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # v1.7.3
 
+* Allow `return;` statement without arguments _(implicit return nil)_.
+
+# v1.7.3
+
 * Improve destroy websocket when unexpected disconnect.
 * Fix in recursive `for-each` loop.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-# v1.7.3
+# v1.7.4
 
-* Allow `return;` statement without arguments _(implicit return nil)_.
+* Allow `return;` statement without arguments _(implicitly return nil)_, pr #404.
 
 # v1.7.3
 

--- a/grammar/grammar.py
+++ b/grammar/grammar.py
@@ -161,7 +161,7 @@ class LangDef(Grammar):
 
     return_statement = Sequence(
         k_return,
-        List(THIS, mi=1, ma=3, opt=False))
+        List(THIS, mi=0, ma=3, opt=False))
 
     for_statement = Sequence(
         k_for,

--- a/inc/ti/do.h
+++ b/inc/ti/do.h
@@ -28,6 +28,7 @@ int ti_do_compare_and(ti_query_t * query, cleri_node_t * nd, ex_t * e);
 int ti_do_compare_or(ti_query_t * query, cleri_node_t * nd, ex_t * e);
 int ti_do_ternary(ti_query_t * query, cleri_node_t * nd, ex_t * e);
 int ti_do_if_statement(ti_query_t * query, cleri_node_t * nd, ex_t * e);
+int ti_do_return_nil(ti_query_t * query, cleri_node_t * nd, ex_t * e);
 int ti_do_return_val(ti_query_t * query, cleri_node_t * nd, ex_t * e);
 int ti_do_return_alt_deep(ti_query_t * query, cleri_node_t * nd, ex_t * e);
 int ti_do_return_alt_flags(ti_query_t * query, cleri_node_t * nd, ex_t * e);

--- a/inc/ti/version.h
+++ b/inc/ti/version.h
@@ -6,7 +6,7 @@
 
 #define TI_VERSION_MAJOR 1
 #define TI_VERSION_MINOR 7
-#define TI_VERSION_PATCH 3
+#define TI_VERSION_PATCH 4
 
 /* The syntax version is used to test compatibility with functions
  * using the `ti_nodes_check_syntax()` function */
@@ -25,7 +25,7 @@
  *  "-rc0"
  *  ""
  */
-#define TI_VERSION_PRE_RELEASE ""
+#define TI_VERSION_PRE_RELEASE "-alpha0"
 
 #define TI_MAINTAINER \
     "Jeroen van der Heijden <jeroen@cesbit.com>"

--- a/itest/test_syntax.py
+++ b/itest/test_syntax.py
@@ -177,8 +177,11 @@ class TestSyntax(TestBase):
         ])
 
     async def test_empty(self, client):
-        await client.query("")
+        res = await client.query("")
+        self.assertIsNone(res)
         await client.query("nil;;;")
+        self.assertIsNone(res)
+        await client.query("return;")
 
 
 if __name__ == '__main__':

--- a/src/langdef/langdef.c
+++ b/src/langdef/langdef.c
@@ -232,7 +232,7 @@ cleri_grammar_t * compile_langdef(void)
         CLERI_GID_RETURN_STATEMENT,
         2,
         k_return,
-        cleri_list(CLERI_NONE, CLERI_THIS, cleri_token(CLERI_NONE, ","), 1, 3, 0)
+        cleri_list(CLERI_NONE, CLERI_THIS, cleri_token(CLERI_NONE, ","), 0, 3, 0)
     );
     cleri_t * for_statement = cleri_sequence(
         CLERI_GID_FOR_STATEMENT,

--- a/src/ti/do.c
+++ b/src/ti/do.c
@@ -924,6 +924,13 @@ int ti_do_if_statement(ti_query_t * query, cleri_node_t * nd, ex_t * e)
     return ti_do_statement(query, nd, e);
 }
 
+int ti_do_return_nil(ti_query_t * query, cleri_node_t * UNUSED(nd), ex_t * e)
+{
+    query->rval = (ti_val_t *) ti_nil_get();
+    ex_set_return(e);
+    return e->nr;
+}
+
 int ti_do_return_val(ti_query_t * query, cleri_node_t * nd, ex_t * e)
 {
     if (ti_do_statement(query, nd->children->next->children, e) == 0)

--- a/src/ti/qbind.c
+++ b/src/ti/qbind.c
@@ -1347,6 +1347,13 @@ static inline void qbind__return_statement(
         cleri_node_t * nd)
 {
     cleri_node_t * node = nd->children->next->children;
+    if (!node)
+    {
+        nd->data = ti_do_return_nil;
+        nd->children->data = NULL;
+        return;
+    }
+
     qbind__statement(qbind, node);
     if (node->next)
     {


### PR DESCRIPTION
## Description

Allow the `return;` statement to be used without arguments to implicitly return `nil`.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Test syntax updated

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
