### PR TITLE
Opimize `del_history` task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v1.8.3-alpha0
 
 * Added the `America/Coyhaique` time zone, pr #432.
+* Optimize `del_history` task _(use single loop)_, pr #433.
 
 # v1.8.2
 

--- a/inc/ti/version.h
+++ b/inc/ti/version.h
@@ -25,7 +25,7 @@
  *  "-rc0"
  *  ""
  */
-#define TI_VERSION_PRE_RELEASE "-alpha0"
+#define TI_VERSION_PRE_RELEASE "-alpha1"
 
 #define TI_MAINTAINER \
     "Jeroen van der Heijden <jeroen@cesbit.com>"

--- a/src/ti/commits.c
+++ b/src/ti/commits.c
@@ -463,6 +463,7 @@ vec_t * ti_commits_del(vec_t ** commits, ti_commits_options_t * options)
     if (!vec)
         return NULL;
 
+    /* must push from high to low as the `del_history` depends on this order */
     commits__init(*commits, options, &begin, &end);
     while (begin < end)
     {

--- a/src/ti/ttask.c
+++ b/src/ti/ttask.c
@@ -787,7 +787,8 @@ static int ttask__del_history(mp_unp_t * up)
             log_critical("task `del_history`: invalid task data");
             return -1;
         }
-
+        /* we can use a single loop as we're sure the commits in the list are
+         * ordered from high to low */
         for (vec_each_rev(*commits, ti_commit_t, commit) j--)
         {
             if (commit->id == mp_id.via.u64)


### PR DESCRIPTION
## Description

This pull request improves the `del_history` task which previously required to loop over commits for each `ID` to be removed. After this pull request, the same is done in a single loop.

## Type of change

- [x] Performance improvement.

## How Has This Been Tested?

- [x] Test commits

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
