### PR TITLE
Less sleep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v1.9.3-alpha0
 
 * Fixed sanatize runtime checking, pr #455.
+* Replaced `ti_sleep(..)` with `sched_yield()` with a few exceptions, pr #456.
 
 # v1.9.2
 

--- a/inc/ti/version.h
+++ b/inc/ti/version.h
@@ -25,7 +25,7 @@
  *  "-rc0"
  *  ""
  */
-#define TI_VERSION_PRE_RELEASE "-alpha0"
+#define TI_VERSION_PRE_RELEASE "-alpha1"
 
 #define TI_MAINTAINER \
     "Jeroen van der Heijden <jeroen@cesbit.com>"

--- a/src/ti/archive.c
+++ b/src/ti/archive.c
@@ -186,7 +186,7 @@ static int archive__to_disk(void)
 
         ti_cpkg_drop(cpkg);
 
-        (void) ti_sleep(10);
+        (void) sched_yield();
     }
     while ((cpkg = queue_shift(archive->queue)));
 
@@ -425,7 +425,7 @@ int ti_archive_to_disk(void)
         (void) ti_store_store();
 
     /* sleep a little before archiving */
-    (void) ti_sleep(200);
+    (void) ti_sleep(100);
 
     /* archive changes, even after full store for synchronizing `other` nodes */
     if (archive__to_disk())

--- a/src/ti/collection.c
+++ b/src/ti/collection.c
@@ -539,7 +539,7 @@ int ti_collection_gc(ti_collection_t * collection, _Bool do_mark_things)
         /* Release the lock */
         uv_mutex_unlock(collection->lock);
 
-        (void) ti_sleep(5);
+        (void) sched_yield();
     }
 
     uv_mutex_lock(collection->lock);
@@ -601,7 +601,7 @@ int ti_collection_gc(ti_collection_t * collection, _Bool do_mark_things)
     /* Release the lock and let the thread sleep some time */
     uv_mutex_unlock(collection->lock);
 
-    (void) ti_sleep(5);
+    (void) sched_yield();
 
     /* Take a new lock */
     uv_mutex_lock(collection->lock);
@@ -626,7 +626,7 @@ int ti_collection_gc(ti_collection_t * collection, _Bool do_mark_things)
     /* Finished, release the collection lock */
     uv_mutex_unlock(collection->lock);
 
-    (void) ti_sleep(2);
+    (void) sched_yield();
 
     ti_counters_add_garbage_collected(n);
 

--- a/src/ti/collections.c
+++ b/src/ti/collections.c
@@ -79,7 +79,7 @@ int ti_collections_gc(void)
             rc = -1;
         }
 
-        (void) ti_sleep(100);
+        (void) sched_yield();
     }
 
     return rc;

--- a/src/ti/qcache.c
+++ b/src/ti/qcache.c
@@ -187,8 +187,7 @@ void ti_qcache_cleanup(void)
         return;
 
     (void) smap_values(qcache, (smap_val_cb) qcache__cleanup_cb, &w);
-
-    (void) ti_sleep(100);
+    (void) sched_yield();
 
     log_info("removed %u item(s) from query cache", w.qcached->n);
 

--- a/src/ti/store.c
+++ b/src/ti/store.c
@@ -202,7 +202,7 @@ int ti_store_store(void)
         log_errno_file("cannot create directory", errno, store->tmp_path);
     }
 
-    (void) ti_sleep(5);
+    (void) sched_yield();
 
     store__set_filename(/* use_tmp: */ true);
 
@@ -231,7 +231,7 @@ int ti_store_store(void)
         if (!store_collection)
             goto failed;
 
-        (void) ti_sleep(2);
+        (void) sched_yield();
 
         rc = mkdir(store_collection->collection_path, FX_DEFAULT_DIR_ACCESS);
         if (rc)
@@ -286,7 +286,7 @@ int ti_store_store(void)
     }
 
     (void) rename(store->store_path, store->prev_path);
-    (void) ti_sleep(2);
+    (void) sched_yield();
 
     if (rename(store->tmp_path, store->store_path))
     {
@@ -297,9 +297,9 @@ int ti_store_store(void)
         goto failed;
     }
 
-    (void) ti_sleep(2);
+    (void) sched_yield();
     (void) fx_rmdir(store->prev_path);
-    (void) ti_sleep(2);
+    (void) sched_yield();
 
     store->last_stored_change_id = ti.node->ccid;
 

--- a/src/ti/store/storeaccess.c
+++ b/src/ti/store/storeaccess.c
@@ -44,7 +44,7 @@ done:
         log_errno_file("cannot close file", errno, fn);
         return -1;
     }
-    (void) ti_sleep(5);
+    (void) sched_yield();
     return 0;
 }
 

--- a/src/ti/store/storecollection.c
+++ b/src/ti/store/storecollection.c
@@ -120,7 +120,7 @@ int ti_store_collection_store(ti_collection_t * collection, const char * fn)
     if (rc == 0)
         log_debug("stored collection info to file: `%s`", fn);
 
