### PR TITLE
no error when nse() with change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Added `bit_count()` function, pr #405.
 * Allow `return;` statement without arguments _(implicitly return nil)_, pr #404.
+* Function `nse();` should not error when a side-effect outside nse() is enforced
 
 # v1.7.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * Added `bit_count()` function, pr #405.
 * Allow `return;` statement without arguments _(implicitly return nil)_, pr #404.
-* Function `nse();` should not error when a side-effect outside nse() is enforced
+* Function `nse();` should not error when a side-effect outside nse() is enforced, pr #406.
 
 # v1.7.3
 

--- a/inc/ti/fn/fnnse.h
+++ b/inc/ti/fn/fnnse.h
@@ -7,14 +7,6 @@ static int do__f_nse(ti_query_t * query, cleri_node_t * nd, ex_t * e)
     if (fn_nargs_max("nse", DOC_NSE, 1, nargs, e))
         return e->nr;
 
-    if (query->qbind.flags & TI_QBIND_FLAG_WSE)
-    {
-        ex_set(e, EX_OPERATION,
-                "function `nse` failed; at least one side-effect is enforced"
-                DOC_NSE);
-        return e->nr;
-    }
-
     if (!nargs)
     {
         query->rval = (ti_val_t *) ti_nil_get();

--- a/inc/ti/version.h
+++ b/inc/ti/version.h
@@ -25,7 +25,7 @@
  *  "-rc0"
  *  ""
  */
-#define TI_VERSION_PRE_RELEASE "-alpha1"
+#define TI_VERSION_PRE_RELEASE "-alpha2"
 
 #define TI_MAINTAINER \
     "Jeroen van der Heijden <jeroen@cesbit.com>"

--- a/itest/test_collection_functions.py
+++ b/itest/test_collection_functions.py
@@ -5857,10 +5857,8 @@ class TestCollectionFunctions(TestBase):
                 'but 2 were given'):
             await client.query('nse(nil, nil);')
 
-        with self.assertRaisesRegex(
-                OperationError,
-                'function `nse` failed; at least one side-effect is enforced'):
-            await client.query('.x = 1; nse();')
+        await client.query('.x = 1; nse();')
+        self.assertEqual(await client.query('.x'), 1)
 
         with self.assertRaisesRegex(
                 OperationError,


### PR DESCRIPTION
## Description

Currently, ThingsDB returns with the following error when a change is enforced and the `nse()` function is being called:

_"function `nse` failed; at least one side-effect is enforced"_

This can be annoying, as you sometimes want to create a closure which by itself does not require a change, but can be used in a scenario where a change is perfectly fine. 

This PR removes the error and let `nse()` silently continue if a change exists.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Test collection functions

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
