### PR TITLE
Add definition to expose type name

### DIFF
--- a/inc/ti/fn/fnmodtype.h
+++ b/inc/ti/fn/fnmodtype.h
@@ -1079,7 +1079,7 @@ static void type__ren(
     if (fn_nargs(fnname, DOC_MOD_TYPE_REN, 4, nargs, e))
         return;
 
-    if (type->idname != name && !field && !method)
+    if (type->idname != name && type->typename != name && !field && !method)
     {
         ex_set(e, EX_LOOKUP_ERROR,
                 "type `%s` has no property or method `%s`",
@@ -1096,11 +1096,7 @@ static void type__ren(
 
     rname = (ti_raw_t *) query->rval;
 
-    oldname = field
-            ? field->name
-            : method
-            ? method->name
-            : type->idname;
+    oldname = name;
     ti_incref(oldname);
 
     /* method */
@@ -1128,7 +1124,7 @@ static void type__ren(
             goto done;
         newname = method->name;
     }
-    else
+    else if (type->idname == name )
     {
         if (ti_type_set_idname(
                 type,
@@ -1137,6 +1133,16 @@ static void type__ren(
                 e))
             goto done;
         newname = type->idname;
+    }
+    else
+    {
+        if (ti_type_set_typename(
+                type,
+                (const char *) rname->data,
+                rname->n,
+                e))
+            goto done;
+        newname = type->typename;
     }
 
     task = ti_task_get_task(query->change, query->collection->root);

--- a/inc/ti/task.h
+++ b/inc/ti/task.h
@@ -85,6 +85,7 @@ int ti_task_add_mod_type_add_field(
         ti_type_t * type,
         ti_val_t * dval);
 int ti_task_add_mod_type_add_idname(ti_task_t * task, ti_type_t * type);
+int ti_task_add_mod_type_add_typename(ti_task_t * task, ti_type_t * type);
 int ti_task_add_mod_type_add_method(
         ti_task_t * task,
         ti_type_t * type);

--- a/inc/ti/type.h
+++ b/inc/ti/type.h
@@ -59,6 +59,11 @@ int ti_type_set_idname(
         const char * s,
         size_t n,
         ex_t * e);
+int ti_type_set_typename(
+        ti_type_t * type,
+        const char * s,
+        size_t n,
+        ex_t * e);
 int ti_type_methods_to_pk(ti_type_t * type, msgpack_packer * pk);
 int ti_type_relations_to_pk(ti_type_t * type, msgpack_packer * pk);
 int ti_type_methods_info_to_pk(

--- a/inc/ti/type.t.h
+++ b/inc/ti/type.t.h
@@ -38,6 +38,7 @@ struct ti_type_s
     ti_raw_t * rname;       /* name as raw type */
     ti_raw_t * rwname;      /* wrapped name as raw type */
     ti_name_t * idname;     /* use this as the id field */
+    ti_name_t * typename;   /* use this to expose type */
     ti_types_t * types;
     vec_t * dependencies;   /* ti_type_t/ti_enum_t; contains type and enum
                                where this type is depended on. A type or enum

--- a/inc/ti/val.h
+++ b/inc/ti/val.h
@@ -56,6 +56,7 @@ ti_val_t * ti_val_charset_str(void);
 ti_val_t * ti_val_borrow_any_str(void);
 ti_val_t * ti_val_borrow_tar_gz_str(void);
 ti_val_t * ti_val_borrow_gs_str(void);
+ti_val_t * ti_val_borrow_thing_str(void);
 ti_val_t * ti_val_empty_bin(void);
 ti_val_t * ti_val_wrapped_thing_str(void);
 ti_val_t * ti_val_utc_str(void);

--- a/src/ti/field.c
+++ b/src/ti/field.c
@@ -1168,7 +1168,7 @@ int ti_field_set_name(
         return e->nr;
     }
 
-    if (field->type->idname == name
+    if (field->type->idname == name ||
         field->type->typename == name ||
         ti_field_by_name(field->type, name) ||
         ti_type_get_method(field->type, name))

--- a/src/ti/field.c
+++ b/src/ti/field.c
@@ -1168,7 +1168,8 @@ int ti_field_set_name(
         return e->nr;
     }
 
-    if (field->type->idname == name ||
+    if (field->type->idname == name
+        field->type->typename == name ||
         ti_field_by_name(field->type, name) ||
         ti_type_get_method(field->type, name))
     {

--- a/src/ti/method.c
+++ b/src/ti/method.c
@@ -140,6 +140,7 @@ int ti_method_set_name_t(
     }
 
     if (type->idname == name ||
+        type->typename == name ||
         ti_field_by_name(type, name) ||
         ti_type_get_method(type, name))
     {

--- a/src/ti/task.c
+++ b/src/ti/task.c
@@ -1712,6 +1712,48 @@ fail_data:
     return -1;
 }
 
+int ti_task_add_mod_type_add_typename(ti_task_t * task, ti_type_t * type)
+{
+    size_t alloc = 64 + type->typename->n;
+    ti_data_t * data;
+    msgpack_packer pk;
+    msgpack_sbuffer buffer;
+
+    if (mp_sbuffer_alloc_init(&buffer, alloc, sizeof(ti_data_t)))
+        return -1;
+    msgpack_packer_init(&pk, &buffer, msgpack_sbuffer_write);
+
+    msgpack_pack_array(&pk, 2);
+
+    msgpack_pack_uint8(&pk, TI_TASK_MOD_TYPE_ADD);
+    msgpack_pack_map(&pk, 4);
+
+    mp_pack_str(&pk, "type_id");
+    msgpack_pack_uint16(&pk, type->type_id);
+
+    mp_pack_str(&pk, "modified_at");
+    msgpack_pack_uint64(&pk, type->modified_at);
+
+    mp_pack_str(&pk, "name");
+    mp_pack_strn(&pk, type->typename->str, type->typename->n);
+
+    mp_pack_str(&pk, "spec");
+    mp_pack_strn(&pk, "@", 1);
+
+    data = (ti_data_t *) buffer.data;
+    ti_data_init(data, buffer.size);
+
+    if (vec_push(&task->list, data))
+        goto fail_data;
+
+    task__upd_approx_sz(task, data);
+    return 0;
+
+fail_data:
+    free(data);
+    return -1;
+}
+
 int ti_task_add_mod_type_add_method(ti_task_t * task, ti_type_t * type)
 {
     ti_method_t * method = VEC_last(type->methods);

--- a/src/ti/type.c
+++ b/src/ti/type.c
@@ -274,6 +274,7 @@ int ti_type_set_idname(
     }
 
     if (type->idname == name ||
+        type->typename == name ||
         ti_field_by_name(type, name) ||
         ti_type_get_method(type, name))
     {
@@ -286,6 +287,49 @@ int ti_type_set_idname(
 
     ti_name_unsafe_drop(type->idname);
     type->idname = name;
+    return 0;
+
+fail0:
+    ti_name_unsafe_drop(name);
+    return e->nr;
+}
+
+int ti_type_set_typename(
+        ti_type_t * type,
+        const char * s,
+        size_t n,
+        ex_t * e)
+{
+    ti_name_t * name;
+
+    if (!ti_name_is_valid_strn(s, n))
+    {
+        ex_set(e, EX_VALUE_ERROR,
+            "property name must follow the naming rules"DOC_NAMES);
+        return e->nr;
+    }
+
+    name = ti_names_get(s, n);
+    if (!name)
+    {
+        ex_set_mem(e);
+        return e->nr;
+    }
+
+    if (type->idname == name ||
+        type->typename == name ||
+        ti_field_by_name(type, name) ||
+        ti_type_get_method(type, name))
+    {
+        ex_set(e, EX_VALUE_ERROR,
+            "property or method `%s` already exists on type `%s`"DOC_T_TYPED,
+            name->str,
+            type->name);
+        goto fail0;
+    }
+
+    ti_name_unsafe_drop(type->typename);
+    type->typename = name;
     return 0;
 
 fail0:

--- a/src/ti/val.c
+++ b/src/ti/val.c
@@ -912,6 +912,11 @@ ti_val_t * ti_val_borrow_gs_str(void)
     return val__gs_str;
 }
 
+ti_val_t * ti_val_borrow_thing_str(void)
+{
+    return val__sthing;
+}
+
 ti_val_t * ti_val_empty_bin(void)
 {
     ti_incref(val__empty_bin);


### PR DESCRIPTION
## Description

It would be useful to have a shortcut for exposing the type name when wrapping a type.

The equavalent of: 

```javascript
set_type('_T', {
   type: |this| type(this),
});
```

We could use the `@` symbol, similar as we do for exposing the thing ID (with `#`)

```javascript
set_type('_T', {
   type: '@',
});
```

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [ ] Update type test

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
