### PR TITLE
Added "skip nil" (?) prefix flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,6 +160,7 @@ set(SOURCES
     src/ti/gc.c
     src/ti/index.c
     src/ti/item.c
+    src/ti/map.c
     src/ti/mapping.c
     src/ti/member.c
     src/ti/method.c

--- a/inc/ti/field.t.h
+++ b/inc/ti/field.t.h
@@ -28,6 +28,8 @@ enum
     TI_FIELD_FLAG_ENAME=16, /* return enumerator names instead of value */
 
     TI_FIELD_FLAG_NO_IDS=TI_FLAGS_NO_IDS,  /* 32 */
+
+    TI_FIELD_FLAG_SKIP_NIL=64,  /* skip when prop is nil */
 };
 
 #define TI_FIELD_MIN_MAX (TI_FIELD_FLAG_MIN_DEEP|TI_FIELD_FLAG_MAX_DEEP)

--- a/inc/ti/fn/fnmapwrap.h
+++ b/inc/ti/fn/fnmapwrap.h
@@ -83,6 +83,8 @@ static int do__f_map_wrap(ti_query_t * query, cleri_node_t * nd, ex_t * e)
     if (!varr)
         goto fail0;
 
+    varr->flags |= TI_VARR_FLAG_MHT;
+
     switch (iterable->tp)
     {
     case TI_VAL_ARR:

--- a/inc/ti/map.h
+++ b/inc/ti/map.h
@@ -1,0 +1,21 @@
+/*
+ * ti/map.h
+ */
+#ifndef TI_MAP_H_
+#define TI_MAP_H_
+
+typedef struct ti_map_s ti_map_t;
+
+#include <util/vec.h>
+#include <stdbool.h>
+
+ti_map_t * ti_map_new(vec_t * mappings);
+void ti_map_destroy(ti_map_t * map);
+
+struct ti_map_s
+{
+    vec_t * mappings;  /* ti_mapping_t */
+    bool can_skip;   /* true when size might be less */
+};
+
+#endif  /* TI_MAP_H_ */

--- a/inc/ti/type.h
+++ b/inc/ti/type.h
@@ -10,6 +10,7 @@
 #include <ti/closure.t.h>
 #include <ti/method.t.h>
 #include <ti/name.t.h>
+#include <ti/map.h>
 #include <ti/thing.t.h>
 #include <ti/type.t.h>
 #include <ti/types.t.h>
@@ -40,7 +41,7 @@ int ti_type_init_from_unp(
         _Bool with_hide_id);
 int ti_type_fields_to_pk(ti_type_t * type, msgpack_packer * pk);
 ti_val_t * ti_type_as_mpval(ti_type_t * type, _Bool with_definition);
-vec_t * ti_type_map(ti_type_t * to_type, ti_type_t * from_type);
+ti_map_t * ti_type_map(ti_type_t * to_type, ti_type_t * from_type);
 ti_val_t * ti_type_dval(ti_type_t * type);
 int ti_type_convert(
         ti_type_t * type,

--- a/inc/ti/type.t.h
+++ b/inc/ti/type.t.h
@@ -46,7 +46,7 @@ struct ti_type_s
                                order is not important */
     vec_t * fields;         /* ti_field_t */
     vec_t * methods;        /* ti_method_t */
-    imap_t * t_mappings;    /* from_type_id / vec_t * with ti_field_t */
+    imap_t * t_mappings;    /* from_type_id / vec_t * with ti_mapping_t */
 };
 
 #endif  /* TI_TYPE_T_H_ */

--- a/inc/ti/type.t.h
+++ b/inc/ti/type.t.h
@@ -46,7 +46,7 @@ struct ti_type_s
                                order is not important */
     vec_t * fields;         /* ti_field_t */
     vec_t * methods;        /* ti_method_t */
-    imap_t * t_mappings;    /* from_type_id / vec_t * with ti_mapping_t */
+    imap_t * t_mappings;    /* from_type_id / ti_map_t */
 };
 
 #endif  /* TI_TYPE_T_H_ */

--- a/inc/ti/version.h
+++ b/inc/ti/version.h
@@ -25,7 +25,7 @@
  *  "-rc0"
  *  ""
  */
-#define TI_VERSION_PRE_RELEASE "-alpha1"
+#define TI_VERSION_PRE_RELEASE "-alpha2"
 
 #define TI_MAINTAINER \
     "Jeroen van der Heijden <jeroen@cesbit.com>"

--- a/itest/test_wrap.py
+++ b/itest/test_wrap.py
@@ -332,16 +332,21 @@ class TestWrap(TestBase):
         await client.query("""//ti
             set_type('T', {
                 name: 'str',
+                age: 'int?',
+                other: '[str]?',
+            });
+            set_type('_T', {
+                name: 'str',
                 age: '?int?',
                 other: '?any',
-            }, false, true);
+            }, true, true);
         """)
         res = await client.query("""//ti
             .orig = [
                 T{name: 'a'},
                 T{name: 'b', age: 123, other: ['other']},
                 {name: 'c', age: nil, other: nil}
-            ].map_wrap('T');
+            ].map_wrap('_T');
         """)
         self.assertEqual(res, [
             {'name': 'a'},

--- a/src/ti/map.c
+++ b/src/ti/map.c
@@ -1,0 +1,36 @@
+/*
+ * ti/map.c
+ */
+#include <assert.h>
+#include <stdlib.h>
+#include <ti/map.h>
+#include <ti/field.t.h>
+#include <ti/mapping.h>
+
+ti_map_t * ti_map_new(vec_t * mappings)
+{
+    ti_map_t * map = malloc(sizeof(ti_map_t));
+    if (!map)
+        return NULL;
+
+    map->mappings = mappings;
+    map->can_skip = false;
+    for (vec_each(mappings, ti_mapping_t, mapping))
+    {
+        if (mapping->t_field->flags & TI_FIELD_FLAG_SKIP_NIL)
+        {
+            map->can_skip = true;
+            break;
+        }
+    }
+    return map;
+}
+
+void ti_map_destroy(ti_map_t * map)
+{
+    if (map)
+        vec_destroy(map->mappings, free);
+    free(map);
+}
+
+


### PR DESCRIPTION
## Description

To reduce size, it can be useful to not return `nil` values. For example, support type `T` has a property with definition `str?` and this property is `nil` most of the time, you might save bandwidth to not include the value when `nil`.

This pull request adds the `?` prefix flag which tells to exclude from a result when `nil`.

Example:
```javascript
set_type('A', {
    name: 'str',
    description: 'str?',  // will return when nil
});
set_type('B', {
    name: 'str',
    description: '?str?',  // do not return when nil
});

[A{name: 'a'}.wrap(), B{name: 'a'}.wrap()];
```
Returns:

```json
[
    {
        "description": null,
        "name": "a"
    },
    {
        "name": "a"
    }
]
```

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Test wrap contains the test code

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
