### PR TITLE
copy wrap behavior

### DIFF
--- a/inc/ti/fn/fncopy.h
+++ b/inc/ti/fn/fncopy.h
@@ -27,7 +27,9 @@ static int do__f_copy(ti_query_t * query, cleri_node_t * nd, ex_t * e)
         query->rval = val;
     }
 
-    if (ti_val_copy(&query->rval, NULL, NULL, deep))
+    if (ti_val_is_wrap(query->rval) && ti_wrap_cp(query, deep, e))
+       return e->nr;  /* quit without fail0, e is set*/
+    else if (ti_val_copy(&query->rval, NULL, NULL, deep))
         ex_set_mem(e);
 
     return e->nr;

--- a/inc/ti/version.h
+++ b/inc/ti/version.h
@@ -5,8 +5,8 @@
 #define TI_VERSION_H_
 
 #define TI_VERSION_MAJOR 1
-#define TI_VERSION_MINOR 7
-#define TI_VERSION_PATCH 7
+#define TI_VERSION_MINOR 8
+#define TI_VERSION_PATCH 0
 
 /* The syntax version is used to test compatibility with functions
  * using the `ti_nodes_check_syntax()` function */

--- a/inc/ti/wrap.h
+++ b/inc/ti/wrap.h
@@ -8,8 +8,10 @@ typedef struct ti_wrap_s  ti_wrap_t;
 
 #include <inttypes.h>
 #include <ti/thing.h>
+#include <ti/query.t.h>
 #include <ti/vp.t.h>
 #include <util/mpack.h>
+#include <ex.h>
 
 ti_wrap_t * ti_wrap_create(ti_thing_t * thing, uint16_t type_id);
 void ti_wrap_destroy(ti_wrap_t * wrap);
@@ -19,6 +21,7 @@ int ti__wrap_field_thing(
         uint16_t spec,
         int deep,
         int flags);
+int ti_wrap_cp(ti_query_t * query, uint8_t deep, ex_t * e);
 int ti_wrap_copy(ti_wrap_t ** wrap, uint8_t deep);
 int ti_wrap_dup(ti_wrap_t ** wrap, uint8_t deep);
 

--- a/itest/test_wrap.py
+++ b/itest/test_wrap.py
@@ -406,6 +406,34 @@ class TestWrap(TestBase):
             {'name': 'd'}
         ])
 
+    async def test_wrap_copy(self, client):
+        await client.query("""//ti
+            set_type('T', {
+               name: 'str',
+               upper: |this| this.name.upper(),
+            });
+        """)
+
+        res = await client.query("""//ti
+            .t = T{name: "Iris"};
+            .t.wrap().copy();
+        """)
+        self.assertEqual(res, {"name": "Iris", "upper": "IRIS"})
+
+        res = await client.query("""//ti
+            .o = {
+                t: .t.wrap()
+            };
+            return .o.copy(2), 2;
+        """)
+        self.assertEqual(res, {'t': {'name': 'Iris', "upper": "IRIS"}})
+
+        res = await client.query("""//ti
+            .t = T{name: "Iris"};
+            .t.wrap().copy().upper;
+        """)
+        self.assertEqual(res, "IRIS")
+
 
 if __name__ == '__main__':
     run_test(TestWrap())


### PR DESCRIPTION
## Description

Calling `copy()` on wrap type has slightly strange behavior. It currently unpacks properties to a new thing, but skips methods. It's behavior is more logic if we copy nested wraps just as a copy of the internal thing, together with the wrap type itself. When called directly on a wrapped thing, we can unpack including the computed methods.

Example:

```javascript
set_type('T', {
   name: 'str',
   upper: |this| this.name.upper(),
});
// This pull request ensure `copy()` creates a thing with the computed properties executed
T{name: "Test"}.wrap().copy().upper;  // return "TEST"
```

> Note that the ID's are never copied, the copy will be a new thing. The change is breaking although `copy()` on a wrapped thing is most likely not used extensively as the "old" behavior wasn't really useful.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

- [x] Test wrap

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