-    (void) ti_sleep(5);
+    (void) sched_yield();
     return rc;
 }
 

--- a/src/ti/store/storecollections.c
+++ b/src/ti/store/storecollections.c
@@ -55,7 +55,7 @@ done:
         log_errno_file("cannot close file", errno, fn);
         return -1;
     }
-    (void) ti_sleep(5);
+    (void) sched_yield();
     return 0;
 }
 

--- a/src/ti/store/storecommits.c
+++ b/src/ti/store/storecommits.c
@@ -52,7 +52,7 @@ done:
         log_errno_file("cannot close file", errno, fn);
         return -1;
     }
-    (void) ti_sleep(5);
+    (void) sched_yield();
     return 0;
 }
 

--- a/src/ti/store/storeenums.c
+++ b/src/ti/store/storeenums.c
@@ -78,7 +78,7 @@ done:
         log_errno_file("cannot close file", errno, fn);
         return -1;
     }
-    (void) ti_sleep(5);
+    (void) sched_yield();
     return 0;
 }
 

--- a/src/ti/store/storegcollect.c
+++ b/src/ti/store/storegcollect.c
@@ -55,7 +55,7 @@ done:
         log_errno_file("cannot close file", errno, fn);
         return -1;
     }
-    (void) ti_sleep(5);
+    (void) sched_yield();
     return 0;
 }
 
@@ -138,7 +138,7 @@ done:
         log_errno_file("cannot close file", errno, fn);
         return -1;
     }
-    (void) ti_sleep(5);
+    (void) sched_yield();
     return 0;
 }
 

--- a/src/ti/store/storemodules.c
+++ b/src/ti/store/storemodules.c
@@ -62,7 +62,7 @@ done:
         log_errno_file("cannot close file", errno, fn);
         return -1;
     }
-    (void) ti_sleep(5);
+    (void) sched_yield();
     return 0;
 }
 

--- a/src/ti/store/storenamedrooms.c
+++ b/src/ti/store/storenamedrooms.c
@@ -53,7 +53,7 @@ done:
         log_errno_file("cannot close file", errno, fn);
         return -1;
     }
-    (void) ti_sleep(5);
+    (void) sched_yield();
     return 0;
 }
 

--- a/src/ti/store/storenames.c
+++ b/src/ti/store/storenames.c
@@ -38,7 +38,7 @@ done:
         log_errno_file("cannot close file", errno, fn);
         return -1;
     }
-    (void) ti_sleep(5);
+    (void) sched_yield();
     return 0;
 }
 

--- a/src/ti/store/storeprocedures.c
+++ b/src/ti/store/storeprocedures.c
@@ -53,7 +53,7 @@ done:
         log_errno_file("cannot close file", errno, fn);
         return -1;
     }
-    (void) ti_sleep(5);
+    (void) sched_yield();
     return 0;
 }
 

--- a/src/ti/store/storestatus.c
+++ b/src/ti/store/storestatus.c
@@ -36,7 +36,7 @@ done:
         log_errno_file("cannot close file", errno, fn);
         return -1;
     }
-    (void) ti_sleep(5);
+    (void) sched_yield();
     return 0;
 }
 

--- a/src/ti/store/storetasks.c
+++ b/src/ti/store/storetasks.c
@@ -62,7 +62,7 @@ done:
         return -1;
     }
 
-    (void) ti_sleep(5);
+    (void) sched_yield();
     return 0;
 }
 

--- a/src/ti/store/storethings.c
+++ b/src/ti/store/storethings.c
@@ -76,7 +76,7 @@ done:
         log_errno_file("cannot close file", errno, fn);
         return -1;
     }
-    (void) ti_sleep(5);
+    (void) sched_yield();
     return 0;
 }
 
@@ -155,7 +155,7 @@ done:
         log_errno_file("cannot close file", errno, fn);
         return -1;
     }
-    (void) ti_sleep(5);
+    (void) sched_yield();
     return 0;
 }
 

--- a/src/ti/store/storetypes.c
+++ b/src/ti/store/storetypes.c
@@ -160,7 +160,7 @@ done:
         log_errno_file("cannot close file", errno, fn);
         return -1;
     }
-    (void) ti_sleep(5);
+    (void) sched_yield();
     return 0;
 }
 

--- a/src/ti/store/storeusers.c
+++ b/src/ti/store/storeusers.c
@@ -90,7 +90,7 @@ done:
         log_errno_file("cannot close file", errno, fn);
         return -1;
     }
-    (void) ti_sleep(5);
+    (void) sched_yield();
     return 0;
 }
 


### PR DESCRIPTION
## Description

Replace `ti_sleep(..)` with `sched_yield()` for small sleeps. Only keep longer sleeps of 100ms.

## How Has This Been Tested?

- [x] All existing tests

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
