### PR TITLE
Type count from cache if possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v1.8.6-alpha0
+
+* Read `type_count(..)` from cache if available.
+
 # v1.8.5
 
 * Added `min()` and `max()` functions, issue #441.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # v1.8.6-alpha0
 
-* Read `type_count(..)` from cache if available.
+* Read `type_count(..)` from cache if available, pr #443.
 
 # v1.8.5
 

--- a/inc/ti/fn/fntypecount.h
+++ b/inc/ti/fn/fntypecount.h
@@ -16,7 +16,8 @@ static int do__f_type_count(ti_query_t * query, cleri_node_t * nd, ex_t * e)
     if (!type)
         return ti_raw_err_not_found((ti_raw_t *) query->rval, "type", e);
 
-    n = ti_query_count_type(query, type);
+    /* use cache if available */
+    n = type->t_cache ? type->t_cache->n : ti_query_count_type(query, type);
 
     ti_val_unsafe_drop(query->rval);
     query->rval = (ti_val_t *) ti_vint_create((int64_t) n);

--- a/inc/ti/fn/fntypecount.h
+++ b/inc/ti/fn/fntypecount.h
@@ -17,7 +17,20 @@ static int do__f_type_count(ti_query_t * query, cleri_node_t * nd, ex_t * e)
         return ti_raw_err_not_found((ti_raw_t *) query->rval, "type", e);
 
     /* use cache if available */
-    n = type->t_cache ? type->t_cache->n : ti_query_count_type(query, type);
+    if (type->t_cache)
+    {
+        n = type->t_cache->n;
+    }
+    else
+    {
+        ssize_t r = ti_query_count_type(query, type);
+        if (r < 0)
+        {
+            ex_set_mem(e);
+            return e->nr;
+        }
+        n = (size_t) r;
+    }
 
     ti_val_unsafe_drop(query->rval);
     query->rval = (ti_val_t *) ti_vint_create((int64_t) n);

--- a/inc/ti/version.h
+++ b/inc/ti/version.h
@@ -6,7 +6,7 @@
 
 #define TI_VERSION_MAJOR 1
 #define TI_VERSION_MINOR 8
-#define TI_VERSION_PATCH 5
+#define TI_VERSION_PATCH 6
 
 /* The syntax version is used to test compatibility with functions
  * using the `ti_nodes_check_syntax()` function */
@@ -25,7 +25,7 @@
  *  "-rc0"
  *  ""
  */
-#define TI_VERSION_PRE_RELEASE ""
+#define TI_VERSION_PRE_RELEASE "-alpha0"
 
 #define TI_MAINTAINER \
     "Jeroen van der Heijden <jeroen@cesbit.com>"

--- a/itest/test_type.py
+++ b/itest/test_type.py
@@ -2406,9 +2406,14 @@ class TestType(TestBase):
                                  [
                                  timeit(type_all('T1').len()),  // fast
                                  timeit(type_all('V').len()),  // slow
+                                 timeit(type_count('T1')),  // fast
+                                 timeit(type_count('V')),  // slow
                                  ];
                                  """)
         self.assertLess(res[0]['time'], res[1]['time'])
+        self.assertLess(res[2]['time'], res[3]['time'])
+        self.assertEqual(res[0], res[2])
+        self.assertEqual(res[1], res[3])
 
 
 if __name__ == '__main__':

--- a/itest/test_type.py
+++ b/itest/test_type.py
@@ -2412,8 +2412,8 @@ class TestType(TestBase):
                                  """)
         self.assertLess(res[0]['time'], res[1]['time'])
         self.assertLess(res[2]['time'], res[3]['time'])
-        self.assertEqual(res[0], res[2])
-        self.assertEqual(res[1], res[3])
+        self.assertEqual(res[0]['data'], res[2]['data'])
+        self.assertEqual(res[1]['data'], res[3]['data'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description

When cache is available, `type_count()` can use this instead of counting the instances by itself.

## Type of change

- [x] Improvement

## How Has This Been Tested?

- [x] Test type (update). 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
